### PR TITLE
Handle new users where a TRN is *not* matched in Find

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/HttpContextExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/HttpContextExtensions.cs
@@ -17,7 +17,7 @@ public static class HttpContextExtensions
     public static async Task SignInUser(this HttpContext httpContext, User user, string? trn)
     {
         var authenticationState = httpContext.GetAuthenticationState();
-        authenticationState.Populate(user);
+        authenticationState.Populate(user, trn);
 
         var authorizationRequest = authenticationState.GetAuthorizationRequest();
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/EmailConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/EmailConfirmation.cshtml.cs
@@ -1,7 +1,5 @@
 using System.ComponentModel.DataAnnotations;
-using System.Net.Http.Headers;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Models;
@@ -54,14 +52,12 @@ public class EmailConfirmationModel : PageModel
         var user = await _dbContext.Users.Where(u => u.EmailAddress == Email).SingleOrDefaultAsync();
         if (user is not null)
         {
+            // N.B. If the user didn't match to a TRN when they registered then we won't get a result back from this API call
             var dqtIdentityInfo = await _dqtApiClient.GetTeacherIdentityInfo(user.UserId);
-            if (dqtIdentityInfo != null)
-            {
-                await HttpContext.SignInUser(user, dqtIdentityInfo.Trn);
-            }
+
+            await HttpContext.SignInUser(user, dqtIdentityInfo?.Trn);
 
             authenticationState.FirstTimeUser = false;
-            authenticationState.Trn = dqtIdentityInfo!.Trn;
         }
         else
         {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/State/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/State/AuthenticationState.cs
@@ -90,7 +90,7 @@ public class AuthenticationState
         return AuthorizationUrl;
     }
 
-    public void Populate(User user)
+    public void Populate(User user, string? trn)
     {
         UserId = user.UserId;
         EmailAddress = user.EmailAddress;
@@ -99,6 +99,7 @@ public class AuthenticationState
         LastName = user.LastName;
         DateOfBirth = user.DateOfBirth;
         HaveCompletedFindALostTrnJourney = true;
+        Trn = trn;
     }
 
     public string Serialize() => JsonSerializer.Serialize(this, _jsonSerializerOptions);

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.EndToEndTests/TeacherIdentity.AuthServer.EndToEndTests.csproj
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.EndToEndTests/TeacherIdentity.AuthServer.EndToEndTests.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FakeItEasy" Version="7.3.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.7" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="Microsoft.Playwright" Version="1.24.1" />

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
@@ -92,40 +92,17 @@ public class EmailConfirmationTests : TestBase
         Assert.True(authStateHelper.AuthenticationState.FirstTimeUser);
     }
 
