### PR TITLE
Use Container apps instead of App Service

### DIFF
--- a/.github/workflows/actions/deploy-environment/action.yml
+++ b/.github/workflows/actions/deploy-environment/action.yml
@@ -48,6 +48,12 @@ runs:
         TFVARS: ${{ inputs.terraform_vars }}
       working-directory: terraform
 
+    - name: Install extensions
+      run: |
+        az config set extension.use_dynamic_install=yes_without_prompt
+        pwsh -c "Install-Module powershell-yaml -Force"
+      shell: bash
+
     - uses: Azure/login@v1
       with:
         creds: ${{ inputs.azure_credentials }}
@@ -67,7 +73,7 @@ runs:
       id: terraform
       run: |
         make ci ${{ inputs.environment_name }} terraform-apply
-        cd terraform && echo ::set-output name=url::$(terraform output -raw get_an_identity_fqdn)/
+        cd terraform && echo ::set-output name=url::https://$(terraform output -raw auth_server_fqdn)/
       env:
         ARM_ACCESS_KEY: ${{ steps.get_secrets.outputs.TFSTATE-CONTAINER-ACCESS-KEY }}
         TF_VAR_azure_sp_credentials_json: ${{ inputs.azure_credentials }}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
@@ -352,8 +352,7 @@ public class Program
 
         var app = builder.Build();
 
