### PR TITLE
Make the PUT TRN lookup state endpoint retry-able

### DIFF
--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/TestData.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/TestData.cs
@@ -32,8 +32,7 @@ public partial class TestData
 
     public async Task<T> WithDbContext<T>(Func<TeacherIdentityServerDbContext, Task<T>> action)
     {
-        var serviceScopeFactory = _serviceProvider.GetRequiredService<IServiceScopeFactory>();
-        using var scope = serviceScopeFactory.CreateScope();
+        await using var scope = _serviceProvider.CreateAsyncScope();
         var dbContext = scope.ServiceProvider.GetRequiredService<TeacherIdentityServerDbContext>();
         return await action(dbContext);
     }


### PR DESCRIPTION
This change allows the TRN lookup state to be set multiple times for a given `journeyId`, until that `journey` is locked (which happens once the user is created).

This is important for reliability and also to make the 'back' button work as expected.