### PR TITLE
Persist TsPersonId/TRN association in DQT

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/HttpContextExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/HttpContextExtensions.cs
@@ -14,7 +14,7 @@ public static class HttpContextExtensions
         httpContext.Features.Get<AuthenticationStateFeature>()?.AuthenticationState ??
             throw new InvalidOperationException($"The current request has no {nameof(AuthenticationState)}.");
 
-    public static async Task SignInUser(this HttpContext httpContext, User user)
+    public static async Task SignInUser(this HttpContext httpContext, User user, string? trn)
     {
         var authenticationState = httpContext.GetAuthenticationState();
         authenticationState.Populate(user);
@@ -31,9 +31,9 @@ public static class HttpContextExtensions
             new Claim(Claims.FamilyName, user.LastName!)
         };
 
-        if (authorizationRequest.HasScope(CustomScopes.Trn) && user.Trn is not null)
+        if (authorizationRequest.HasScope(CustomScopes.Trn) && trn is not null)
         {
-            claims.Add(new Claim(CustomClaims.Trn, user.Trn));
+            claims.Add(new Claim(CustomClaims.Trn, trn));
         }
 
         var identity = new ClaimsIdentity(claims, authenticationType: "email", nameType: Claims.Name, roleType: null);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20220816080552_RemoveTrnFromUsersTable.Designer.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20220816080552_RemoveTrnFromUsersTable.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeacherIdentity.AuthServer.Models;
