### PR TITLE
Add a health check endpoint at /status

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
@@ -84,6 +84,9 @@ public class Program
 
         var pgConnectionString = GetPostgresConnectionString();
 
+        var healthCheckBuilder = builder.Services.AddHealthChecks()
+            .AddNpgSql(pgConnectionString);
+
         builder.Services.AddDbContext<TeacherIdentityServerDbContext>(options =>
         {
             TeacherIdentityServerDbContext.ConfigureOptions(options, pgConnectionString);
@@ -200,6 +203,8 @@ public class Program
         }
 
         app.UseHttpMetrics();
+
+        app.UseHealthChecks("/status");
 
         app.UseAuthentication();
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/TeacherIdentity.AuthServer.csproj
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/TeacherIdentity.AuthServer.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="AspNetCore.HealthChecks.NpgSql" Version="6.0.2" />
     <PackageReference Include="EFCore.NamingConventions" Version="6.0.0" />
     <PackageReference Include="Flurl" Version="3.0.6" />
     <PackageReference Include="GovUk.Frontend.AspNetCore" Version="1.0.0-beta1" />


### PR DESCRIPTION
Includes a check on the Postgres DB only for now.