### PR TITLE
Add blue/green deployment

### DIFF
--- a/.github/workflows/actions/deploy-environment/action.yml
+++ b/.github/workflows/actions/deploy-environment/action.yml
@@ -4,14 +4,8 @@ inputs:
   environment_name:
     description: 'The name of the environment'
     required: true
-  docker_image:
-    description: 'Auth server Docker image to deploy to the app service'
-    required: true
-  authserver_tag:
-    description: 'Test client Docker image to deploy to the app service'
-    required: true
-  testclient_tag:
-    description: 'Test client Docker image to deploy to the app service'
+  image_tag:
+    description: 'github SHA of the image'
     required: true
   azure_credentials:
     description: 'JSON object containing a service principal that can read from Azure Key Vault'
@@ -27,6 +21,9 @@ outputs:
   environment_url:
     description: 'The base URL for the deployed environment'
     value: ${{ steps.terraform.outputs.url }}
+  postgres_server_name:
+    description: The name of the postgres server deployed
+    value: ${{ steps.terraform.outputs.postgres_server_name }}
 
 
 runs:
@@ -37,12 +34,21 @@ runs:
       id: config
       run: |
         KEY_VAULT_NAME=$(jq -r '.key_vault_name' $TFVARS)
-        PAAS_SPACE=$(jq -r '.paas_space' $TFVARS)
+        RESOURCE_GROUP_NAME=$(jq -r '.resource_group_name' $TFVARS)
+
         if [ -z "$KEY_VAULT_NAME" ]; then
           echo "::error ::Failed to extract key_vault_name from $TFVARS"
           exit 1
         fi
+
+        if [ -z "$RESOURCE_GROUP_NAME" ]; then
+          echo "::error ::Failed to extract resource_group_name from $TFVARS"
+          exit 1
+        fi
+
+        echo ::set-output name=resource_group_name::$RESOURCE_GROUP_NAME
         echo ::set-output name=key_vault_name::$KEY_VAULT_NAME
+
       shell: bash
       env:
         TFVARS: ${{ inputs.terraform_vars }}
@@ -67,23 +73,21 @@ runs:
       id: terraform
       run: |
         make ci ${{ inputs.environment_name }} terraform-apply
-        cd terraform && echo ::set-output name=url::https://$(terraform output -raw auth_server_fqdn)/
+        cd terraform && echo ::set-output name=url::$(terraform output -raw auth_server_fqdn)/
         echo ::set-output name=postgres_server_name::$(terraform output -raw postgres_server_name)
       env:
         ARM_ACCESS_KEY: ${{ steps.get_secrets.outputs.TFSTATE-CONTAINER-ACCESS-KEY }}
         TF_VAR_azure_sp_credentials_json: ${{ inputs.azure_credentials }}
-        TF_VAR_docker_image: ${{ inputs.docker_image }}
-        TF_VAR_authserver_tag: ${{ inputs.authserver_tag }}
-        TF_VAR_testclient_tag: ${{ inputs.testclient_tag }}
+        IMAGE_TAG: ${{ inputs.image_tag }}
       shell: bash
 
     - name: Public IP
       id: ip
       uses: haythem/public-ip@v1.2
 
-    - name: Azure CLI script
-      uses: azure/CLI@v1
-      with:
-        azcliversion: 2.30.0
-        inlineScript: |
-          az postgres flexible-server firewall-rule create --name ${{ steps.terraform.outputs.postgres_server_name }} --resource-group ${{ steps.config.outputs.resource_group_name }} --rule-name Allow-GithubRunner --start-ip-address ${{ steps.ip.outputs.ipv4 }} --end-ip-address ${{ steps.ip.outputs.ipv4 }}
+    # - name: Azure CLI script
+    #   uses: azure/CLI@v1
+    #   with:
+    #     azcliversion: 2.30.0
+    #     inlineScript: |
+    #       az postgres flexible-server firewall-rule create --name ${{ steps.terraform.outputs.postgres_server_name }} --resource-group ${{ steps.config.outputs.resource_group_name }} --rule-name Allow-GithubRunner --start-ip-address ${{ steps.ip.outputs.ipv4 }} --end-ip-address ${{ steps.ip.outputs.ipv4 }}

--- a/.github/workflows/actions/deploy-environment/action.yml
+++ b/.github/workflows/actions/deploy-environment/action.yml
@@ -68,6 +68,7 @@ runs:
       run: |
         make ci ${{ inputs.environment_name }} terraform-apply
         cd terraform && echo ::set-output name=url::https://$(terraform output -raw auth_server_fqdn)/
