### PR TITLE
Add HA app service plan

### DIFF
--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -134,12 +134,13 @@ resource "azurerm_application_insights" "insights" {
   }
 }
 resource "azurerm_service_plan" "service-plan" {
-  name                = local.app_service_plan_name
-  location            = data.azurerm_resource_group.group.location
-  resource_group_name = data.azurerm_resource_group.group.name
-  os_type             = "Linux"
-  sku_name            = var.app_service_plan_sku
-
+  name                   = local.app_service_plan_name
+  location               = data.azurerm_resource_group.group.location
+  resource_group_name    = data.azurerm_resource_group.group.name
+  os_type                = "Linux"
+  sku_name               = var.app_service_plan_sku
+  zone_balancing_enabled = var.worker_count != null ? true : false
+  worker_count           = var.worker_count
   lifecycle {
     ignore_changes = [
       tags

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -121,6 +121,11 @@ variable "enable_blue_green" {
   default = false
 }
 
+variable "worker_count" {
+  description = "It should be set to a multiple of the number of availability zones in the region"
+  type        = number
+  default     = null
+}
 
 locals {
   hosting_environment          = var.environment_name

--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -7,5 +7,6 @@
     "keyvault_logging_enabled": true,
     "storage_log_categories": [],
     "resource_prefix": "s165p01-",
-    "app_service_plan_sku": "P3v3"
+    "app_service_plan_sku": "P1v2",
+    "worker_count": 3
   }


### PR DESCRIPTION
### Context

Production deployment of apps needs high availability app service plan deployment. This enables more resilient service in the event of outage to Azure Zones.

### Trello card
https://trello.com/c/3lE4Frte/701-implement-ha-in-production-and-update-app-service-plan