-        if (builder.Environment.IsProduction() &&
-            Environment.GetEnvironmentVariable("WEBSITE_ROLE_INSTANCE_ID ") == "0")
+        if (builder.Environment.IsProduction())
         {
             await MigrateDatabase();
             await ConfigureClients();

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,11 +1,32 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/azure/azapi" {
+  version     = "0.5.0"
+  constraints = "0.5.0"
+  hashes = [
+    "h1:Yca1Jmc3+bBd+w7CuoBmgdpu58vMOz47gak5DLVvcDw=",
+    "zh:1bbd3e887b13085aa1d989f11e3fc7c8cf0d81cc8dcfeb58f7f752478f061001",
+    "zh:2c52b4f0bd0e96d8f60c878947a63ae8ea08a735968d8603769f0da4654954b3",
+    "zh:32837d15d002721c20f4561a1b2d44438b066f9812801295d864e0b4c93b6297",
+    "zh:3e9fbb1137a36d782df4935acbf89e88f14e6672934ac03fd0226e5ddd4430e4",
+    "zh:4ce3d703c596bc998f4392a9a177b75ee4d48181c09512fee67ef38aff7dd945",
+    "zh:53ec2fcdb866b763cc05f8dbd6caf9320d86381c6083d69b4d838dc9bc8128cf",
+    "zh:5aafa486486ec52d4ca621b490016fa7c022b3f5e3ac16b1dd3b01b98cd86a1c",
+    "zh:83817bb7dc503254e93972464c496d0f9f4fc7499d294b74c7df9105100c41e7",
+    "zh:9bce71b22b4700c625f8bd2dddd72e01470c410675fa5c2b014c71acfd7ecb3c",
+    "zh:d7fc35384b21c0209575c74ae057061048ab342d0bf8d923ed44d83bd6670e42",
+    "zh:df8e045e6fd72d94fa18c082989d69cd2c73d3b4ade008362ddb90dfcfa91ac7",
+    "zh:f245a74fc9eca9b63ff0d6856da9d71ccab951b299d45af54e3d3b47bc5ef85f",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/azurerm" {
   version     = "3.17.0"
   constraints = "~> 3.17.0"
   hashes = [
     "h1:F3JekbiJ1K4eZadbgZ4FzdWflo5/h9Jg+Y2DKdm933g=",
+    "h1:NpYFAK+qIR/nRQZxnxHmTZMFoxA3spIOUFE6HkmMYlQ=",
     "zh:03d2c6e49cd1392c583db88e2c9dcaef53d16d6bb0452a4c9a55baaca7fcd821",
     "zh:05e797f57b91284a2a3deb5c75134c330301635932a28d01b55135ae633ee387",
     "zh:092e8356721ff4c2965fc99359a8cba9430576ac5f03bbc4c3ffbcdfe89c6519",
@@ -18,5 +39,62 @@ provider "registry.terraform.io/hashicorp/azurerm" {
     "zh:e6b2b6ff4159a23027216d838703e9d8707d24ea58e10028be96788e1fde4b14",
     "zh:f2306d7870676f432e7f16d59f7ec0172a77928b943880b18e1cd39dd0f3346e",
     "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/external" {
+  version = "2.2.2"
+  hashes = [
+    "h1:5907Z/VOLV770KacxmmM1jG4H1l6ruXAvKPQAB0sMNc=",
+    "zh:0b84ab0af2e28606e9c0c1289343949339221c3ab126616b831ddb5aaef5f5ca",
+    "zh:10cf5c9b9524ca2e4302bf02368dc6aac29fb50aeaa6f7758cce9aa36ae87a28",
+    "zh:56a016ee871c8501acb3f2ee3b51592ad7c3871a1757b098838349b17762ba6b",
+    "zh:719d6ef39c50e4cffc67aa67d74d195adaf42afcf62beab132dafdb500347d39",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7fbfc4d37435ac2f717b0316f872f558f608596b389b895fcb549f118462d327",
+    "zh:8ac71408204db606ce63fe8f9aeaf1ddc7751d57d586ec421e62d440c402e955",
+    "zh:a4cacdb06f114454b6ed0033add28006afa3f65a0ea7a43befe45fc82e6809fb",
+    "zh:bb5ce3132b52ae32b6cc005bc9f7627b95259b9ffe556de4dad60d47d47f21f0",
+    "zh:bb60d2976f125ffd232a7ccb4b3f81e7109578b23c9c6179f13a11d125dca82a",
+    "zh:f9540ecd2e056d6e71b9ea5f5a5cf8f63dd5c25394b9db831083a9d4ea99b372",
+    "zh:ffd998b55b8a64d4335a090b6956b4bf8855b290f7554dd38db3302de9c41809",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.2.3"
+  hashes = [
+    "h1:3bH88Z7tlWvcoubm6hQUBk3s9bSIJC8bVHQz749B87E=",
+    "zh:04f0978bb3e052707b8e82e46780c371ac1c66b689b4a23bbc2f58865ab7d5c0",
+    "zh:6484f1b3e9e3771eb7cc8e8bab8b35f939a55d550b3f4fb2ab141a24269ee6aa",
+    "zh:78a56d59a013cb0f7eb1c92815d6eb5cf07f8b5f0ae20b96d049e73db915b238",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8aa9950f4c4db37239bcb62e19910c49e47043f6c8587e5b0396619923657797",
+    "zh:996beea85f9084a725ff0e6473a4594deb5266727c5f56e9c1c7c62ded6addbb",
+    "zh:9a7ef7a21f48fabfd145b2e2a4240ca57517ad155017e86a30860d7c0c109de3",
+    "zh:a63e70ac052aa25120113bcddd50c1f3cfe61f681a93a50cea5595a4b2cc3e1c",
+    "zh:a6e8d46f94108e049ad85dbed60354236dc0b9b5ec8eabe01c4580280a43d3b8",
+    "zh:bb112ce7efbfcfa0e65ed97fa245ef348e0fd5bfa5a7e4ab2091a9bd469f0a9e",
+    "zh:d7bec0da5c094c6955efed100f3fe22fca8866859f87c025be1760feb174d6d9",
+    "zh:fb9f271b72094d07cef8154cd3d50e9aa818a0ea39130bc193132ad7b23076fd",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.1.1"
+  hashes = [
+    "h1:1J3nqAREzuaLE7x98LEELCCaMV6BRiawHSg9MmFvfQo=",
+    "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
+    "zh:08c058e367de6debdad35fc24d97131c7cf75103baec8279aba3506a08b53faf",
+    "zh:73ce6dff935150d6ddc6ac4a10071e02647d10175c173cfe5dca81f3d13d8afe",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8fdd792a626413502e68c195f2097352bdc6a0df694f7df350ed784741eb587e",
+    "zh:976bbaf268cb497400fd5b3c774d218f3933271864345f18deebe4dcbfcd6afa",
+    "zh:b21b78ca581f98f4cdb7a366b03ae9db23a73dfa7df12c533d7c19b68e9e72e5",
+    "zh:b7fc0c1615dbdb1d6fd4abb9c7dc7da286631f7ca2299fb9cd4664258ccfbff4",
+    "zh:d1efc942b2c44345e0c29bc976594cb7278c38cfb8897b344669eafbc3cddf46",
+    "zh:e356c245b3cd9d4789bab010893566acace682d7db877e52d40fc4ca34a50924",
+    "zh:ea98802ba92fcfa8cf12cbce2e9e7ebe999afbf8ed47fa45fc847a098d89468b",
+    "zh:eff8872458806499889f6927b5d954560f3d74bf20b6043409edf94d26cd906f",
   ]
 }

--- a/terraform/modules/container-app/main.tf
+++ b/terraform/modules/container-app/main.tf
@@ -1,0 +1,29 @@
+locals {
+  generated_yaml_path = abspath("${path.module}/.terraform/temp/container-app-${sha1(var.app_definition_yaml)}.yml")
+
+  app_name = yamldecode(var.app_definition_yaml).name
+  resource_group = yamldecode(var.app_definition_yaml).resourcegroup
+}
+
+resource "null_resource" "deploy_container_app_revision" {
+  triggers = {
+    defition = var.app_definition_yaml
+  }
+
+  provisioner "local-exec" {
+    working_dir = "${path.module}/scripts"
+    command     = "(echo $env:YAML | Out-File (New-Item -Path ${local.generated_yaml_path} -Force)) -And (./Publish-ContainerAppRevision.ps1 -YamlFile ${local.generated_yaml_path} -TimeoutSeconds ${var.timeout})"
+    interpreter = ["pwsh", "-Command"]
+    environment = {
+      YAML = var.app_definition_yaml
+     }
+  }
+}
+
+data "external" "container_app" {
+  program = ["pwsh", "-Command", "az", "containerapp", "show", "--name", local.app_name, "-g", local.resource_group, "--query", "'{fqdn: properties.configuration.ingress.fqdn}'"]
+
+  depends_on = [
+    null_resource.deploy_container_app_revision
+  ]
+}

--- a/terraform/modules/container-app/outputs.tf
+++ b/terraform/modules/container-app/outputs.tf
@@ -1,0 +1,3 @@
+output "container_app_fqdn" {
+  value = data.external.container_app.result.fqdn
+}

--- a/terraform/modules/container-app/scripts/Publish-ContainerAppRevision.ps1
+++ b/terraform/modules/container-app/scripts/Publish-ContainerAppRevision.ps1
@@ -1,0 +1,117 @@
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $true, Position = 1)]
+    [String]$YamlFile,
+    [Parameter(Mandatory = $false)]
+    [Int]$TimeoutSeconds = 2 * 60
+)
+
+$ErrorActionPreference = "Stop"
+
+Import-Module powershell-yaml
+
+function Invoke-NativeCommand() {
+    $command = $args[0]
+    $commandArgs = @()
+    if ($args.Count -gt 1) {
+        $commandArgs = $args[1..($args.Count - 1)]
+    }
+
+    $output = (& $command $commandArgs) -join "`n"
+    $result = $LASTEXITCODE
+
+    if ($result -ne 0) {
+        throw "$command $commandArgs exited with code $result."
+    }
+
+    return $output
+}
+
+$definition = ConvertFrom-Yaml ((Get-Content $YamlFile) -join "`n")
+$appName = $definition.name
+$resourceGroup = $definition.resourcegroup
+$environment = $definition.properties.managedEnvironmentId
+
+
+# Does the app exist already?
+
+$appExists = (Invoke-NativeCommand az containerapp list --environment $environment -g $resourceGroup --query "[?name == '$appName']") -ne '[]'
+
+
+# If there's already an active revision ensure it continues to receive all the traffic until the new revision has successfully started
+
+$definition.properties.configuration.ingress.traffic = @()
+
+$haveExistingActiveRevisions = $false
+
+if ($appExists -eq $true) {
+    $existingRevisions = ConvertFrom-Json (Invoke-NativeCommand az containerapp revision list --name $appName -g $resourceGroup)
+
+    foreach ($r in $existingRevisions) {
+        $trafficWeight = $r.properties.trafficWeight
+        if ($trafficWeight -eq 0) {
+            continue
+        } else {
+            $haveExistingActiveRevisions = $true
+            $definition.properties.configuration.ingress.traffic += @{
+                revisionName = $r.name
+                weight = $r.properties.trafficWeight
+            }
+        }
+    }
+}
+
+$definition.properties.configuration.ingress.traffic += @{
+    latestRevision = $true
+    weight = $(if ($haveExistingActiveRevisions -eq $true) { 0 } else { 100 })
+}
+
+
+# Create the new revision
+
+$tempYamlPath = New-TemporaryFile
+(ConvertTo-Yaml $definition) | Out-File $tempYamlPath
+
+$action = if ($appExists -eq $true) { "update" } else { "create" }
+(Invoke-NativeCommand az containerapp $action -n $AppName -g $resourceGroup --yaml $tempYamlPath --only-show-errors) | Out-Null
+$revision = (Invoke-NativeCommand az containerapp show -n $AppName -g $resourceGroup --query "properties.latestRevisionName" -o tsv)
+
+
+# Wait for the new revision to spin up successfully
+
+$timer = [Diagnostics.Stopwatch]::StartNew()
+while ($true) {
+    $containerRevision = (ConvertFrom-Json (Invoke-NativeCommand az containerapp revision show --revision $revision --name $appName -g $resourceGroup))
+    $healthState = $containerRevision.properties.healthState
+    $provisioningState = $containerRevision.properties.provisioningState
+    $replicas = $containerRevision.properties.replicas
+
+    if ($provisioningState -eq "Failed" -or $healthState -eq "Unhealthy" -or ($replicas -eq 0 -and $provisioningState -eq "Provisioned")) {
+        Write-Error "Container provisioning failed for revision $revision; provisioning state: '$provisioningState', health state: '$healthState'."
+        exit 1
+    }
+
+    if ($provisioningState -eq "Provisioned") {
+        break
+    }
+
+    if ($timer.ElapsedMilliseconds -gt ($timeoutSeconds * 1000)) {
+        Write-Error "Timed out waiting for container to prevision successfully"
+        exit 1
+    }
+
+    Start-Sleep 5
+}
+
+
+# Swap 100% traffic to the new revision and deactivate older revisions
+
+if ($haveExistingActiveRevisions -eq $true) {
+    Invoke-NativeCommand az containerapp ingress traffic set --name $appName -g $resourceGroup --revision-weight latest=100 | Out-Null
+
+    foreach ($r in $existingRevisions) {
+        if ($r.name -ne $revision) {
+            Invoke-NativeCommand az containerapp revision deactivate --revision $r.name --name $appName -g $resourceGroup | Out-Null
+        }
+    }
+}

--- a/terraform/modules/container-app/variables.tf
+++ b/terraform/modules/container-app/variables.tf
@@ -1,0 +1,9 @@
+variable "app_definition_yaml" {
+  type = string
+}
+
+variable "timeout" {
+  description = "The timeout in seconds for provisioning the container app revision"
+  default     = 120
+  type        = string
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,3 +1,3 @@
-output "get_an_identity_fqdn" {
-  value = "https://${azurerm_linux_web_app.auth-server-app.default_hostname}"
+output "auth_server_fqdn" {
+  value = module.auth_server_container_app.container_app_fqdn
 }

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -12,3 +12,10 @@ provider "azurerm" {
 
   features {}
 }
+
+provider "azapi" {
+  subscription_id = try(local.azure_credentials.subscriptionId, null)
+  client_id       = try(local.azure_credentials.clientId, null)
+  client_secret   = try(local.azure_credentials.clientSecret, null)
+  tenant_id       = try(local.azure_credentials.tenantId, null)
+}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -10,5 +10,10 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 3.17.0"
     }
+
+    azapi = {
+      source  = "Azure/azapi"
+      version = "0.5.0"
+    }
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,22 +1,20 @@
 variable "environment_name" {
   type = string
 }
+
 variable "resource_prefix" {
   type    = string
   default = ""
 }
+
 variable "app_suffix" {
   type    = string
   default = ""
 }
+
 variable "azure_sp_credentials_json" {
   type    = string
   default = null
-}
-
-variable "app_service_plan_sku" {
-  type    = string
-  default = "B1"
 }
 
 variable "postgres_flexible_server_sku" {
@@ -46,7 +44,6 @@ variable "redis_service_version" {
   type    = number
   default = 6
 }
-
 
 variable "redis_service_family" {
   type    = string
@@ -116,15 +113,15 @@ variable "testclient_tag" {
 }
 
 locals {
-  hosting_environment              = var.environment_name
-  app_service_plan_name            = "${var.resource_prefix}getanid-${var.environment_name}-plan"
-  get_an_identity_app_name         = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-auth-server-app"
-  get_an_identity_test_client_name = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-test-client-app"
-  postgres_server_name             = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-psql"
-  postgres_database_name           = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-psql-db"
-  redis_database_name              = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-redis"
-  app_insights_name                = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-appi"
-  log_analytics_workspace_name     = "${var.resource_prefix}getanid-${var.environment_name}-log"
+  hosting_environment             = var.environment_name
+  auth_server_app_name            = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-authserver"
+  test_client_app_name            = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-testclient"
+  postgres_server_name            = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-psql"
+  postgres_database_name          = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-psql-db"
+  redis_database_name             = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-redis"
+  app_insights_name               = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-appi"
+  log_analytics_workspace_name    = "${var.resource_prefix}getanid-${var.environment_name}-log"
+  container_apps_environment_name = "${var.resource_prefix}getanid-${var.environment_name}-acaenv"
 
   keyvault_logging_enabled            = var.keyvault_logging_enabled
   storage_diagnostics_logging_enabled = length(var.storage_log_categories) > 0


### PR DESCRIPTION
We're having some problems with App Service around deployments; the deployment completes *before* the Docker container has spun up and there seems to be no simple way to query whether the container has started up successfully or not. We want to do this for two reasons: 1) we don't want the deployment step to complete until the app is actually up and running and 2) we want the deployment step to fail if the container cannot start. Implementing blue/green deployments without this would be tricky.

This PR moves to using Azure Container Apps. Container apps *do* have a simple way of querying whether they have started successfully so we can trivially script up a check to block until the app is running. The script used here for deployment also does a blue/green deployment.

It works like this:
A YAML definition of the container app is declared in the main terraform module. The format is as-per [the docs](https://docs.microsoft.com/en-gb/azure/container-apps/azure-resource-manager-api-spec?tabs=yaml#container-app-examples). A script is then invoked which ingests the YAML then checks whether the container app already exists or not. If it does, it modifies the ingress traffic rules so that the new revision doesn't get any traffic i.e. the traffic remains routed to the existing revision. The new revision is then deployed and the script waits for it to spin up successfully. If the new revision doesn't spin up successfully then the script fails. If the new revision did spin up successfully, the traffic rules are amended so the new revision gets 100% of the traffic then the old revision is deactivated.

There are a couple of nits with the process as implemented here:
- Container apps seem to need a GitHub PAT to pull images from GHCR. Perhaps moving to ACR would be better?
- ~~The temporary file creates a resource in Terraform's state file which is a little ugly. In future the process could be modified to avoid this.~~ This is now fixed