+        echo ::set-output name=postgres_server_name::$(terraform output -raw postgres_server_name)
       env:
         ARM_ACCESS_KEY: ${{ steps.get_secrets.outputs.TFSTATE-CONTAINER-ACCESS-KEY }}
         TF_VAR_azure_sp_credentials_json: ${{ inputs.azure_credentials }}
@@ -75,3 +76,14 @@ runs:
         TF_VAR_authserver_tag: ${{ inputs.authserver_tag }}
         TF_VAR_testclient_tag: ${{ inputs.testclient_tag }}
       shell: bash
+
+    - name: Public IP
+      id: ip
+      uses: haythem/public-ip@v1.2
+
+    - name: Azure CLI script
+      uses: azure/CLI@v1
+      with:
+        azcliversion: 2.30.0
+        inlineScript: |
+          az postgres flexible-server firewall-rule create --name ${{ steps.terraform.outputs.postgres_server_name }} --resource-group ${{ steps.config.outputs.resource_group_name }} --rule-name Allow-GithubRunner --start-ip-address ${{ steps.ip.outputs.ipv4 }} --end-ip-address ${{ steps.ip.outputs.ipv4 }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
     - main
+    - add-swap-slots
   pull_request:
     branches:
     - main
+    - add-swap-slots
 
 env:
   CONTAINER_REGISTRY: ghcr.io
@@ -148,56 +150,95 @@ jobs:
         working_directory: terraform
       continue-on-error: true  # temporary- we're getting sporadic 503 errors here in action setup
 
-  deploy_dev:
-    name: Deploy to dev environment
-    needs: [build, validate_terraform]
-    runs-on: ubuntu-latest
-    if: (github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-    environment:
-      name: dev
-      url: ${{ steps.deploy.outputs.environment_url }}
-    concurrency: deploy_dev
+  # deploy_dev:
+  #   name: Deploy to dev environment
+  #   needs: [build, validate_terraform]
+  #   runs-on: ubuntu-latest
+  #   if: (github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+  #   environment:
+  #     name: dev
+  #     url: ${{ steps.deploy.outputs.environment_url }}
+  #   concurrency: deploy_dev
 
-    outputs:
-      environment_url: ${{ steps.deploy.outputs.environment_url }}
+  #   outputs:
+  #     environment_url: ${{ steps.deploy.outputs.environment_url }}
 
-    steps:
-    - uses: actions/checkout@v3
+  #   steps:
+  #   - uses: actions/checkout@v3
 
-    - uses: ./.github/workflows/actions/deploy-environment
-      id: deploy
-      with:
-        environment_name: dev
-        docker_image: ghcr.io/dfe-digital/get-an-identity
-        authserver_tag: authserver-${{ github.sha }}
-        testclient_tag: testclient-${{ github.sha }}
-        azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-        terraform_vars: workspace_variables/dev.tfvars.json
-        terraform_backend_vars: workspace_variables/dev.backend.tfvars
+  #   - uses: ./.github/workflows/actions/deploy-environment
+  #     id: deploy
+  #     with:
+  #       environment_name: dev
+  #       docker_image: ghcr.io/dfe-digital/get-an-identity
+  #       authserver_tag: authserver-${{ github.sha }}
+  #       testclient_tag: testclient-${{ github.sha }}
+  #       azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+  #       terraform_vars: workspace_variables/dev.tfvars.json
+  #       terraform_backend_vars: workspace_variables/dev.backend.tfvars
 
-  deploy_preprod:
-    name: Deploy to preprod environment
-    needs: [build, validate_terraform]
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
-    environment:
-      name: preprod
-      url: ${{ steps.deploy.outputs.environment_url }}
-    concurrency: deploy_preprod
+  # deploy_preprod:
+  #   name: Deploy to preprod environment
+  #   needs: [build, validate_terraform]
+  #   runs-on: ubuntu-latest
+  #   if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+  #   environment:
+  #     name: preprod
+  #     url: ${{ steps.deploy.outputs.environment_url }}
+  #   concurrency: deploy_preprod
 
-    outputs:
-      environment_url: ${{ steps.deploy.outputs.environment_url }}
+  #   outputs:
+  #     environment_url: ${{ steps.deploy.outputs.environment_url }}
 
-    steps:
-    - uses: actions/checkout@v3
+  #   steps:
+  #   - uses: actions/checkout@v3
 
-    - uses: ./.github/workflows/actions/deploy-environment
-      id: deploy
-      with:
-        environment_name: preprod
-        docker_image: ghcr.io/dfe-digital/get-an-identity
-        authserver_tag: authserver-${{ github.sha }}
-        testclient_tag: testclient-${{ github.sha }}
-        azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-        terraform_vars: workspace_variables/preprod.tfvars.json
-        terraform_backend_vars: workspace_variables/preprod.backend.tfvars
+  #   - uses: ./.github/workflows/actions/deploy-environment
+  #     id: deploy
+  #     with:
+  #       environment_name: preprod
+  #       docker_image: ghcr.io/dfe-digital/get-an-identity
+  #       authserver_tag: authserver-${{ github.sha }}
+  #       testclient_tag: testclient-${{ github.sha }}
+  #       azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+  #       terraform_vars: workspace_variables/preprod.tfvars.json
+  #       terraform_backend_vars: workspace_variables/preprod.backend.tfvars
+
+  deploy_production:
+      name: Deploy to production environment
+      needs: [build, validate_terraform]
+      runs-on: ubuntu-latest
+      # if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+      if: (github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch' || github.event_name == 'push' && github.ref == 'refs/heads/add-swap-slots'
+      environment:
+        name: production
+        url: ${{ steps.deploy.outputs.environment_url }}
+      concurrency: deploy_production
+
+      outputs:
+        environment_url: ${{ steps.deploy.outputs.environment_url }}
+        postgres_server_name: ${{ steps.deploy.outputs.postgres_server_name }}
+
+      steps:
+      - uses: actions/checkout@v3
+
+      - uses: ./.github/workflows/actions/deploy-environment
+        id: deploy
+        with:
+          environment_name: production
+          docker_image: ghcr.io/dfe-digital/get-an-identity
+          IMAGE_TAG: ${{ github.sha }}
+          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+          terraform_vars: workspace_variables/production.tfvars.json
+          terraform_backend_vars: workspace_variables/production.backend.tfvars
+
+      - uses: azure/webapps-deploy@v2 #import the Azure webapps-deploy action v2
+        with:
+          app-name: "s165p01-getanid-production-auth-server-app" #Your PRODUCTION SLOT'S APP NAME goes here
+          images: "ghcr.io/dfe-digital/get-an-identity:authserver-${{ github.sha }}"
+          slot-name: "staging" #Your staging slot name goes here
+
+      - uses: azure/CLI@v1
+        with:
+          inlineScript: |
+            az webapp deployment slot swap  -g s165p01-getanid-pd-rg -n s165p01-getanid-production-auth-server-app --slot staging --target-slot production

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,11 +4,9 @@ on:
   push:
     branches:
     - main
-    - add-swap-slots
   pull_request:
     branches:
     - main
-    - add-swap-slots
 
 env:
   CONTAINER_REGISTRY: ghcr.io
@@ -150,95 +148,111 @@ jobs:
         working_directory: terraform
       continue-on-error: true  # temporary- we're getting sporadic 503 errors here in action setup
 
-  # deploy_dev:
-  #   name: Deploy to dev environment
-  #   needs: [build, validate_terraform]
-  #   runs-on: ubuntu-latest
-  #   if: (github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
-  #   environment:
-  #     name: dev
-  #     url: ${{ steps.deploy.outputs.environment_url }}
-  #   concurrency: deploy_dev
+  deploy_dev:
+    name: Deploy to dev environment
+    needs: [build, validate_terraform]
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch'
+    environment:
+      name: dev
+      url: ${{ steps.deploy.outputs.environment_url }}
+    concurrency: deploy_dev
 
-  #   outputs:
-  #     environment_url: ${{ steps.deploy.outputs.environment_url }}
+    outputs:
+      environment_url: ${{ steps.deploy.outputs.environment_url }}
 
-  #   steps:
-  #   - uses: actions/checkout@v3
+    steps:
+    - uses: actions/checkout@v3
 
-  #   - uses: ./.github/workflows/actions/deploy-environment
-  #     id: deploy
-  #     with:
-  #       environment_name: dev
-  #       docker_image: ghcr.io/dfe-digital/get-an-identity
-  #       authserver_tag: authserver-${{ github.sha }}
-  #       testclient_tag: testclient-${{ github.sha }}
-  #       azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-  #       terraform_vars: workspace_variables/dev.tfvars.json
-  #       terraform_backend_vars: workspace_variables/dev.backend.tfvars
+    - uses: ./.github/workflows/actions/deploy-environment
+      id: deploy
+      with:
+        environment_name: dev
+        image_tag: ${{ github.sha }}
+        azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+        terraform_vars: workspace_variables/dev.tfvars.json
+        terraform_backend_vars: workspace_variables/dev.backend.tfvars
 
-  # deploy_preprod:
-  #   name: Deploy to preprod environment
-  #   needs: [build, validate_terraform]
-  #   runs-on: ubuntu-latest
-  #   if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
-  #   environment:
-  #     name: preprod
-  #     url: ${{ steps.deploy.outputs.environment_url }}
-  #   concurrency: deploy_preprod
+    - name: Check the deployed service URL
+      uses: jtalk/url-health-check-action@v2
+      with:
+        url: ${{ steps.deploy.outputs.environment_url }}
+        follow-redirect: false
+        max-attempts: 30 # Optional, defaults to 1
+        # Delay between retries
+        retry-delay: 10s
+        retry-all: false # Optional, defaults to "false"
 
-  #   outputs:
-  #     environment_url: ${{ steps.deploy.outputs.environment_url }}
+  deploy_preprod:
+    name: Deploy to preprod environment
+    needs: [build]
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    environment:
+      name: preprod
+      url: ${{ steps.deploy.outputs.environment_url }}
+    concurrency: deploy_preprod
 
-  #   steps:
-  #   - uses: actions/checkout@v3
+    outputs:
+      environment_url: ${{ steps.deploy.outputs.environment_url }}
 
-  #   - uses: ./.github/workflows/actions/deploy-environment
-  #     id: deploy
-  #     with:
-  #       environment_name: preprod
-  #       docker_image: ghcr.io/dfe-digital/get-an-identity
-  #       authserver_tag: authserver-${{ github.sha }}
-  #       testclient_tag: testclient-${{ github.sha }}
-  #       azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-  #       terraform_vars: workspace_variables/preprod.tfvars.json
-  #       terraform_backend_vars: workspace_variables/preprod.backend.tfvars
+    steps:
+    - uses: actions/checkout@v3
+
+    - uses: ./.github/workflows/actions/deploy-environment
+      id: deploy
+      with:
+        environment_name: preprod
+        image_tag: ${{ github.sha }}
+        azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+        terraform_vars: workspace_variables/preprod.tfvars.json
+        terraform_backend_vars: workspace_variables/preprod.backend.tfvars
+
+    - uses: azure/webapps-deploy@v2
+      with:
+        app-name: "s165t01-getanid-preprod-auths-app"
+        images: "ghcr.io/dfe-digital/get-an-identity:authserver-${{ github.sha }}"
+        slot-name: "staging"
+
+    - uses: azure/CLI@v1
+      with:
+        inlineScript: |
+          az webapp deployment slot swap  -g s165t01-getanid-pp-rg -n s165t01-getanid-preprod-auths-app --slot staging --target-slot production
+
 
   deploy_production:
-      name: Deploy to production environment
-      needs: [build, validate_terraform]
-      runs-on: ubuntu-latest
-      # if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
-      if: (github.event_name == 'pull_request' && github.event.pull_request.draft == false) || github.event_name == 'workflow_dispatch' || github.event_name == 'push' && github.ref == 'refs/heads/add-swap-slots'
-      environment:
-        name: production
-        url: ${{ steps.deploy.outputs.environment_url }}
-      concurrency: deploy_production
+    name: Deploy to production environment
+    needs: [build, deploy_preprod]
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' || github.event_name == 'workflow_dispatch'
+    environment:
+      name: production
+      url: ${{ steps.deploy.outputs.environment_url }}
+    concurrency: deploy_production
 
-      outputs:
-        environment_url: ${{ steps.deploy.outputs.environment_url }}
-        postgres_server_name: ${{ steps.deploy.outputs.postgres_server_name }}
+    outputs:
+      environment_url: ${{ steps.deploy.outputs.environment_url }}
+      postgres_server_name: ${{ steps.deploy.outputs.postgres_server_name }}
 
-      steps:
-      - uses: actions/checkout@v3
+    steps:
+    - uses: actions/checkout@v3
 
-      - uses: ./.github/workflows/actions/deploy-environment
-        id: deploy
-        with:
-          environment_name: production
-          docker_image: ghcr.io/dfe-digital/get-an-identity
-          IMAGE_TAG: ${{ github.sha }}
-          azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
-          terraform_vars: workspace_variables/production.tfvars.json
-          terraform_backend_vars: workspace_variables/production.backend.tfvars
+    - uses: ./.github/workflows/actions/deploy-environment
+      id: deploy
+      with:
+        environment_name: production
+        image_tag: ${{ github.sha }}
+        azure_credentials: ${{ secrets.AZURE_CREDENTIALS }}
+        terraform_vars: workspace_variables/production.tfvars.json
+        terraform_backend_vars: workspace_variables/production.backend.tfvars
 
-      - uses: azure/webapps-deploy@v2 #import the Azure webapps-deploy action v2
-        with:
-          app-name: "s165p01-getanid-production-auth-server-app" #Your PRODUCTION SLOT'S APP NAME goes here
-          images: "ghcr.io/dfe-digital/get-an-identity:authserver-${{ github.sha }}"
-          slot-name: "staging" #Your staging slot name goes here
+    - uses: azure/webapps-deploy@v2
+      with:
+        app-name: "s165p01-getanid-production-auths-app"
+        images: "ghcr.io/dfe-digital/get-an-identity:authserver-${{ github.sha }}"
+        slot-name: "staging"
 
-      - uses: azure/CLI@v1
-        with:
-          inlineScript: |
-            az webapp deployment slot swap  -g s165p01-getanid-pd-rg -n s165p01-getanid-production-auth-server-app --slot staging --target-slot production
+    - uses: azure/CLI@v1
+      with:
+        inlineScript: |
+          az webapp deployment slot swap  -g s165p01-getanid-pd-rg -n s165p01-getanid-production-auths-app --slot staging --target-slot production

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,9 @@ validate-keyvault-secret: read-keyvault-config install-fetch-config set-azure-ac
 		&& echo Data in ${KEY_VAULT_NAME}/${KEY_VAULT_SECRET_NAME} looks valid
 
 terraform-init:
-	$(if $(or $(DISABLE_PASSCODE),$(PASSCODE)), , $(error Missing environment variable "PASSCODE", retrieve from https://login.london.cloud.service.gov.uk/passcode))
+	$(if $(IMAGE_TAG), , $(eval export IMAGE_TAG=main))
+	$(eval export TF_VAR_authserver_tag=authserver-$(IMAGE_TAG))
+	$(eval export TF_VAR_testclient_tag=testclient-$(IMAGE_TAG))
 	[[ "${SP_AUTH}" != "true" ]] && az account show && az account set -s $(AZURE_SUBSCRIPTION) || true
 	terraform -chdir=terraform init -backend-config workspace_variables/${DEPLOY_ENV}.backend.tfvars $(backend_config) -upgrade -reconfigure
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,3 +1,6 @@
 output "auth_server_fqdn" {
   value = azurerm_linux_web_app.auth-server-app.default_hostname
 }
+output "postgres_server_name" {
+  value = azurerm_postgresql_flexible_server.postgres-server.name
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -119,8 +119,8 @@ variable "testclient_tag" {
 
 locals {
   hosting_environment          = var.environment_name
-  auth_server_app_name         = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-auths"
-  test_client_app_name         = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-testc"
+  auth_server_app_name         = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-auths-app"
+  test_client_app_name         = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-testc-app"
   postgres_server_name         = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-psql"
   postgres_database_name       = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-psql-db"
   redis_database_name          = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-redis"

--- a/terraform/workspace_variables/production.backend.tfvars
+++ b/terraform/workspace_variables/production.backend.tfvars
@@ -1,0 +1,3 @@
+storage_account_name = "s165p01getanidtfstatepd"
+key                  = "production.tfstate"
+resource_group_name  = "s165p01-getanid-pd-rg"

--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -1,0 +1,11 @@
+{
+    "environment_name": "production",
+    "key_vault_name": "s165p01-getanid-pd-kv",
+    "resource_group_name": "s165p01-getanid-pd-rg",
+    "data_protection_storage_account_name": "s165p01getaniddatapdst",
+    "deploy_test_client_app": true,
+    "keyvault_logging_enabled": true,
+    "storage_log_categories": [],
+    "resource_prefix": "s165p01-",
+    "app_service_plan_sku": "P3v3"
+  }


### PR DESCRIPTION
### Context

Get an Identity app deployments in preprod and production should use app service swap deployment capability. This ensures that apps are deployed and smoke tested before swapping to production slot. This PR adds Terraform configuration and deployment jobs to include blue/green deployment for preprod and production.

### Trello card

https://trello.com/c/aVpNrBsY