### PR TITLE
Add the confirmation 'book end' page

### DIFF
--- a/dotnet-authserver/.editorconfig
+++ b/dotnet-authserver/.editorconfig
@@ -16,3 +16,5 @@ dotnet_sort_system_directives_first = true
 csharp_style_namespace_declarations = file_scoped:warning
 csharp_prefer_braces = true:warning
 
+[src/**/Migrations/*]
+generated_code = true

--- a/dotnet-authserver/.editorconfig
+++ b/dotnet-authserver/.editorconfig
@@ -13,6 +13,6 @@ indent_size = 2
 [*.cs]
 indent_size = 4
 dotnet_sort_system_directives_first = true
-csharp_style_namespace_declarations = file_scoped
-csharp_prefer_braces = true
+csharp_style_namespace_declarations = file_scoped:warning
+csharp_prefer_braces = true:warning
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/HttpContextExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/HttpContextExtensions.cs
@@ -1,7 +1,6 @@
 ﻿using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
-using Microsoft.AspNetCore.Mvc;
 using OpenIddict.Abstractions;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.State;
@@ -15,9 +14,11 @@ public static class HttpContextExtensions
         httpContext.Features.Get<AuthenticationStateFeature>()?.AuthenticationState ??
             throw new InvalidOperationException($"The current request has no {nameof(AuthenticationState)}.");
 
-    public static async Task<IActionResult> SignInUser(this HttpContext httpContext, User user)
+    public static async Task SignInUser(this HttpContext httpContext, User user)
     {
         var authenticationState = httpContext.GetAuthenticationState();
+        authenticationState.Populate(user);
+
         var authorizationRequest = authenticationState.GetAuthorizationRequest();
 
         var claims = new List<Claim>()
@@ -39,7 +40,5 @@ public static class HttpContextExtensions
         var principal = new ClaimsPrincipal(identity);
 
         await httpContext.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, principal);
-
-        return new RedirectResult(authenticationState.AuthorizationUrl);
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Json/DateOnlyConverter.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Json/DateOnlyConverter.cs
@@ -1,0 +1,27 @@
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace TeacherIdentity.AuthServer.Json;
+
+public class DateOnlyConverter : JsonConverter<DateOnly>
+{
+    private readonly string _serializationFormat;
+
+    public DateOnlyConverter() : this(null)
+    {
+    }
+
+    public DateOnlyConverter(string? serializationFormat)
+    {
+        _serializationFormat = serializationFormat ?? "yyyy-MM-dd";
+    }
+
+    public override DateOnly Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var value = reader.GetString();
+        return DateOnly.Parse(value!);
+    }
+
+    public override void Write(Utf8JsonWriter writer, DateOnly value, JsonSerializerOptions options) =>
+        writer.WriteStringValue(value.ToString(_serializationFormat));
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20220810135535_UserDateOfBirth.Designer.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20220810135535_UserDateOfBirth.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeacherIdentity.AuthServer.Models;
@@ -11,9 +12,10 @@ using TeacherIdentity.AuthServer.Models;
 namespace TeacherIdentity.AuthServer.Migrations
 {
     [DbContext(typeof(TeacherIdentityServerDbContext))]
-    partial class TeacherIdentityServerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220810135535_UserDateOfBirth")]
+    partial class UserDateOfBirth
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20220810135535_UserDateOfBirth.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20220810135535_UserDateOfBirth.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeacherIdentity.AuthServer.Migrations
+{
+    public partial class UserDateOfBirth : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateOnly>(
+                name: "date_of_birth",
+                table: "users",
+                type: "date",
+                nullable: false,
+                defaultValue: new DateOnly(1, 1, 1));
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "date_of_birth",
+                table: "users");
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/User.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/User.cs
@@ -3,8 +3,9 @@
 public class User
 {
     public Guid UserId { get; set; }
-    public string? EmailAddress { get; set; }
+    public string EmailAddress { get; set; } = null!;
     public string? Trn { get; set; }
-    public string? FirstName { get; set; }
-    public string? LastName { get; set; }
+    public string FirstName { get; set; } = null!;
+    public string LastName { get; set; } = null!;
+    public DateOnly DateOfBirth { get; set; }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Confirmation.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Confirmation.cshtml
@@ -1,0 +1,60 @@
+﻿@page "/sign-in/confirmation"
+@model TeacherIdentity.AuthServer.Pages.SignIn.ConfirmationModel
+@{
+    ViewBag.Title = Model.FirstTimeUser ? "Continue with your NPQ registration" : "You're signed in";
+}
+
+@if (Model.FirstTimeUser)
+{
+    <govuk-panel class="app-panel--interruption" data-testid="first-time-user-content">
+      <govuk-panel-title>Continue with your NPQ registration</govuk-panel-title>
+
+      <govuk-panel-body>
+        @if (Model.GotTrn)
+        {
+            <p class="govuk-body" data-testid="known-trn-content">Thank you, we’ve finished checking our records.</p>
+        }
+        else
+        {
+            <div data-testid="unknown-trn-content">
+              <h2 class="govuk-heading-m">You can continue without a match</h2>
+              <p class="govuk-body">We will attempt to match your record again. If we cannot, someone might be in touch to ask for more information.</p>
+            </div>
+        }
+
+        <h2 class="govuk-heading-m">Next time</h2>
+        <p class="govuk-body govuk-!-margin-bottom-6">Next time, you can skip these questions by signing in with your email address: <b>@Model.Email</b></p>
+
+        <form action="@Url.Confirmation()" method="post" asp-antiforgery="true">
+          <govuk-button type="submit" class="app-button--inverse govuk-!-margin-bottom-0">Continue</govuk-button>
+        </form>
+      </govuk-panel-body>
+    </govuk-panel>
+}
+else
+{
+    <div class="govuk-grid-row" data-testid="known-user-content">
+      <div class="govuk-grid-column-two-thirds-from-desktop">
+        <h1 class="govuk-heading-xl">You're signed in</h1>
+
+        <govuk-summary-list>
+          <govuk-summary-list-row>
+            <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value>@Model.Name</govuk-summary-list-row-value>
+          </govuk-summary-list-row>
+          <govuk-summary-list-row>
+            <govuk-summary-list-row-key>TRN</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value>@Model.Trn</govuk-summary-list-row-value>
+          </govuk-summary-list-row>
+          <govuk-summary-list-row>
+            <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
+            <govuk-summary-list-row-value>@(Model.DateOfBirth.ToString("d MMMM yyyy"))</govuk-summary-list-row-value>
+          </govuk-summary-list-row>
+        </govuk-summary-list>
+
+        <form action="@Url.Confirmation()" method="post" asp-antiforgery="true">
+          <govuk-button type="submit">Continue</govuk-button>
+        </form>
+      </div>
+    </div>
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Confirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Confirmation.cshtml.cs
@@ -1,0 +1,57 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn;
+
+public class ConfirmationModel : PageModel
+{
+    private readonly ILogger<ConfirmationModel> _logger;
+
+    public ConfirmationModel(ILogger<ConfirmationModel> logger)
+    {
+        _logger = logger;
+    }
+
+    public string? Email { get; set; }
+
+    public bool GotTrn { get; set; }
+
+    public bool FirstTimeUser { get; set; }
+
+    public string? Name { get; set; }
+
+    public string? Trn { get; set; }
+
+    public DateOnly DateOfBirth { get; set; }
+
+    public void OnGet()
+    {
+        var authenticationState = HttpContext.GetAuthenticationState();
+        Email = authenticationState.EmailAddress;
+        GotTrn = authenticationState.Trn is not null;
+        FirstTimeUser = authenticationState.FirstTimeUser!.Value;
+        Name = $"{authenticationState.FirstName} {authenticationState.LastName}";
+        Trn = authenticationState.Trn;
+        DateOfBirth = authenticationState.DateOfBirth!.Value;
+    }
+
+    public IActionResult OnPost()
+    {
+        var authenticationState = HttpContext.GetAuthenticationState();
+        authenticationState.HaveCompletedConfirmationPage = true;
+
+        return Redirect(authenticationState.GetNextHopUrl(Url));
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var authenticationState = HttpContext.GetAuthenticationState();
+
+        if (!authenticationState.UserId.HasValue)
+        {
+            _logger.LogWarning($"Hit {nameof(ConfirmationModel)} without a known user.");
+            context.Result = BadRequest();
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/EmailConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/EmailConfirmation.cshtml.cs
@@ -36,15 +36,17 @@ public class EmailConfirmationModel : PageModel
         }
 
         var authenticationState = HttpContext.GetAuthenticationState();
-        authenticationState.EmailAddressConfirmed = true;
 
         var user = await _dbContext.Users.Where(u => u.EmailAddress == Email).SingleOrDefaultAsync();
         if (user is not null)
         {
             await HttpContext.SignInUser(user);
-
-            authenticationState.UserId = user.UserId;
-            authenticationState.Trn = user.Trn;
+            authenticationState.FirstTimeUser = false;
+        }
+        else
+        {
+            authenticationState.EmailAddressConfirmed = true;
+            authenticationState.FirstTimeUser = true;
         }
 
         return Redirect(authenticationState.GetNextHopUrl(Url));

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnCallback.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnCallback.cshtml.cs
@@ -44,33 +44,28 @@ public class TrnCallbackModel : PageModel
             throw new NotImplementedException();
         }
 
-        if (!RequiredClaimsAreProvided(findALostTrnUser, "trn", Claims.GivenName, Claims.FamilyName, Claims.Birthdate))
+        if (!RequiredClaimsAreProvided(findALostTrnUser, Claims.GivenName, Claims.FamilyName, Claims.Birthdate))
         {
             return BadRequest();
         }
 
-        authenticationState.Trn = findALostTrnUser.FindFirst("trn")!.Value;
-        authenticationState.FirstName = findALostTrnUser.FindFirst(Claims.GivenName)!.Value;
-        authenticationState.LastName = findALostTrnUser.FindFirst(Claims.FamilyName)!.Value;
-        authenticationState.DateOfBirth = DateOnly.ParseExact(findALostTrnUser.FindFirst(Claims.Birthdate)!.Value, "yyyy-MM-dd");
-
         var userId = Guid.NewGuid();
         var user = new User()
         {
-            DateOfBirth = authenticationState.DateOfBirth!.Value,
+            DateOfBirth = DateOnly.ParseExact(findALostTrnUser.FindFirst(Claims.Birthdate)!.Value, "yyyy-MM-dd"),
             EmailAddress = authenticationState.EmailAddress!,
-            FirstName = authenticationState.FirstName,
-            LastName = authenticationState.LastName,
-            Trn = authenticationState.Trn,
+            FirstName = findALostTrnUser.FindFirst(Claims.GivenName)!.Value,
+            LastName = findALostTrnUser.FindFirst(Claims.FamilyName)!.Value,
+            Trn = findALostTrnUser.FindFirst("trn")?.Value,
             UserId = userId
         };
 
         _dbContext.Users.Add(user);
         await _dbContext.SaveChangesAsync();
 
-        authenticationState.UserId = userId;
+        await HttpContext.SignInUser(user);
 
-        return await HttpContext.SignInUser(user);
+        return Redirect(authenticationState.GetNextHopUrl(Url));
 
         bool RequiredClaimsAreProvided(ClaimsPrincipal principal, params string[] claimTypes)
         {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnCallback.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnCallback.cshtml.cs
@@ -44,7 +44,7 @@ public class TrnCallbackModel : PageModel
             throw new NotImplementedException();
         }
 
-        if (!RequiredClaimsAreProvided(findALostTrnUser, "trn", Claims.GivenName, Claims.FamilyName))
+        if (!RequiredClaimsAreProvided(findALostTrnUser, "trn", Claims.GivenName, Claims.FamilyName, Claims.Birthdate))
         {
             return BadRequest();
         }
@@ -52,11 +52,13 @@ public class TrnCallbackModel : PageModel
         authenticationState.Trn = findALostTrnUser.FindFirst("trn")!.Value;
         authenticationState.FirstName = findALostTrnUser.FindFirst(Claims.GivenName)!.Value;
         authenticationState.LastName = findALostTrnUser.FindFirst(Claims.FamilyName)!.Value;
+        authenticationState.DateOfBirth = DateOnly.ParseExact(findALostTrnUser.FindFirst(Claims.Birthdate)!.Value, "yyyy-MM-dd");
 
         var userId = Guid.NewGuid();
         var user = new User()
         {
-            EmailAddress = authenticationState.EmailAddress,
+            DateOfBirth = authenticationState.DateOfBirth!.Value,
+            EmailAddress = authenticationState.EmailAddress!,
             FirstName = authenticationState.FirstName,
             LastName = authenticationState.LastName,
             Trn = authenticationState.Trn,

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/StubFindALostTrn/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/StubFindALostTrn/Index.cshtml.cs
@@ -39,7 +39,6 @@ public class IndexModel : PageModel
 
     [BindProperty]
     [Display(Name = "TRN")]
-    [Required(ErrorMessage = "Enter TRN")]
     public string? Trn { get; set; }
 
     public bool IsCallback { get; set; }
@@ -63,17 +62,23 @@ public class IndexModel : PageModel
         var pskBytes = Encoding.UTF8.GetBytes(_findALostTrnIntegrationHelper.Options.SharedKey);
         var signingCredentials = new SigningCredentials(new SymmetricSecurityKey(pskBytes), SecurityAlgorithms.HmacSha256Signature);
 
+        var subject = new ClaimsIdentity(new[]
+        {
+            new Claim("email", Email!),
+            new Claim("birthdate", DateOfBirth!.Value.ToString("yyyy-MM-dd")),
+            new Claim("given_name", FirstName!),
+            new Claim("family_name", LastName!)
+        });
+
+        if (!string.IsNullOrEmpty(Trn))
+        {
+            subject.AddClaim(new Claim("trn", Trn!));
+        }
+
         var tokenHandler = new JwtSecurityTokenHandler();
         var jwt = tokenHandler.CreateEncodedJwt(new SecurityTokenDescriptor()
         {
-            Subject = new ClaimsIdentity(new[]
-            {
-                new Claim("email", Email!),
-                new Claim("birthdate", DateOfBirth!.Value.ToString("yyyy-MM-dd")),
-                new Claim("given_name", FirstName!),
-                new Claim("family_name", LastName!),
-                new Claim("trn", Trn!),
-            }),
+            Subject = subject,
             SigningCredentials = signingCredentials
         });
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/State/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/State/AuthenticationState.cs
@@ -1,8 +1,10 @@
-﻿using System.Text.Json;
+﻿using System.Diagnostics;
+using System.Text.Json;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebUtilities;
 using OpenIddict.Abstractions;
 using TeacherIdentity.AuthServer.Json;
+using TeacherIdentity.AuthServer.Models;
 
 namespace TeacherIdentity.AuthServer.State;
 
@@ -27,18 +29,15 @@ public class AuthenticationState
     public Guid JourneyId { get; }
     public string AuthorizationUrl { get; }
     public Guid? UserId { get; set; }
+    public bool? FirstTimeUser { get; set; }
     public string? EmailAddress { get; set; }
     public bool EmailAddressConfirmed { get; set; }
     public string? FirstName { get; set; }
     public string? LastName { get; set; }
-    public string? PreviousFirstName { get; set; }
-    public string? PreviousLastName { get; set; }
     public DateOnly? DateOfBirth { get; set; }
-    public string? Nino { get; set; }
-    public bool? HaveQts { get; set; }
-    public bool? DidAUniversityScittOrSchoolAwardQts { get; set; }
-    public string? QtsProviderName { get; set; }
     public string? Trn { get; set; }
+    public bool HaveCompletedFindALostTrnJourney { get; set; }
+    public bool HaveCompletedConfirmationPage { get; set; }
 
     public static AuthenticationState Deserialize(string serialized) =>
         JsonSerializer.Deserialize<AuthenticationState>(serialized, _jsonSerializerOptions) ??
@@ -69,23 +68,38 @@ public class AuthenticationState
         // For now we only support flows that have the trn scope specified
         if (!request.HasScope(CustomScopes.Trn))
         {
-            throw new NotSupportedException($"The '{CustomScopes.Trn}' must be specified.");
+            throw new NotSupportedException($"The '{CustomScopes.Trn}' scope must be specified.");
         }
 
-        // qualified_teacher scope is specified; launch the journey to collect TRN
-        if (request.HasScope(CustomScopes.Trn) && Trn is null)
+        // trn scope is specified; launch the journey to collect TRN
+        if (request.HasScope(CustomScopes.Trn) && Trn is null && !HaveCompletedFindALostTrnJourney)
         {
             return urlHelper.Trn();
         }
 
-        // We should be signed in at this point - complete authorization
-        if (UserId.HasValue)
+        // We should have a known user at this point
+        Debug.Assert(UserId.HasValue);
+
+        // Confirmation bookend page
+        if (!HaveCompletedConfirmationPage)
         {
-            return AuthorizationUrl;
+            return urlHelper.Confirmation();
         }
 
-        // We should never get here
-        throw new Exception("Cannot continue authorization journey.");
+        // We're done - complete authorization
+        return AuthorizationUrl;
+    }
+
+    public void Populate(User user)
+    {
+        UserId = user.UserId;
+        EmailAddress = user.EmailAddress;
+        EmailAddressConfirmed = true;
+        FirstName = user.FirstName;
+        LastName = user.LastName;
+        DateOfBirth = user.DateOfBirth;
+        Trn = user.Trn;
+        HaveCompletedFindALostTrnJourney = true;
     }
 
     public string Serialize() => JsonSerializer.Serialize(this, _jsonSerializerOptions);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/State/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/State/AuthenticationState.cs
@@ -2,11 +2,20 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.WebUtilities;
 using OpenIddict.Abstractions;
+using TeacherIdentity.AuthServer.Json;
 
 namespace TeacherIdentity.AuthServer.State;
 
 public class AuthenticationState
 {
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new JsonSerializerOptions()
+    {
+        Converters =
+        {
+            new DateOnlyConverter()
+        }
+    };
+
     public AuthenticationState(
         Guid journeyId,
         string authorizationUrl)
@@ -24,7 +33,7 @@ public class AuthenticationState
     public string? LastName { get; set; }
     public string? PreviousFirstName { get; set; }
     public string? PreviousLastName { get; set; }
-    public DateTime? DateOfBirth { get; set; }
+    public DateOnly? DateOfBirth { get; set; }
     public string? Nino { get; set; }
     public bool? HaveQts { get; set; }
     public bool? DidAUniversityScittOrSchoolAwardQts { get; set; }
@@ -32,7 +41,7 @@ public class AuthenticationState
     public string? Trn { get; set; }
 
     public static AuthenticationState Deserialize(string serialized) =>
-        JsonSerializer.Deserialize<AuthenticationState>(serialized) ??
+        JsonSerializer.Deserialize<AuthenticationState>(serialized, _jsonSerializerOptions) ??
             throw new ArgumentException($"Serialized {nameof(AuthenticationState)} is not valid.", nameof(serialized));
 
     public OpenIddictRequest GetAuthorizationRequest()
@@ -79,5 +88,5 @@ public class AuthenticationState
         throw new Exception("Cannot continue authorization journey.");
     }
 
-    public string Serialize() => JsonSerializer.Serialize(this);
+    public string Serialize() => JsonSerializer.Serialize(this, _jsonSerializerOptions);
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/State/RequireAuthenticationStateFilter.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/State/RequireAuthenticationStateFilter.cs
@@ -3,21 +3,13 @@ using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace TeacherIdentity.AuthServer.State;
 
-public class RequireAuthenticationStateFilter : IPageFilter
+public class RequireAuthenticationStateFilter : IAuthorizationFilter
 {
-    public void OnPageHandlerExecuted(PageHandlerExecutedContext context)
-    {
-    }
-
-    public void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    public void OnAuthorization(AuthorizationFilterContext context)
     {
         if (context.HttpContext.Features.Get<AuthenticationStateFeature>() is null)
         {
             context.Result = new BadRequestResult();
         }
-    }
-
-    public void OnPageHandlerSelected(PageHandlerSelectedContext context)
-    {
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/UrlHelperExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/UrlHelperExtensions.cs
@@ -14,6 +14,8 @@ public static class UrlHelperExtensions
 
     public static string TrnCallback(this IUrlHelper urlHelper) => urlHelper.PageWithAuthenticationJourneyId("/SignIn/TrnCallback");
 
+    public static string Confirmation(this IUrlHelper urlHelper) => urlHelper.PageWithAuthenticationJourneyId("/SignIn/Confirmation");
+
     /// <summary>
     /// Generates a link to a Razor page and appends the authentication journey id query parameter.
     /// </summary>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/wwwroot/Styles/panel.scss
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/wwwroot/Styles/panel.scss
@@ -6,6 +6,7 @@
   text-align: left;
 
   p,
+  .govuk-heading-m,
   .govuk-list,
   .govuk-body,
   .govuk-label,

--- a/dotnet-authserver/src/TeacherIdentity.TestClient/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.TestClient/Program.cs
@@ -23,7 +23,10 @@ public class Program
                 options.DefaultScheme = "Cookies";
                 options.DefaultChallengeScheme = "oidc";
             })
-            .AddCookie("Cookies")
+            .AddCookie("Cookies", options =>
+            {
+                options.ExpireTimeSpan = TimeSpan.FromSeconds(30);
+            })
             .AddOpenIdConnect("oidc", options =>
             {
                 options.Authority = builder.Configuration.GetValue<string>("SignInAuthority");

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.EndToEndTests/SignIn.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.EndToEndTests/SignIn.cs
@@ -43,10 +43,14 @@ public class SignIn : IClassFixture<HostFixture>
         // Fill in the sign in form (email + PIN)
 
         await page.FillAsync("text=Email", email);
-        await page.ClickAsync("text=Continue");
+        await page.ClickAsync("button:has-text('Continue')");
 
         await page.FillAsync("text=Enter your code", "123456");
-        await page.ClickAsync("text=Continue");
+        await page.ClickAsync("button:has-text('Continue')");
+
+        // Should now be on the confirmation page
+
+        await page.ClickAsync("button:has-text('Continue')");
 
         // Should now be back at the client, signed in
 
@@ -78,17 +82,17 @@ public class SignIn : IClassFixture<HostFixture>
         // Fill in the sign in form (email + PIN)
 
         await page.FillAsync("text=Email", email);
-        await page.ClickAsync("text=Continue");
+        await page.ClickAsync("button:has-text('Continue')");
 
         await page.FillAsync("text=Enter your code", "123456");
-        await page.ClickAsync("text=Continue");
+        await page.ClickAsync("button:has-text('Continue')");
 
         // Should now be at the first bookend page
 
         var urlPath = new Uri(page.Url).LocalPath;
         Assert.EndsWith("/trn", urlPath);
 
-        await page.ClickAsync("text=Continue");
+        await page.ClickAsync("button:has-text('Continue')");
 
         // Should now be on our stub Find page
 
@@ -103,7 +107,11 @@ public class SignIn : IClassFixture<HostFixture>
         await page.FillAsync("id=DateOfBirth.Year", dateOfBirth.Year.ToString());
         await page.FillAsync("#Trn", trn);
 
-        await page.ClickAsync("text=Continue");
+        await page.ClickAsync("button:has-text('Continue')");
+
+        // Should now be on the confirmation page
+
+        await page.ClickAsync("button:has-text('Continue')");
 
         // Should now be back on the client, signed in
 

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/AngleSharpExtensions.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/AngleSharpExtensions.cs
@@ -1,0 +1,25 @@
+﻿using AngleSharp.Dom;
+using AngleSharp.Html.Dom;
+
+namespace TeacherIdentity.AuthServer.Tests;
+
+public static class AngleSharpExtensions
+{
+    public static T? As<T>(this IElement element)
+        where T : class, IElement
+    {
+        return element as T;
+    }
+
+    public static IReadOnlyList<IElement> GetAllElementsByTestId(this IElement element, string testId) =>
+        element.QuerySelectorAll($"*[data-testid='{testId}']").ToList();
+
+    public static IElement? GetElementByTestId(this IElement element, string testId) =>
+        GetAllElementsByTestId(element, testId).SingleOrDefault();
+
+    public static IReadOnlyList<IElement> GetAllElementsByTestId(this IHtmlDocument doc, string testId) =>
+        doc.Body!.GetAllElementsByTestId(testId);
+
+    public static IElement? GetElementByTestId(this IHtmlDocument doc, string testId) =>
+        doc.Body!.GetElementByTestId(testId);
+}

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
@@ -26,7 +26,7 @@ public sealed class AuthenticationStateHelper
         var authorizationUrl = $"/connect/authorize" +
             $"?client_id={client.ClientId}" +
             $"&response_type=code" +
-            $"&scope=email%20profile" +
+            $"&scope=email%20profile%20trn" +
             $"&redirect_uri={Uri.EscapeDataString(client.RedirectUris.First().ToString())}";
 
         var authenticationState = new AuthenticationState(journeyId, authorizationUrl);

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/ConfirmationTests.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/ConfirmationTests.cs
@@ -1,0 +1,163 @@
+﻿namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn;
+
+public class ConfirmationTests : TestBase
+{
+    public ConfirmationTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_NoAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/confirmation");
+    }
+
+    [Fact]
+    public async Task Get_UserNotKnown_ReturnsBadRequest()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(HttpClient, userKnown: false);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/confirmation?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Act
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_FirstTimeUserWithTrn_RendersExpectedContent()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(HttpClient, userKnown: true, hasTrn: true, firstTimeUser: true);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/confirmation?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Act
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+        Assert.NotNull(doc.GetElementByTestId("first-time-user-content"));
+        Assert.NotNull(doc.GetElementByTestId("known-trn-content"));
+        Assert.Null(doc.GetElementByTestId("unknown-trn-content"));
+    }
+
+    [Fact]
+    public async Task Get_FirstTimeUserWithoutTrn_RendersExpectedContent()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(HttpClient, userKnown: true, hasTrn: false, firstTimeUser: true);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/confirmation?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Act
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+        Assert.NotNull(doc.GetElementByTestId("first-time-user-content"));
+        Assert.Null(doc.GetElementByTestId("known-trn-content"));
+        Assert.NotNull(doc.GetElementByTestId("unknown-trn-content"));
+    }
+
+    [Fact]
+    public async Task Get_KnownUser_RendersExpectedContent()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(HttpClient, userKnown: true);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/confirmation?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Act
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+        Assert.NotNull(doc.GetElementByTestId("known-user-content"));
+    }
+
+    [Fact]
+    public async Task Post_NoAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Post, "/sign-in/confirmation");
+    }
+
+    [Fact]
+    public async Task Post_UserNotKnown_ReturnsBadRequest()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(HttpClient, userKnown: false);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/confirmation?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder().ToContent()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Act
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_UpdatedAuthenticationStateAndRedirects()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(HttpClient, userKnown: true);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/confirmation?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder().ToContent()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Act
+        Assert.True(authStateHelper.AuthenticationState.HaveCompletedConfirmationPage);
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal(authStateHelper.AuthenticationState.AuthorizationUrl, response.Headers.Location?.OriginalString);
+    }
+
+    private async Task<AuthenticationStateHelper> CreateAuthenticationStateHelper(
+        HttpClient httpClient,
+        bool userKnown = true,
+        bool hasTrn = true,
+        bool firstTimeUser = false)
+    {
+        var user = userKnown ? (await TestData.CreateUser(trn: hasTrn ? TestData.GenerateTrn() : null)) : null;
+
+        var authenticationStateHelper = CreateAuthenticationStateHelper(authState =>
+        {
+            authState.EmailAddress = Faker.Internet.Email();
+            authState.EmailAddressConfirmed = true;
+
+            if (userKnown)
+            {
+                authState.DateOfBirth = user!.DateOfBirth;
+                authState.FirstName = user.FirstName;
+                authState.LastName = user.LastName;
+                authState.FirstTimeUser = firstTimeUser;
+                authState.HaveCompletedFindALostTrnJourney = !userKnown && !firstTimeUser;
+                authState.UserId = user.UserId;
+
+                if (hasTrn)
+                {
+                    authState.Trn = user.Trn;
+                }
+            }
+        });
+
+        if (userKnown)
+        {
+            await HostFixture.SignInUser(user!.UserId, authenticationStateHelper, httpClient);
+        }
+
+        return authenticationStateHelper;
+    }
+}

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnCallbackTests.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnCallbackTests.cs
@@ -60,7 +60,7 @@ public class TrnCallbackTests : TestBase
     }
 
     [Fact]
-    public async Task Post_ValidCallback_CreatesUserAndCompletesAuthorization()
+    public async Task Post_ValidCallback_CreatesUserAndRedirectsToConfirmation()
     {
         // Arrange
         var authStateHelper = CreateAuthenticationStateHelper();
@@ -85,7 +85,7 @@ public class TrnCallbackTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal("/connect/authorize", new Url(response.Headers.Location).Path);
+        Assert.Equal("/sign-in/confirmation", new Url(response.Headers.Location).Path);
 
         await TestData.WithDbContext(async dbContext =>
         {
@@ -101,7 +101,7 @@ public class TrnCallbackTests : TestBase
 
             Assert.Equal(firstName, user!.FirstName);
             Assert.Equal(lastName, user!.LastName);
-            //Assert.Equal(dateOfBirth, user!.DateOfBirth);
+            Assert.Equal(dateOfBirth, user!.DateOfBirth);
             Assert.Equal(trn, user!.Trn);
         });
     }

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/SignInUserMiddleware.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/SignInUserMiddleware.cs
@@ -1,0 +1,21 @@
+﻿using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.Tests;
+
+public class SignInUserMiddleware
+{
+    private readonly TeacherIdentityServerDbContext _dbContext;
+
+    public SignInUserMiddleware(RequestDelegate next, TeacherIdentityServerDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task Invoke(HttpContext context)
+    {
+        var userId = Guid.Parse(context.Request.Form["UserId"]);
+        var user = await _dbContext.Users.SingleAsync(u => u.UserId == userId);
+        await context.SignInUser(user);
+    }
+}

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/State/AuthenticationStateTests.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/State/AuthenticationStateTests.cs
@@ -1,0 +1,178 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Abstractions;
+using Microsoft.AspNetCore.Mvc.Routing;
+using Moq;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.State;
+
+namespace TeacherIdentity.AuthServer.Tests.State;
+
+public class AuthenticationStateTests
+{
+    [Theory]
+    [MemberData(nameof(GetNextHopUrlData))]
+    public void GetNextHopUrl(AuthenticationState authenticationState, string expectedResult)
+    {
+        // Arrange
+        var urlHelper = new Mock<IUrlHelper>();
+
+        var httpContext = new DefaultHttpContext();
+        httpContext.Features.Set(new AuthenticationStateFeature(authenticationState));
+
+        var actionContext = new ActionContext()
+        {
+            ActionDescriptor = new ActionDescriptor(),
+            HttpContext = httpContext,
+            RouteData = new RouteData()
+        };
+
+        urlHelper.SetupGet(mock => mock.ActionContext).Returns(actionContext);
+
+        void ConfigureMockForPage(string pageName, string returns)
+        {
+            urlHelper
+                .Setup(mock =>
+                    mock.RouteUrl(It.Is<UrlRouteContext>(ctx => (string)((RouteValueDictionary)ctx.Values!)["page"]! == pageName)))
+                .Returns(returns);
+        }
+
+        ConfigureMockForPage("/SignIn/Email", "/sign-in/email");
+        ConfigureMockForPage("/SignIn/EmailConfirmation", "/sign-in/email-confirmation");
+        ConfigureMockForPage("/SignIn/Trn", "/sign-in/trn");
+        ConfigureMockForPage("/SignIn/TrnCallback", "/sign-in/trn-callback");
+        ConfigureMockForPage("/SignIn/Confirmation", "/sign-in/confirmation");
+
+        // Act
+        var result = authenticationState.GetNextHopUrl(urlHelper.Object);
+
+        // Assert
+        Assert.Equal(expectedResult, result);
+    }
+
+    [Fact]
+    public void Populate()
+    {
+        // Arrange
+        var user = new User()
+        {
+            DateOfBirth = new DateOnly(2001, 4, 1),
+            EmailAddress = Faker.Internet.Email(),
+            FirstName = Faker.Name.First(),
+            LastName = Faker.Name.Last(),
+            Trn = "1234567",
+            UserId = Guid.NewGuid()
+        };
+
+        var authenticationState = new AuthenticationState(Guid.NewGuid(), "/");
+
+        // Act
+        authenticationState.Populate(user);
+
+        // Assert
+        Assert.Equal(user.DateOfBirth, authenticationState.DateOfBirth);
+        Assert.Equal(user.EmailAddress, authenticationState.EmailAddress);
+        Assert.Equal(user.FirstName, authenticationState.FirstName);
+        Assert.Equal(user.LastName, authenticationState.LastName);
+        Assert.Equal(user.Trn, authenticationState.Trn);
+        Assert.Equal(user.UserId, authenticationState.UserId);
+        Assert.True(authenticationState.EmailAddressConfirmed);
+        Assert.Null(authenticationState.FirstTimeUser);  // Should not be changed
+        Assert.True(authenticationState.HaveCompletedFindALostTrnJourney);
+    }
+
+    public static TheoryData<AuthenticationState, string> GetNextHopUrlData
+    {
+        get
+        {
+            var journeyId = Guid.NewGuid();
+            var authorizationUrl = "/connect/authorize?client_id=client&grant_type=code&scope=email%20profile%20trn&redirect_uri=%2F";
+
+            return new TheoryData<AuthenticationState, string>()
+            {
+                // No email address
+                {
+                    new AuthenticationState(journeyId, authorizationUrl)
+                    {
+                        EmailAddress = null
+                    },
+                    $"/sign-in/email?asid={journeyId}"
+                },
+
+                // Not confirmed email address
+                {
+                    new AuthenticationState(journeyId, authorizationUrl)
+                    {
+                        EmailAddress = "john.doe@example.com"
+                    },
+                    $"/sign-in/email-confirmation?asid={journeyId}"
+                },
+
+                // Known user, not confirmed
+                {
+                    new AuthenticationState(journeyId, authorizationUrl)
+                    {
+                        EmailAddress = "john.doe@example.com",
+                        EmailAddressConfirmed = true,
+                        UserId = Guid.NewGuid(),
+                        Trn = "1234567",
+                        FirstTimeUser = false
+                    },
+                    $"/sign-in/confirmation?asid={journeyId}"
+                },
+
+                // Unknown user, not redirected to Find yet
+                {
+                    new AuthenticationState(journeyId, authorizationUrl)
+                    {
+                        EmailAddress = "john.doe@example.com",
+                        EmailAddressConfirmed = true,
+                        FirstTimeUser = true,
+                        HaveCompletedFindALostTrnJourney = false
+                    },
+                    $"/sign-in/trn?asid={journeyId}"
+                },
+
+                // Unknown user, has completed Find journey
+                {
+                    new AuthenticationState(journeyId, authorizationUrl)
+                    {
+                        EmailAddress = "john.doe@example.com",
+                        EmailAddressConfirmed = true,
+                        FirstTimeUser = true,
+                        HaveCompletedFindALostTrnJourney = true,
+                        UserId = Guid.NewGuid()
+                    },
+                    $"/sign-in/confirmation?asid={journeyId}"
+                },
+
+                // Known user, confirmed
+                {
+                    new AuthenticationState(journeyId, authorizationUrl)
+                    {
+                        EmailAddress = "john.doe@example.com",
+                        EmailAddressConfirmed = true,
+                        UserId = Guid.NewGuid(),
+                        Trn = "1234567",
+                        FirstTimeUser = false,
+                        HaveCompletedConfirmationPage = true
+                    },
+                    authorizationUrl
+                },
+
+                // Unknown user, has completed Find journey & confirmed
+                {
+                    new AuthenticationState(journeyId, authorizationUrl)
+                    {
+                        EmailAddress = "john.doe@example.com",
+                        EmailAddressConfirmed = true,
+                        UserId = Guid.NewGuid(),
+                        FirstTimeUser = true,
+                        HaveCompletedFindALostTrnJourney = true,
+                        HaveCompletedConfirmationPage = true
+                    },
+                    authorizationUrl
+                },
+            };
+        }
+    }
+}

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/TeacherIdentity.AuthServer.Tests.csproj
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/TeacherIdentity.AuthServer.Tests.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Faker.Net" Version="2.0.154" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/TestData.CreateUser.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/TestData.CreateUser.cs
@@ -4,14 +4,15 @@ namespace TeacherIdentity.AuthServer.Tests;
 
 public partial class TestData
 {
-    public Task<User> CreateUser(string? email = null) => WithDbContext(async dbContext =>
+    public Task<User> CreateUser(string? email = null, string? trn = null) => WithDbContext(async dbContext =>
     {
         var user = new User()
         {
             UserId = Guid.NewGuid(),
             EmailAddress = email ?? Faker.Internet.Email(),
             FirstName = Faker.Name.First(),
-            LastName = Faker.Name.Last()
+            LastName = Faker.Name.Last(),
+            Trn = trn
         };
 
         dbContext.Users.Add(user);


### PR DESCRIPTION
https://trello.com/c/KwMC8uic/615-blue-callback-bookend-ui

Adds the confirmation page with alternative content for known users, new users where the TRN is found and new users where the TRN was not found.

Also persists the DOB in the `Users` table (which was missing before).

Added test coverage for `AuthenticationState.GetNextHopUrl()`.