### PR TITLE
Prevent going 'back' once authorization is completed

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -78,11 +78,15 @@ public class AuthenticationState
         }
 
         // We should have a known user at this point
-        Debug.Assert(UserId.HasValue);
+        Debug.Assert(IsComplete());
 
         // We're done - complete authorization
         return AuthorizationUrl;
     }
+
+    public bool IsComplete() => EmailAddressVerified &&
+        (Trn is not null || HaveCompletedFindALostTrnJourney || !GetAuthorizationRequest().HasScope(CustomScopes.Trn)) &&
+        UserId.HasValue;
 
     public void Populate(User user, bool firstTimeUser, string? trn)
     {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/HttpContextExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/HttpContextExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
@@ -29,6 +30,7 @@ public static class HttpContextExtensions
     {
         var authenticationState = httpContext.GetAuthenticationState();
         authenticationState.Populate(user, firstTimeUser, trn);
+        Debug.Assert(authenticationState.IsComplete());
 
         var authorizationRequest = authenticationState.GetAuthorizationRequest();
 
@@ -47,6 +49,9 @@ public static class HttpContextExtensions
         {
             claims.Add(new Claim(CustomClaims.Trn, trn));
         }
+
+        // TODO In future the user might already been signed in with a different set of claims (e.g. for different scopes)
+        // We should copy over any existing claims in such a case.
 
         var identity = new ClaimsIdentity(claims, authenticationType: "email", nameType: Claims.Name, roleType: null);
         var principal = new ClaimsPrincipal(identity);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
@@ -181,10 +181,12 @@ public class Program
                 options.JsonSerializerOptions.Converters.Add(new DateOnlyConverter());
             });
 
+        builder.Services.AddSingleton<RequireAuthenticationStateFilter>();
+
         builder.Services.AddRazorPages(options =>
         {
             // Every page within the SignIn folder must have AuthenticationState passed to it
-            options.Conventions.AddFolderApplicationModelConvention("/SignIn", model => model.Filters.Add(new RequireAuthenticationStateFilter()));
+            options.Conventions.AddFolderApplicationModelConvention("/SignIn", model => model.Filters.Add(new RequireAuthenticationStateFilterFactory()));
         });
 
         builder.Services.AddSession(options =>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/State/IAuthenticationStateProvider.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/State/IAuthenticationStateProvider.cs
@@ -2,6 +2,7 @@ namespace TeacherIdentity.AuthServer.State;
 
 public interface IAuthenticationStateProvider
 {
+    void ClearAuthenticationState(HttpContext httpContext);
     AuthenticationState? GetAuthenticationState(HttpContext httpContext);
     void SetAuthenticationState(HttpContext httpContext, AuthenticationState authenticationState);
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/State/RequireAuthenticationStateFilter.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/State/RequireAuthenticationStateFilter.cs
@@ -1,14 +1,45 @@
+using Microsoft.AspNetCore.Http.Extensions;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace TeacherIdentity.AuthServer.State;
 
+public class RequireAuthenticationStateFilterFactory : IFilterFactory
+{
+    public bool IsReusable => true;
+
+    public IFilterMetadata CreateInstance(IServiceProvider serviceProvider)
+    {
+        var filter = serviceProvider.GetRequiredService<RequireAuthenticationStateFilter>();
+        return filter;
+    }
+}
+
 public class RequireAuthenticationStateFilter : IAuthorizationFilter
 {
+    private readonly ILogger<RequireAuthenticationStateFilter> _logger;
+
+    public RequireAuthenticationStateFilter(ILogger<RequireAuthenticationStateFilter> logger)
+    {
+        _logger = logger;
+    }
+
     public void OnAuthorization(AuthorizationFilterContext context)
     {
-        if (context.HttpContext.Features.Get<AuthenticationStateFeature>() is null)
+        var authenticationStateFeature = context.HttpContext.Features.Get<AuthenticationStateFeature>();
+
+        if (authenticationStateFeature is null)
         {
+            _logger.LogDebug("Request to {RequestUrl} is missing authentication state.", context.HttpContext.Request.GetEncodedUrl());
+            context.Result = new BadRequestResult();
+            return;
+        }
+
+        // If this request has already been completed then return an error
+        // (this will typically happen when the user hits the back button)
+        if (authenticationStateFeature.AuthenticationState.IsComplete())
+        {
+            _logger.LogDebug("Authorization journey has already been completed.");
             context.Result = new BadRequestResult();
         }
     }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/State/SessionAuthenticationStateProvider.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/State/SessionAuthenticationStateProvider.cs
@@ -9,6 +9,16 @@ public class SessionAuthenticationStateProvider : IAuthenticationStateProvider
         _logger = logger;
     }
 
+    public void ClearAuthenticationState(HttpContext httpContext)
+    {
+        if (httpContext.Request.Query.TryGetValue(AuthenticationStateMiddleware.IdQueryParameterName, out var asidStr) &&
+            Guid.TryParse(asidStr, out var asid))
+        {
+            var sessionKey = GetSessionKey(asid);
+            httpContext.Session.Remove(sessionKey);
+        }
+    }
+
     public AuthenticationState? GetAuthenticationState(HttpContext httpContext)
     {
         if (httpContext.Request.Query.TryGetValue(AuthenticationStateMiddleware.IdQueryParameterName, out var asidStr) &&

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/Infrastructure/TestAuthenticationStateProvider.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/Infrastructure/TestAuthenticationStateProvider.cs
@@ -7,6 +7,14 @@ public class TestAuthenticationStateProvider : IAuthenticationStateProvider
 {
     private readonly ConcurrentDictionary<string, AuthenticationState> _state = new();
 
+    public void ClearAuthenticationState(HttpContext httpContext)
+    {
+        if (httpContext.Request.Query.TryGetValue(AuthenticationStateMiddleware.IdQueryParameterName, out var asid))
+        {
+            _state.Remove(asid, out _);
+        }
+    }
+
     public AuthenticationState? GetAuthenticationState(HttpContext httpContext) =>
         httpContext.Request.Query.TryGetValue(AuthenticationStateMiddleware.IdQueryParameterName, out var asid) &&
             _state.TryGetValue(asid, out var authenticationState) ?


### PR DESCRIPTION
Once a user has signed in and the authorization flow has been completed, we don't want to allow a user to go 'back'. There are a few reasons for this:
- Many OIDC libraries won't allow you to complete the callback multiple times so a user would see an error once they go back to the `redirect_uri`.
- If the user registered we want to ensure they can't register again by going back to before their account was created.

This change simply renders a generic `bad request`-type of error if a user goes back after authorization has completed. In future we could produce a more user-friendly error.