### PR TITLE
Introduce an API call to the Find/Auth server handover process

### DIFF
--- a/docs/find-lost-trn-integration.md
+++ b/docs/find-lost-trn-integration.md
@@ -17,9 +17,10 @@ sequenceDiagram
         authz_server->dqt_api: lookup DQT contact record with matching teacher_id
     end
     alt not existing user or lookup failed
-        authz_server->>find_lost_trn: redirects user with a callback URL + additional context
+        authz_server->>find_lost_trn: POSTs user to /identity with a callback URL + additional context
         find_lost_trn->dqt_api: resolve TRN
-        find_lost_trn->>authz_server: redirects user to callback URL with JWT containing TRN
+        find_lost_trn->authz_server: calls API to store the user information for the journey ID
+        find_lost_trn->>authz_server: redirects user to callback URL
         authz_server->dqt_api: persist the teacher_id against the DQT contact record
     end
     authz_server->>client: redirects user to the client with id_token containing email + TRN claims
@@ -77,18 +78,23 @@ redirect_uri=https%3A%2F%2Fauthserveruri%2F&client_title=The%20Client%20Title&em
 
 ## Handover from Find a lost TRN to the authorization server
 
-Once Find a lost TRN has completed its journey (whether successfully resolving a TRN or not), it needs to redirect back to the authorization server with the user's information.
-Find a lost TRN should POST to the `redirect_uri` specified in the initial request using the `application/x-www-form-urlencoded` content type.
-The request should include a `user` parameter. The `user` parameter must contain a JWT that includes the user's names, DOB, NINO and TRN, if known. The JWT should be signed with the same pre-shared key referenced above.
+Once Find a lost TRN has completed its journey (whether successfully resolving a TRN or not), it needs to provide the user information to the authorization server and redirect back there.
 
-When the authorization server receives the callback, it should validate the JWT has been signed by the pre-shared key. If validation fails an error should be shown; the authorization process must *not* complete.
+Find a lost TRN must do a back-end API call to a PUT endpoint on the authorization server's API `/api/find-trn/user/{journeyId}` (where `{journeyId}` is the ID passed in the initial handover request).
+The body is a JSON object with a single property - `subject`. This should contain a JWT that includes the user's names, DOB, NINO and TRN, if known. The JWT does not need to be signed.
 
-### Example:
+Finally, Find a lost TRN should redirect the user to the `redirect_uri` specified in the initial handover request.
+
+When the authorization server receives the callback, it will look up the user information that was persisted against the journey ID by the API call. Using that information it will register the user and completed the authorization process.
+
+### Example API call:
 
 ```
-POST / HTTP/1.1
+PUT /api/find-trn/user/2345 HTTP/1.1
 Host: https://authserveruri
-Content-Type: application/x-www-form-urlencoded
+Content-Type: application/json
 
-user=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJnaXZlbl9uYW1lIjoiRmlyc3ROYW1lIiwiZmFtaWx5X25hbWUiOiJMYXN0TmFtZSIsInRybiI6IjEyMzQ1NjciLCJiaXJ0aGRhdGUiOiIxOTkwLTAxLTAxIiwibmlubyI6IlFRMTIzNDU2QyIsIm5iZiI6MTY1OTYxMzUzMywiZXhwIjoxNjU5NjE3MTMzLCJpYXQiOjE2NTk2MTM1MzN9.MZSUNq2jG1loFD0X5H76pMmNnN-CMLjAMdCqBrvYz_8
+{
+  "user": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJnaXZlbl9uYW1lIjoiRmlyc3ROYW1lIiwiZmFtaWx5X25hbWUiOiJMYXN0TmFtZSIsInRybiI6IjEyMzQ1NjciLCJiaXJ0aGRhdGUiOiIxOTkwLTAxLTAxIiwibmlubyI6IlFRMTIzNDU2QyIsIm5iZiI6MTY1OTYxMzUzMywiZXhwIjoxNjU5NjE3MTMzLCJpYXQiOjE2NTk2MTM1MzN9.MZSUNq2jG1loFD0X5H76pMmNnN-CMLjAMdCqBrvYz_8"
+}
 ```

--- a/docs/find-lost-trn-integration.md
+++ b/docs/find-lost-trn-integration.md
@@ -85,7 +85,7 @@ The body is a JSON object with a single property - `subject`. This should contai
 
 Finally, Find a lost TRN should redirect the user to the `redirect_uri` specified in the initial handover request.
 
-When the authorization server receives the callback, it will look up the user information that was persisted against the journey ID by the API call. Using that information it will register the user and completed the authorization process.
+When the authorization server receives the callback, it will look up the user information that was persisted against the journey ID by the API call. Using that information it will register the user and complete the authorization process.
 
 ### Example API call:
 


### PR DESCRIPTION
We want to redirect the user from Find back to the Authorization server with a GET and not a POST. (Doing the latter would require introducing an interstitial page that we don't want.)

Using GET requires specifying all the handover information in a URL but this will likely lead to problems with URLs getting too long.

This change is to introduce an API call so that the information is exchanged through the back channel instead of the front channel. In turn that means we can redirect with a shorter URL as it only needs to contain an ID. 