### PR TITLE
Fix Container apps deployment on pre-prod

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -61,25 +61,6 @@ provider "registry.terraform.io/hashicorp/external" {
   ]
 }
 
-provider "registry.terraform.io/hashicorp/local" {
-  version = "2.2.3"
-  hashes = [
-    "h1:3bH88Z7tlWvcoubm6hQUBk3s9bSIJC8bVHQz749B87E=",
-    "zh:04f0978bb3e052707b8e82e46780c371ac1c66b689b4a23bbc2f58865ab7d5c0",
-    "zh:6484f1b3e9e3771eb7cc8e8bab8b35f939a55d550b3f4fb2ab141a24269ee6aa",
-    "zh:78a56d59a013cb0f7eb1c92815d6eb5cf07f8b5f0ae20b96d049e73db915b238",
-    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
-    "zh:8aa9950f4c4db37239bcb62e19910c49e47043f6c8587e5b0396619923657797",
-    "zh:996beea85f9084a725ff0e6473a4594deb5266727c5f56e9c1c7c62ded6addbb",
-    "zh:9a7ef7a21f48fabfd145b2e2a4240ca57517ad155017e86a30860d7c0c109de3",
-    "zh:a63e70ac052aa25120113bcddd50c1f3cfe61f681a93a50cea5595a4b2cc3e1c",
-    "zh:a6e8d46f94108e049ad85dbed60354236dc0b9b5ec8eabe01c4580280a43d3b8",
-    "zh:bb112ce7efbfcfa0e65ed97fa245ef348e0fd5bfa5a7e4ab2091a9bd469f0a9e",
-    "zh:d7bec0da5c094c6955efed100f3fe22fca8866859f87c025be1760feb174d6d9",
-    "zh:fb9f271b72094d07cef8154cd3d50e9aa818a0ea39130bc193132ad7b23076fd",
-  ]
-}
-
 provider "registry.terraform.io/hashicorp/null" {
   version = "3.1.1"
   hashes = [

--- a/terraform/modules/container-app/main.tf
+++ b/terraform/modules/container-app/main.tf
@@ -7,16 +7,16 @@ locals {
 
 resource "null_resource" "deploy_container_app_revision" {
   triggers = {
-    defition = var.app_definition_yaml
+    definition = var.app_definition_yaml
   }
 
   provisioner "local-exec" {
     working_dir = "${path.module}/scripts"
-    command     = "(echo $env:YAML | Out-File (New-Item -Path ${local.generated_yaml_path} -Force)) -And (./Publish-ContainerAppRevision.ps1 -YamlFile ${local.generated_yaml_path} -TimeoutSeconds ${var.timeout})"
+    command     = "&{echo $env:YAML | Out-File (New-Item -Path ${local.generated_yaml_path} -Force); ./Publish-ContainerAppRevision.ps1 -YamlFile ${local.generated_yaml_path} -TimeoutSeconds ${var.timeout}}"
     interpreter = ["pwsh", "-Command"]
     environment = {
       YAML = var.app_definition_yaml
-     }
+    }
   }
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -114,8 +114,8 @@ variable "testclient_tag" {
 
 locals {
   hosting_environment             = var.environment_name
-  auth_server_app_name            = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-authserver"
-  test_client_app_name            = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-testclient"
+  auth_server_app_name            = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-auths"
+  test_client_app_name            = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-testc"
   postgres_server_name            = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-psql"
   postgres_database_name          = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-psql-db"
   redis_database_name             = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-redis"

--- a/terraform/workspace_variables/preprod.tfvars.json
+++ b/terraform/workspace_variables/preprod.tfvars.json
@@ -6,6 +6,5 @@
     "deploy_test_client_app": true,
     "keyvault_logging_enabled": true,
     "storage_log_categories": [],
-    "resource_prefix": "s165t01-",
-    "app_service_plan_sku": "S1"
+    "resource_prefix": "s165t01-"
   }


### PR DESCRIPTION
- Shorten app names so they're within 32 character limit.
- Remove redundant variable from `preprod.tfvars.json`
- Ensure provisioning fails if the publish script fails