-    [Fact]
-    public async Task Post_ValidPinForKnownUserWithTrn_UpdatesAuthenticationStateSignsInAndRedirects()
-    {
-        // Arrange
-        var trn = "1234567";
-        var email = Faker.Internet.Email();
-        var teacherIdentity = new DqtTeacherIdentityInfo() { Trn = trn };
-        A.CallTo(() => HostFixture.DqtApiClient!.GetTeacherIdentityInfo(A<Guid>.Ignored)).Returns(teacherIdentity);
-        var user = await TestData.CreateUser();
-        var emailConfirmationService = HostFixture.Services.GetRequiredService<IEmailConfirmationService>();
-        var pin = await emailConfirmationService.GeneratePin(user.EmailAddress);
-
-        var authStateHelper = CreateAuthenticationStateHelper(user.EmailAddress);
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
-        {
-            Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pin)
-                .ToContent()
-        };
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal("/sign-in/confirmation", new Url(response.Headers.Location).Path);
-        Assert.Equal(trn, authStateHelper.AuthenticationState.Trn);
-    }
-
-    [Fact]
-    public async Task Post_ValidPinForKnownUser_UpdatesAuthenticationStateSignsInAndRedirects()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Post_ValidPinForKnownUserWithTrn_UpdatesAuthenticationStateSignsInAndRedirects(bool hasTrn)
     {
         // Arrange
         var user = await TestData.CreateUser();
+        var trn = hasTrn ? TestData.GenerateTrn() : null;
+
+        A.CallTo(() => HostFixture.DqtApiClient!.GetTeacherIdentityInfo(user.UserId))
+            .Returns(hasTrn ? new DqtTeacherIdentityInfo() { Trn = trn! } : null);
 
         var emailConfirmationService = HostFixture.Services.GetRequiredService<IEmailConfirmationService>();
         var pin = await emailConfirmationService.GeneratePin(user.EmailAddress);
@@ -148,6 +125,7 @@ public class EmailConfirmationTests : TestBase
         Assert.True(authStateHelper.AuthenticationState.EmailAddressConfirmed);
         Assert.NotNull(authStateHelper.AuthenticationState.UserId);
         Assert.False(authStateHelper.AuthenticationState.FirstTimeUser);
+        Assert.Equal(trn, authStateHelper.AuthenticationState.Trn);
     }
 
     private AuthenticationStateHelper CreateAuthenticationStateHelper(string? email = null) =>

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/HostFixture.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/HostFixture.cs
@@ -45,12 +45,13 @@ public class HostFixture : WebApplicationFactory<TeacherIdentity.AuthServer.Prog
         }
     }
 
-    public async Task SignInUser(Guid userId, AuthenticationStateHelper authenticationStateHelper, HttpClient httpClient)
+    public async Task SignInUser(AuthenticationStateHelper authenticationStateHelper, HttpClient httpClient, Guid userId, string? trn)
     {
         var request = new HttpRequestMessage(HttpMethod.Post, $"/_sign-in?{authenticationStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
                 .Add("UserId", userId.ToString())
+                .Add("Trn", trn ?? string.Empty)
                 .ToContent()
         };
 

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/SignInUserMiddleware.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/SignInUserMiddleware.cs
@@ -15,8 +15,9 @@ public class SignInUserMiddleware
     public async Task Invoke(HttpContext context)
     {
         var userId = Guid.Parse(context.Request.Form["UserId"]);
-        var trn = context.Request.Form["Trn"];
+        var trn = context.Request.Form["Trn"].FirstOrDefault();
+
         var user = await _dbContext.Users.SingleAsync(u => u.UserId == userId);
-        await context.SignInUser(user, trn);
+        await context.SignInUser(user, !string.IsNullOrEmpty(trn) ? trn : null);
     }
 }

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/State/AuthenticationStateTests.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/State/AuthenticationStateTests.cs
@@ -59,11 +59,12 @@ public class AuthenticationStateTests
             LastName = Faker.Name.Last(),
             UserId = Guid.NewGuid()
         };
+        var trn = "1234567";
 
         var authenticationState = new AuthenticationState(Guid.NewGuid(), "/");
 
         // Act
-        authenticationState.Populate(user);
+        authenticationState.Populate(user, trn);
 
         // Assert
         Assert.Equal(user.DateOfBirth, authenticationState.DateOfBirth);
@@ -74,6 +75,7 @@ public class AuthenticationStateTests
         Assert.True(authenticationState.EmailAddressConfirmed);
         Assert.Null(authenticationState.FirstTimeUser);  // Should not be changed
         Assert.True(authenticationState.HaveCompletedFindALostTrnJourney);
+        Assert.Equal(trn, authenticationState.Trn);
     }
 
     public static TheoryData<AuthenticationState, string> GetNextHopUrlData

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/TestBase.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/TestBase.cs
@@ -13,6 +13,7 @@ public abstract partial class TestBase : IClassFixture<HostFixture>
         {
             AllowAutoRedirect = false
         });
+
         HostFixture.ResetMocks();
     }
 


### PR DESCRIPTION
Find will not always locate the TRN so we need to handle the case where this is missing in the callback JWT.