@@ -11,9 +12,10 @@ using TeacherIdentity.AuthServer.Models;
 namespace TeacherIdentity.AuthServer.Migrations
 {
     [DbContext(typeof(TeacherIdentityServerDbContext))]
-    partial class TeacherIdentityServerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220816080552_RemoveTrnFromUsersTable")]
+    partial class RemoveTrnFromUsersTable
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20220816080552_RemoveTrnFromUsersTable.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20220816080552_RemoveTrnFromUsersTable.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeacherIdentity.AuthServer.Migrations
+{
+    public partial class RemoveTrnFromUsersTable : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "trn",
+                table: "users");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "trn",
+                table: "users",
+                type: "character(7)",
+                fixedLength: true,
+                maxLength: 7,
+                nullable: true);
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/DqtTeacherIdentityInfo.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/DqtTeacherIdentityInfo.cs
@@ -1,0 +1,7 @@
+﻿namespace TeacherIdentity.AuthServer.Models;
+
+public class DqtTeacherIdentityInfo
+{
+    public string TsPersonId { get; set; } = null!;
+    public string Trn { get; set; } = null!;
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/Mappings/UserMapping.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/Mappings/UserMapping.cs
@@ -11,7 +11,6 @@ public class UserMapping : IEntityTypeConfiguration<User>
         builder.HasKey(u => u.UserId);
         builder.Property(u => u.EmailAddress).HasMaxLength(200).IsRequired();
         builder.HasIndex(u => u.EmailAddress).IsUnique().HasFilter("is_deleted = true");
-        builder.Property(u => u.Trn).HasMaxLength(7).IsFixedLength();
         builder.Property(u => u.FirstName).HasMaxLength(200).IsRequired();
         builder.Property(u => u.LastName).HasMaxLength(200).IsRequired();
         builder.Property<bool>("is_deleted").IsRequired().HasDefaultValue(false);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/User.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/User.cs
@@ -4,7 +4,6 @@ public class User
 {
     public Guid UserId { get; set; }
     public string EmailAddress { get; set; } = null!;
-    public string? Trn { get; set; }
     public string FirstName { get; set; } = null!;
     public string LastName { get; set; } = null!;
     public DateOnly DateOfBirth { get; set; }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/EmailConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/EmailConfirmation.cshtml.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Net.Http.Headers;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -11,13 +12,16 @@ namespace TeacherIdentity.AuthServer.Pages.SignIn;
 public class EmailConfirmationModel : PageModel
 {
     private readonly TeacherIdentityServerDbContext _dbContext;
+    private readonly IDqtApiClient _dqtApiClient;
     private readonly IEmailConfirmationService _emailConfirmationService;
 
     public EmailConfirmationModel(
         TeacherIdentityServerDbContext dbContext,
-        IEmailConfirmationService emailConfirmationService)
+        IEmailConfirmationService emailConfirmationService,
+        IDqtApiClient apiClient)
     {
         _dbContext = dbContext;
+        _dqtApiClient = apiClient;
         _emailConfirmationService = emailConfirmationService;
     }
 
@@ -50,8 +54,14 @@ public class EmailConfirmationModel : PageModel
         var user = await _dbContext.Users.Where(u => u.EmailAddress == Email).SingleOrDefaultAsync();
         if (user is not null)
         {
-            await HttpContext.SignInUser(user);
+            var dqtIdentityInfo = await _dqtApiClient.GetTeacherIdentityInfo(user.UserId);
+            if (dqtIdentityInfo != null)
+            {
+                await HttpContext.SignInUser(user, dqtIdentityInfo.Trn);
+            }
+
             authenticationState.FirstTimeUser = false;
+            authenticationState.Trn = dqtIdentityInfo!.Trn;
         }
         else
         {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using GovUk.Frontend.AspNetCore;
@@ -51,6 +52,16 @@ public class Program
         });
 
         builder.Services.AddGovUkFrontend(options => options.AddImportsToHtml = false);
+
+        builder.Services.AddHttpClient<DqtApiClient>(httpClient =>
+        {
+            var apiSecret = builder.Configuration.GetSection("DqtApi").GetValue<string>("apiSecret");
+            var apiUrl = builder.Configuration.GetSection("DqtApi").GetValue<string>("ApiUrl");
+            httpClient.BaseAddress = new Uri(apiUrl);
+            httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiSecret);
+
+        });
+        builder.Services.AddSingleton<IDqtApiClient, DqtApiClient>();
 
         builder.Services.AddAuthentication()
             .AddCookie(options =>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApiClient.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApiClient.cs
@@ -1,0 +1,29 @@
+﻿using System.Net.Http.Headers;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Services;
+
+namespace TeacherIdentity.AuthServer;
+
+public class DqtApiClient : IDqtApiClient
+{
+    private IConfiguration _configuration;
+    private HttpClient _client;
+
+    public DqtApiClient(IConfiguration configuration, HttpClient httpClient)
+    {
+        _configuration = configuration;
+        _client = httpClient;
+    }
+
+    public async Task<DqtTeacherIdentityInfo?> GetTeacherIdentityInfo(Guid userId)
+    {
+        var response = await _client.GetFromJsonAsync<DqtTeacherIdentityInfo?>($"/v2/teachers/teacher-identity?tsPersonId={userId}");
+        return response;
+    }
+
+    public async Task SetTeacherIdentityInfo(DqtTeacherIdentityInfo info)
+    {
+        var response = await _client.PutAsJsonAsync($"/v2/teachers/teacher-identity/{info.Trn}", new { TsPersonId = info.TsPersonId });
+        response.EnsureSuccessStatusCode();
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/IDqtApiClient.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/IDqtApiClient.cs
@@ -1,0 +1,9 @@
+﻿using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.Services;
+
+public interface IDqtApiClient
+{
+    public Task SetTeacherIdentityInfo(DqtTeacherIdentityInfo info);
+    public Task<DqtTeacherIdentityInfo?> GetTeacherIdentityInfo(Guid userId);
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/State/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/State/AuthenticationState.cs
@@ -98,7 +98,6 @@ public class AuthenticationState
         FirstName = user.FirstName;
         LastName = user.LastName;
         DateOfBirth = user.DateOfBirth;
-        Trn = user.Trn;
         HaveCompletedFindALostTrnJourney = true;
     }
 

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.EndToEndTests/HostFixture.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.EndToEndTests/HostFixture.cs
@@ -224,10 +224,10 @@ public class HostFixture : IAsyncLifetime
 
     private class TestDqtApiClient : IDqtApiClient
     {
-        public Task<DqtTeacherIdentityInfo> GetTeacherIdentityInfo(Guid userId)
+        public Task<DqtTeacherIdentityInfo?> GetTeacherIdentityInfo(Guid userId)
         {
             var ti = new DqtTeacherIdentityInfo() { TsPersonId = userId.ToString(), Trn = "1234567" };
-            return Task.FromResult(ti);
+            return Task.FromResult(ti)!;
         }
 
         public Task SetTeacherIdentityInfo(DqtTeacherIdentityInfo? info)

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.EndToEndTests/HostFixture.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.EndToEndTests/HostFixture.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.TestHost;
 using Microsoft.Playwright;
 using OpenIddict.Server.AspNetCore;
 using TeacherIdentity.AuthServer.Clients;
+using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Services;
 using TeacherIdentity.AuthServer.TestCommon;
 
@@ -77,6 +78,7 @@ public class HostFixture : IAsyncLifetime
 
         var clientHelper = new ClientConfigurationHelper(AuthServerServices);
         var clients = testConfiguration.GetSection("Clients").Get<ClientConfiguration[]>();
+
         await clientHelper.UpsertClients(clients);
 
         _clientHost = CreateClientHost(testConfiguration);
@@ -105,7 +107,7 @@ public class HostFixture : IAsyncLifetime
                 builder.ConfigureServices(services =>
                 {
                     services.Configure<OpenIddictServerAspNetCoreOptions>(options => options.DisableTransportSecurityRequirement = true);
-
+                    services.AddSingleton<IDqtApiClient, TestDqtApiClient>();
                     services.Decorate<IEmailConfirmationService>(inner =>
                         new CapturePinsEmailConfirmationServiceDecorator(inner, (email, pin) => _capturedEmailConfirmationPins.Add((email, pin))));
                 });
@@ -217,6 +219,20 @@ public class HostFixture : IAsyncLifetime
                     using var _ = CreateDefaultClient();
                 }
             }
+        }
+    }
+
+    private class TestDqtApiClient : IDqtApiClient
+    {
+        public Task<DqtTeacherIdentityInfo> GetTeacherIdentityInfo(Guid userId)
+        {
+            var ti = new DqtTeacherIdentityInfo() { TsPersonId = userId.ToString(), Trn = "1234567" };
+            return Task.FromResult(ti);
+        }
+
+        public Task SetTeacherIdentityInfo(DqtTeacherIdentityInfo? info)
+        {
+            return Task.CompletedTask;
         }
     }
 

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.EndToEndTests/SignIn.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.EndToEndTests/SignIn.cs
@@ -15,6 +15,7 @@ public class SignIn : IClassFixture<HostFixture>
     public async Task ExistingUser_CanSignInSuccessfullyWithEmailAndPin()
     {
         var email = "joe.bloggs+existing-user@example.com";
+        var trn = "1234567";
 
         {
             using var scope = _hostFixture.AuthServerServices.GetRequiredService<IServiceScopeFactory>().CreateScope();
@@ -26,7 +27,6 @@ public class SignIn : IClassFixture<HostFixture>
                 FirstName = "Joe",
                 LastName = "Bloggs",
                 UserId = Guid.NewGuid(),
-                Trn = "1234567"
             });
 
             await dbContext.SaveChangesAsync();
