### PR TITLE
Persist when we completed the TRN lookup for a User

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -37,7 +37,7 @@ public class AuthenticationState
     public string? LastName { get; set; }
     public DateOnly? DateOfBirth { get; set; }
     public string? Trn { get; set; }
-    public bool HaveCompletedFindALostTrnJourney { get; set; }
+    public bool HaveCompletedTrnLookup { get; set; }
 
     public static AuthenticationState Deserialize(string serialized) =>
         JsonSerializer.Deserialize<AuthenticationState>(serialized, _jsonSerializerOptions) ??
@@ -72,7 +72,7 @@ public class AuthenticationState
         }
 
         // trn scope is specified; launch the journey to collect TRN
-        if (request.HasScope(CustomScopes.Trn) && Trn is null && !HaveCompletedFindALostTrnJourney)
+        if (request.HasScope(CustomScopes.Trn) && Trn is null && !HaveCompletedTrnLookup)
         {
             return urlHelper.Trn();
         }
@@ -85,7 +85,7 @@ public class AuthenticationState
     }
 
     public bool IsComplete() => EmailAddressVerified &&
-        (Trn is not null || HaveCompletedFindALostTrnJourney || !GetAuthorizationRequest().HasScope(CustomScopes.Trn)) &&
+        (Trn is not null || HaveCompletedTrnLookup || !GetAuthorizationRequest().HasScope(CustomScopes.Trn)) &&
         UserId.HasValue;
 
     public void Populate(User user, bool firstTimeUser, string? trn)
@@ -96,7 +96,7 @@ public class AuthenticationState
         FirstName = user.FirstName;
         LastName = user.LastName;
         DateOfBirth = user.DateOfBirth;
-        HaveCompletedFindALostTrnJourney = true;
+        HaveCompletedTrnLookup = user.CompletedTrnLookup is not null;
         FirstTimeUser = firstTimeUser;
         Trn = trn;
     }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20220901153949_UserCompletedTrnLookup.Designer.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20220901153949_UserCompletedTrnLookup.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeacherIdentity.AuthServer.Models;
@@ -11,9 +12,10 @@ using TeacherIdentity.AuthServer.Models;
 namespace TeacherIdentity.AuthServer.Migrations
 {
     [DbContext(typeof(TeacherIdentityServerDbContext))]
-    partial class TeacherIdentityServerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220901153949_UserCompletedTrnLookup")]
+    partial class UserCompletedTrnLookup
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20220901153949_UserCompletedTrnLookup.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20220901153949_UserCompletedTrnLookup.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeacherIdentity.AuthServer.Migrations
+{
+    public partial class UserCompletedTrnLookup : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "completed_trn_lookup",
+                table: "users",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "created",
+                table: "users",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "completed_trn_lookup",
+                table: "users");
+
+            migrationBuilder.DropColumn(
+                name: "created",
+                table: "users");
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/Mappings/UserMapping.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/Mappings/UserMapping.cs
@@ -13,6 +13,8 @@ public class UserMapping : IEntityTypeConfiguration<User>
         builder.HasIndex(u => u.EmailAddress).IsUnique().HasFilter("is_deleted = true");
         builder.Property(u => u.FirstName).HasMaxLength(200).IsRequired();
         builder.Property(u => u.LastName).HasMaxLength(200).IsRequired();
+        builder.Property(u => u.Created).IsRequired();
+        builder.Property(u => u.CompletedTrnLookup);
         builder.Property<bool>("is_deleted").IsRequired().HasDefaultValue(false);
         builder.HasQueryFilter(u => EF.Property<bool>(u, "is_deleted") == false);
     }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/User.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/User.cs
@@ -7,4 +7,6 @@ public class User
     public string FirstName { get; set; } = null!;
     public string LastName { get; set; } = null!;
     public DateOnly DateOfBirth { get; set; }
+    public DateTime Created { get; set; }
+    public DateTime? CompletedTrnLookup { get; set; }
 }

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/DbFixture.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/DbFixture.cs
@@ -48,6 +48,7 @@ public class DbFixture : IAsyncLifetime
             contextLifetime: ServiceLifetime.Transient);
 
         services.AddSingleton<TestData>();
+        services.AddSingleton<IClock, TestClock>();
 
         return services.BuildServiceProvider();
     }

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/Authorization/AuthorizeTests.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/Authorization/AuthorizeTests.cs
@@ -84,7 +84,7 @@ public class AuthorizeTests : TestBase
                 authState.FirstName = user.FirstName;
                 authState.LastName = user.LastName;
                 authState.FirstTimeUser = firstTimeUser;
