### PR TITLE
Add default values for monitor diagnostic

### DIFF
--- a/terraform/storage.tf
+++ b/terraform/storage.tf
@@ -60,7 +60,17 @@ resource "azurerm_monitor_diagnostic_setting" "data-protection-storage-diagnosti
     category = "Transaction"
     enabled  = true
     retention_policy {
+      days    = 0
       enabled = true
+    }
+  }
+
+  metric {
+    category = "Capacity"
+    enabled  = false
+    retention_policy {
+      days    = 0
+      enabled = false
     }
   }
 }


### PR DESCRIPTION
We're getting noise from false resource changes when running Terraform.
This adds the default values that so we get clean Terraform runs.