### PR TITLE
Harden the TRN callback endpoint

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20220831141657_JourneyTrnLookupStateUser.Designer.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20220831141657_JourneyTrnLookupStateUser.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeacherIdentity.AuthServer.Models;
@@ -11,9 +12,10 @@ using TeacherIdentity.AuthServer.Models;
 namespace TeacherIdentity.AuthServer.Migrations
 {
     [DbContext(typeof(TeacherIdentityServerDbContext))]
-    partial class TeacherIdentityServerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220831141657_JourneyTrnLookupStateUser")]
+    partial class JourneyTrnLookupStateUser
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20220831141657_JourneyTrnLookupStateUser.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20220831141657_JourneyTrnLookupStateUser.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeacherIdentity.AuthServer.Migrations
+{
+    public partial class JourneyTrnLookupStateUser : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "user_id",
+                table: "journey_trn_lookup_states",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "ix_journey_trn_lookup_states_user_id",
+                table: "journey_trn_lookup_states",
+                column: "user_id");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_journey_trn_lookup_states_users_user_id",
+                table: "journey_trn_lookup_states",
+                column: "user_id",
+                principalTable: "users",
+                principalColumn: "user_id");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_journey_trn_lookup_states_users_user_id",
+                table: "journey_trn_lookup_states");
+
+            migrationBuilder.DropIndex(
+                name: "ix_journey_trn_lookup_states_user_id",
+                table: "journey_trn_lookup_states");
+
+            migrationBuilder.DropColumn(
+                name: "user_id",
+                table: "journey_trn_lookup_states");
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/JourneyTrnLookupState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/JourneyTrnLookupState.cs
@@ -9,4 +9,6 @@ public class JourneyTrnLookupState
     public string LastName { get; set; } = null!;
     public DateOnly DateOfBirth { get; set; }
     public string? Trn { get; set; }
+    public User? User { get; set; }
+    public Guid? UserId { get; set; }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/Mappings/JourneyTrnLookupStateMapping.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/Mappings/JourneyTrnLookupStateMapping.cs
@@ -13,5 +13,6 @@ public class JourneyTrnLookupStateMapping : IEntityTypeConfiguration<JourneyTrnL
         builder.Property(s => s.LastName).IsRequired();
         builder.Property(s => s.DateOfBirth).IsRequired();
         builder.Property(s => s.Trn).HasMaxLength(7).IsFixedLength();
+        builder.HasOne(s => s.User).WithMany().HasForeignKey(s => s.UserId);
     }
 }


### PR DESCRIPTION
The TRN callback was previously a page you could only hit successfully
once for a given authorization journey, since it's the endpoint that
actually creates the user. That's not ideal for a few reasons; it breaks
the back button and should the call to the DQT API fail (and we show an
error) refreshing the page will never work, since we've already
registered the account.

This changes the endpoint so it can be hit successfully multiple times.
We now stash the created user against the journey ID so we know if we've
already created the user or not. Now should the DQT API call fail then
refreshing the page might actually work.