-                authState.HaveCompletedFindALostTrnJourney = !userKnown && !firstTimeUser;
+                authState.HaveCompletedTrnLookup = !userKnown && !firstTimeUser;
                 authState.UserId = user.UserId;
 
                 if (hasTrn)

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnCallbackTests.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnCallbackTests.cs
@@ -71,6 +71,8 @@ public class TrnCallbackTests : TestBase
             Assert.Equal(firstName, user!.FirstName);
             Assert.Equal(lastName, user!.LastName);
             Assert.Equal(dateOfBirth, user!.DateOfBirth);
+            Assert.Equal(Clock.UtcNow, user.Created);
+            Assert.Equal(Clock.UtcNow, user.CompletedTrnLookup);
 
             if (hasTrn)
             {

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/State/AuthenticationStateTests.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/State/AuthenticationStateTests.cs
@@ -49,13 +49,16 @@ public class AuthenticationStateTests
     public void Populate()
     {
         // Arrange
+        var created = DateTime.UtcNow;
         var user = new User()
         {
             DateOfBirth = new DateOnly(2001, 4, 1),
             EmailAddress = Faker.Internet.Email(),
             FirstName = Faker.Name.First(),
             LastName = Faker.Name.Last(),
-            UserId = Guid.NewGuid()
+            UserId = Guid.NewGuid(),
+            Created = created,
+            CompletedTrnLookup = created
         };
         var trn = "1234567";
         var firstTimeUser = true;
@@ -73,7 +76,7 @@ public class AuthenticationStateTests
         Assert.Equal(user.UserId, authenticationState.UserId);
         Assert.True(authenticationState.EmailAddressVerified);
         Assert.Equal(firstTimeUser, authenticationState.FirstTimeUser);
-        Assert.True(authenticationState.HaveCompletedFindALostTrnJourney);
+        Assert.True(authenticationState.HaveCompletedTrnLookup);
         Assert.Equal(trn, authenticationState.Trn);
     }
 
@@ -111,7 +114,7 @@ public class AuthenticationStateTests
                         EmailAddress = "john.doe@example.com",
                         EmailAddressVerified = true,
                         FirstTimeUser = true,
-                        HaveCompletedFindALostTrnJourney = false
+                        HaveCompletedTrnLookup = false
                     },
                     $"/sign-in/trn?asid={journeyId}"
                 },
@@ -123,7 +126,7 @@ public class AuthenticationStateTests
                         EmailAddress = "john.doe@example.com",
                         EmailAddressVerified = true,
                         FirstTimeUser = true,
-                        HaveCompletedFindALostTrnJourney = true,
+                        HaveCompletedTrnLookup = true,
                         UserId = Guid.NewGuid()
                     },
                     authorizationUrl

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/TestData.CreateUser.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/TestData.CreateUser.cs
@@ -4,7 +4,7 @@ namespace TeacherIdentity.AuthServer.Tests;
 
 public partial class TestData
 {
-    public Task<User> CreateUser(string? email = null) => WithDbContext(async dbContext =>
+    public Task<User> CreateUser(string? email = null, bool haveCompletedTrnLookup = true) => WithDbContext(async dbContext =>
     {
         var user = new User()
         {
@@ -12,6 +12,8 @@ public partial class TestData
             EmailAddress = email ?? Faker.Internet.Email(),
             FirstName = Faker.Name.First(),
             LastName = Faker.Name.Last(),
+            Created = _clock.UtcNow,
+            CompletedTrnLookup = haveCompletedTrnLookup ? _clock.UtcNow : null
         };
 
         dbContext.Users.Add(user);

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/TestData.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/TestData.cs
@@ -6,12 +6,14 @@ namespace TeacherIdentity.AuthServer.Tests;
 public partial class TestData
 {
     private readonly IServiceProvider _serviceProvider;
+    private readonly TestClock _clock;
     private readonly Random _random = new();
     private readonly ConcurrentBag<string> _trns = new();
 
     public TestData(IServiceProvider serviceProvider)
     {
         _serviceProvider = serviceProvider;
+        _clock = (TestClock)serviceProvider.GetRequiredService<IClock>();
     }
 
     public string GenerateTrn()


### PR DESCRIPTION
Adds a `CompletedTrnLookup` timestamp column to the `users` table. We set this *after* the API call to DQT to persist the user ID/TRN association has successfully completed. Should that call fail, a subsequent sign in will force the user to go through Find again rather than us simply returning a `null` `trn` claim.

Also adds a `created` column to `users`.