@@ -60,6 +60,7 @@ public class SignIn : IClassFixture<HostFixture>
         Assert.Equal(clientAppHost, pageUrlHost);
 
         var signedInEmail = await page.InnerTextAsync("data-testid=email");
+        Assert.Equal(trn, await page.InnerTextAsync("data-testid=trn"));
         Assert.Equal(email, signedInEmail);
     }
 

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/HostFixture.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/HostFixture.cs
@@ -18,7 +18,7 @@ public class HostFixture : WebApplicationFactory<TeacherIdentity.AuthServer.Prog
     public DbHelper? DbHelper { get; private set; }
 
     public IEmailConfirmationService? EmailConfirmationService { get; private set; }
-
+    public IDqtApiClient? DqtApiClient { get; private set; }
     public IEmailSender? EmailSender { get; private set; }
 
     public async Task InitializeAsync()
@@ -81,6 +81,8 @@ public class HostFixture : WebApplicationFactory<TeacherIdentity.AuthServer.Prog
 
             AddSpy<IEmailConfirmationService>(spy => EmailConfirmationService = spy);
             AddSpy<IEmailSender>(spy => EmailSender = spy);
+            DqtApiClient = A.Fake<IDqtApiClient>();
+            services.AddSingleton<IDqtApiClient>(DqtApiClient);
 
             void AddSpy<T>(Action<T> assignSpy) where T : class
             {

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/SignInUserMiddleware.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/SignInUserMiddleware.cs
@@ -15,7 +15,8 @@ public class SignInUserMiddleware
     public async Task Invoke(HttpContext context)
     {
         var userId = Guid.Parse(context.Request.Form["UserId"]);
+        var trn = context.Request.Form["Trn"];
         var user = await _dbContext.Users.SingleAsync(u => u.UserId == userId);
-        await context.SignInUser(user);
+        await context.SignInUser(user, trn);
     }
 }

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/State/AuthenticationStateTests.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/State/AuthenticationStateTests.cs
@@ -57,7 +57,6 @@ public class AuthenticationStateTests
             EmailAddress = Faker.Internet.Email(),
             FirstName = Faker.Name.First(),
             LastName = Faker.Name.Last(),
