### PR TITLE
Add tests for subsequent sign ins in the same session

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/HttpContextExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/HttpContextExtensions.cs
@@ -56,8 +56,6 @@ public static class HttpContextExtensions
         var identity = new ClaimsIdentity(claims, authenticationType: "email", nameType: Claims.Name, roleType: null);
         var principal = new ClaimsPrincipal(identity);
 
-        httpContext.Session.SetString(SessionKeys.FirstTimeSignIn, firstTimeUser.ToString());
-
         await httpContext.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, principal);
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Authorization/Authorize.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Authorization/Authorize.cshtml.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeacherIdentity.AuthServer.Oidc;
 using static OpenIddict.Abstractions.OpenIddictConstants;
@@ -15,6 +16,7 @@ public class AuthorizeModel : PageModel
 
     public bool GotTrn { get; set; }
 
+    [FromQuery(Name = "ftu")]
     public bool FirstTimeUser { get; set; }
 
     public string? Name { get; set; }
@@ -42,7 +44,6 @@ public class AuthorizeModel : PageModel
         Email = user.FindFirst(Claims.Email)!.Value;
         Trn = user.FindFirst(CustomClaims.Trn)?.Value;
         GotTrn = Trn is not null;
-        FirstTimeUser = HttpContext.Session.GetString(SessionKeys.FirstTimeSignIn) == bool.TrueString;
         Name = $"{user.FindFirst(Claims.GivenName)!.Value} {user.FindFirst(Claims.FamilyName)!.Value}";
         DateOfBirth = DateOnly.ParseExact(user.FindFirst(Claims.Birthdate)!.Value, "yyyy-MM-dd");
     }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
@@ -111,9 +111,6 @@ public class Program
                     var authState = new AuthenticationState(authStateId, ctx.Properties.RedirectUri!);
                     ctx.HttpContext.Features.Set(new AuthenticationStateFeature(authState));
 
-                    // Ensure state from any previous journey in this session doesn't bleed through here
-                    ctx.HttpContext.Session.Remove(SessionKeys.FirstTimeSignIn);
-
                     var urlHelperFactory = ctx.HttpContext.RequestServices.GetRequiredService<Microsoft.AspNetCore.Mvc.Routing.IUrlHelperFactory>();
                     var actionContext = ctx.HttpContext.RequestServices.GetRequiredService<IActionContextAccessor>().ActionContext!;
                     var urlHelper = urlHelperFactory.GetUrlHelper(actionContext);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/SessionKeys.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/SessionKeys.cs
@@ -1,6 +1,0 @@
-namespace TeacherIdentity.AuthServer;
-
-public static class SessionKeys
-{
-    public const string FirstTimeSignIn = nameof(FirstTimeSignIn);
-}

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/Authorization/AuthorizeTests.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/Authorization/AuthorizeTests.cs
@@ -14,7 +14,7 @@ public class AuthorizeTests : TestBase
     {
         // Arrange
         var authStateHelper = await CreateAuthenticationStateHelper(HttpClient, userKnown: true, firstTimeUser: true, hasTrn: true);
-        var request = new HttpRequestMessage(HttpMethod.Get, authStateHelper.AuthenticationState.AuthorizationUrl);
+        var request = new HttpRequestMessage(HttpMethod.Get, authStateHelper.AuthenticationState.GetFinalAuthorizationUrl());
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -33,7 +33,7 @@ public class AuthorizeTests : TestBase
     {
         // Arrange
         var authStateHelper = await CreateAuthenticationStateHelper(HttpClient, userKnown: true, firstTimeUser: true, hasTrn: false);
-        var request = new HttpRequestMessage(HttpMethod.Get, authStateHelper.AuthenticationState.AuthorizationUrl);
+        var request = new HttpRequestMessage(HttpMethod.Get, authStateHelper.AuthenticationState.GetFinalAuthorizationUrl());
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -52,7 +52,7 @@ public class AuthorizeTests : TestBase
     {
         // Arrange
         var authStateHelper = await CreateAuthenticationStateHelper(HttpClient, userKnown: true);
-        var request = new HttpRequestMessage(HttpMethod.Get, authStateHelper.AuthenticationState.AuthorizationUrl);
+        var request = new HttpRequestMessage(HttpMethod.Get, authStateHelper.AuthenticationState.GetFinalAuthorizationUrl());
 
         // Act
         var response = await HttpClient.SendAsync(request);

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/State/AuthenticationStateTests.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/State/AuthenticationStateTests.cs
@@ -1,3 +1,4 @@
+using Flurl;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Routing;
@@ -129,7 +130,7 @@ public class AuthenticationStateTests
                         HaveCompletedTrnLookup = true,
                         UserId = Guid.NewGuid()
                     },
-                    authorizationUrl
+                    authorizationUrl.SetQueryParam("ftu", bool.TrueString)
                 },
 
                 // Known user, confirmed


### PR DESCRIPTION
Also remove the (broken) session clearing approach and use a query
parameter to indicate 'first time users' instead.