### PR TITLE
Add resource prefix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,3 +174,30 @@ jobs:
         azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
         terraform_vars: workspace_variables/dev.tfvars.json
         terraform_backend_vars: workspace_variables/dev.backend.tfvars
+
+  deploy_preprod:
+    name: Deploy to preprod environment
+    needs: [build, validate_terraform]
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    environment:
+      name: preprod
+      url: ${{ steps.deploy.outputs.environment_url }}
+    concurrency: deploy_preprod
+
+    outputs:
+      environment_url: ${{ steps.deploy.outputs.environment_url }}
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: ./.github/workflows/actions/deploy-environment
+      id: deploy
+      with:
+        environment_name: preprod
+        docker_image: ghcr.io/dfe-digital/get-an-identity
+        authserver_tag: authserver-${{ github.sha }}
+        testclient_tag: testclient-${{ github.sha }}
+        azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+        terraform_vars: workspace_variables/preprod.tfvars.json
+        terraform_backend_vars: workspace_variables/preprod.backend.tfvars

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -1,5 +1,5 @@
 resource "azurerm_service_plan" "service-plan" {
-  name                = "getanid-authserver-${var.environment_name}-app-spln"
+  name                = local.app_service_plan_name
   location            = data.azurerm_resource_group.group.location
   resource_group_name = data.azurerm_resource_group.group.name
   os_type             = "Linux"
@@ -143,7 +143,7 @@ resource "azurerm_redis_cache" "redis" {
 }
 
 resource "azurerm_log_analytics_workspace" "analytics" {
-  name                = "getanid-${var.environment_name}-log-analytics-workspace"
+  name                = local.log_analytics_workspace_name
   location            = data.azurerm_resource_group.group.location
   resource_group_name = data.azurerm_resource_group.group.name
   sku                 = var.log_analytics_sku
@@ -157,7 +157,7 @@ resource "azurerm_log_analytics_workspace" "analytics" {
 }
 
 resource "azurerm_application_insights" "insights" {
-  name                 = "getanid-${var.environment_name}-appinsights"
+  name                 = local.app_insights_name
   location             = data.azurerm_resource_group.group.location
   resource_group_name  = data.azurerm_resource_group.group.name
   application_type     = "web"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,7 +1,10 @@
 variable "environment_name" {
   type = string
 }
-
+variable "resource_prefix" {
+  type    = string
+  default = ""
+}
 variable "app_suffix" {
   type    = string
   default = ""
@@ -114,12 +117,14 @@ variable "testclient_tag" {
 
 locals {
   hosting_environment              = var.environment_name
-  get_an_identity_app_name         = "get-an-identity-${var.environment_name}${var.app_suffix}-auth-server"
-  get_an_identity_test_client_name = "get-an-identity-${var.environment_name}${var.app_suffix}-test-client"
-  postgres_server_name             = "get-an-identity-${var.environment_name}${var.app_suffix}-pg-svr"
-  postgres_database_name           = "get-an-identity-${var.environment_name}${var.app_suffix}-pg-database"
-  redis_database_name              = "get-an-identity-${var.environment_name}${var.app_suffix}-redis-svc"
-  app_insights_name                = "get-an-identity-${var.environment_name}${var.app_suffix}-app-ins-svc"
+  app_service_plan_name            = "${var.resource_prefix}getanid-${var.environment_name}-plan"
+  get_an_identity_app_name         = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-auth-server-app"
+  get_an_identity_test_client_name = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-test-client-app"
+  postgres_server_name             = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-psql"
+  postgres_database_name           = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-psql-db"
+  redis_database_name              = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-redis"
+  app_insights_name                = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-appi"
+  log_analytics_workspace_name     = "${var.resource_prefix}getanid-${var.environment_name}-log"
 
   keyvault_logging_enabled            = var.keyvault_logging_enabled
   storage_diagnostics_logging_enabled = length(var.storage_log_categories) > 0

--- a/terraform/workspace_variables/dev.tfvars.json
+++ b/terraform/workspace_variables/dev.tfvars.json
@@ -2,8 +2,9 @@
   "environment_name": "dev",
   "key_vault_name": "s165d01-getanid-dv-kv",
   "resource_group_name": "s165d01-getanid-dv-rg",
-  "data_protection_storage_account_name": "s165d01getaniddataprodv",
+  "data_protection_storage_account_name": "s165d01getaniddatadvst",
   "deploy_test_server_app": true,
   "keyvault_logging_enabled": true,
-  "storage_log_categories": []
+  "storage_log_categories": [],
+  "resource_prefix": "s165d01-"
 }

--- a/terraform/workspace_variables/preprod.backend.tfvars
+++ b/terraform/workspace_variables/preprod.backend.tfvars
@@ -1,0 +1,3 @@
+storage_account_name = "s165t01getanidtfstatepp"
+key                  = "preprod.tfstate"
+resource_group_name  = "s165t01-getanid-pp-rg"

--- a/terraform/workspace_variables/preprod.tfvars.json
+++ b/terraform/workspace_variables/preprod.tfvars.json
@@ -1,0 +1,11 @@
+{
+    "environment_name": "preprod",
+    "key_vault_name": "s165t01-getanid-pp-kv",
+    "resource_group_name": "s165t01-getanid-pp-rg",
+    "data_protection_storage_account_name": "s165t01getaniddatappst",
+    "deploy_test_server_app": true,
+    "keyvault_logging_enabled": true,
+    "storage_log_categories": [],
+    "resource_prefix": "s165t01-",
+    "app_service_plan_sku": "S1"
+  }


### PR DESCRIPTION
### context

All Azure resources deployed should have service code and subscription prefix. This enables an Azure administrator to identify the resources belonging to service/team when working with multiple subscriptions.