-            Trn = "1234567",
             UserId = Guid.NewGuid()
         };
 
@@ -71,7 +70,6 @@ public class AuthenticationStateTests
         Assert.Equal(user.EmailAddress, authenticationState.EmailAddress);
         Assert.Equal(user.FirstName, authenticationState.FirstName);
         Assert.Equal(user.LastName, authenticationState.LastName);
-        Assert.Equal(user.Trn, authenticationState.Trn);
         Assert.Equal(user.UserId, authenticationState.UserId);
         Assert.True(authenticationState.EmailAddressConfirmed);
         Assert.Null(authenticationState.FirstTimeUser);  // Should not be changed

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/TestBase.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/TestBase.cs
@@ -13,7 +13,6 @@ public abstract partial class TestBase : IClassFixture<HostFixture>
         {
             AllowAutoRedirect = false
         });
-
         HostFixture.ResetMocks();
     }
 
@@ -22,6 +21,7 @@ public abstract partial class TestBase : IClassFixture<HostFixture>
     public HostFixture HostFixture { get; }
 
     public HttpClient HttpClient { get; }
+
 
     public TestData TestData => HostFixture.Services.GetRequiredService<TestData>();
 

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/TestData.CreateUser.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/TestData.CreateUser.cs
@@ -4,7 +4,7 @@ namespace TeacherIdentity.AuthServer.Tests;
 
 public partial class TestData
 {
-    public Task<User> CreateUser(string? email = null, string? trn = null) => WithDbContext(async dbContext =>
+    public Task<User> CreateUser(string? email = null) => WithDbContext(async dbContext =>
     {
         var user = new User()
         {
@@ -12,7 +12,6 @@ public partial class TestData
             EmailAddress = email ?? Faker.Internet.Email(),
             FirstName = Faker.Name.First(),
             LastName = Faker.Name.Last(),
-            Trn = trn
         };
 
         dbContext.Users.Add(user);


### PR DESCRIPTION
- Stop trn from being saved to database and get/put trn using dqt api instead.