### PR TITLE
Add alternative UI when the back button is used

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -48,6 +48,11 @@ public class AuthenticationState
     public string? Trn { get; set; }
     public bool HaveCompletedTrnLookup { get; set; }
 
+    /// <summary>
+    /// Whether the user has gone back to an earlier page after this journey has been completed.
+    /// </summary>
+    public bool HaveResumedCompletedJourney { get; set; }
+
     public static AuthenticationState Deserialize(string serialized) =>
         JsonSerializer.Deserialize<AuthenticationState>(serialized, _jsonSerializerOptions) ??
             throw new ArgumentException($"Serialized {nameof(AuthenticationState)} is not valid.", nameof(serialized));

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/Filters/NoCachePageFilter.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/Filters/NoCachePageFilter.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Net.Http.Headers;
+
+namespace TeacherIdentity.AuthServer.Infrastructure.Filters;
+
+public class NoCachePageFilter : IPageFilter
+{
+    public void OnPageHandlerExecuted(PageHandlerExecutedContext context)
+    {
+    }
+
+    public void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var headers = context.HttpContext.Response.Headers;
+
+        headers[HeaderNames.CacheControl] = "no-store";
+        headers.AppendCommaSeparatedValues(HeaderNames.CacheControl, "no-cache");
+        headers[HeaderNames.Pragma] = "no-cache";
+    }
+
+    public void OnPageHandlerSelected(PageHandlerSelectedContext context)
+    {
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/Filters/RedirectToCompletePageFilter.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/Filters/RedirectToCompletePageFilter.cs
@@ -1,0 +1,34 @@
+using Microsoft.AspNetCore.Http.Extensions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.Routing;
+
+namespace TeacherIdentity.AuthServer.Infrastructure.Filters;
+
+public class RedirectToCompletePageFilter : IPageFilter
+{
+    public void OnPageHandlerExecuted(PageHandlerExecutedContext context)
+    {
+    }
+
+    public void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        if (context.HttpContext.TryGetAuthenticationState(out var authenticationState) && authenticationState.IsComplete())
+        {
+            var urlHelperFactory = context.HttpContext.RequestServices.GetRequiredService<IUrlHelperFactory>();
+            var urlHelper = urlHelperFactory.GetUrlHelper(context);
+
+            var completeUrl = urlHelper.CompleteAuthorization();
+
+            if (completeUrl != context.HttpContext.Request.GetEncodedPathAndQuery())
+            {
+                authenticationState.HaveResumedCompletedJourney = true;
+                context.Result = new RedirectResult(completeUrl);
+            }
+        }
+    }
+
+    public void OnPageHandlerSelected(PageHandlerSelectedContext context)
+    {
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Complete.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Complete.cshtml
@@ -2,7 +2,9 @@
 @using static OpenIddict.Abstractions.OpenIddictConstants
 @model TeacherIdentity.AuthServer.Pages.SignIn.CompleteModel
 @{
-    ViewBag.Title = Model.FirstTimeUser ? "Continue with your NPQ registration" : "You’re signed in";
+    ViewBag.Title = Model.FirstTimeUser ? "Continue with your NPQ registration" :
+        Model.AlreadyCompleted ? "We’ve finished checking our records" :
+        "You’re signed in";
 
     async Task RenderForm(string? buttonClasses = null)
     {
@@ -34,7 +36,21 @@
     }
 }
 
-@if (Model.FirstTimeUser)
+@if (Model.AlreadyCompleted)
+{
+    <div class="govuk-grid-row" data-testid="already-completed-content">
+      <div class="govuk-grid-column-two-thirds-from-desktop">
+        <h1 class="govuk-heading-xl">We’ve finished checking our records</h1>
+
+        <p>You can continue with your NPQ registration.</p>
+
+        @{
+          await RenderForm();
+        }
+        </div>
+    </div>
+}
+else if (Model.FirstTimeUser)
 {
     <govuk-panel class="app-panel--interruption" data-testid="first-time-user-content">
       <govuk-panel-title>Continue with your NPQ registration</govuk-panel-title>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Complete.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Complete.cshtml.cs
@@ -22,6 +22,8 @@ public class CompleteModel : PageModel
 
     public IEnumerable<KeyValuePair<string, string>>? ResponseParameters { get; set; }
 
+    public bool AlreadyCompleted { get; set; }
+
     public void OnGet()
     {
         var authenticationState = HttpContext.GetAuthenticationState();
@@ -35,5 +37,6 @@ public class CompleteModel : PageModel
         Name = $"{authenticationState.FirstName} {authenticationState.LastName}";
         Trn = authenticationState.Trn;
         DateOfBirth = authenticationState.DateOfBirth!.Value;
+        AlreadyCompleted = authenticationState.HaveResumedCompletedJourney;
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
@@ -20,6 +20,7 @@ using Serilog;
 using TeacherIdentity.AuthServer.Configuration;
 using TeacherIdentity.AuthServer.Infrastructure;
 using TeacherIdentity.AuthServer.Infrastructure.ApplicationModel;
+using TeacherIdentity.AuthServer.Infrastructure.Filters;
 using TeacherIdentity.AuthServer.Infrastructure.Json;
 using TeacherIdentity.AuthServer.Infrastructure.Middleware;
 using TeacherIdentity.AuthServer.Infrastructure.Security;
@@ -169,8 +170,14 @@ public class Program
 
         builder.Services.AddRazorPages(options =>
         {
-            // Every page within the SignIn folder must have AuthenticationState passed to it
-            options.Conventions.AddFolderApplicationModelConvention("/SignIn", model => model.Filters.Add(new RequireAuthenticationStateFilterFactory()));
+            // Every page within the SignIn folder must have AuthenticationState passed to it.
+            options.Conventions.AddFolderApplicationModelConvention(
+                "/SignIn",
+                model =>
+                {
+                    model.Filters.Add(new RequireAuthenticationStateFilterFactory());
+                    model.Filters.Add(new NoCachePageFilter());
+                });
         });
 
         builder.Services.AddSession(options =>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
@@ -177,6 +177,7 @@ public class Program
                 {
                     model.Filters.Add(new RequireAuthenticationStateFilterFactory());
                     model.Filters.Add(new NoCachePageFilter());
+                    model.Filters.Add(new RedirectToCompletePageFilter());
                 });
         });
 

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/CompleteTests.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/CompleteTests.cs
@@ -64,10 +64,28 @@ public class CompleteTests : TestBase
         Assert.NotNull(doc.GetElementByTestId("known-user-content"));
     }
 
+    [Fact]
+    public async Task Get_AuthorizationIsCompleted_RendersExpectedContent()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(HttpClient, haveResumedCompletedJourney: true);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/complete?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Act
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+        Assert.NotNull(doc.GetElementByTestId("already-completed-content"));
+    }
+
     private async Task<AuthenticationStateHelper> CreateAuthenticationStateHelper(
         HttpClient httpClient,
         bool hasTrn = true,
-        bool firstTimeUser = false)
+        bool firstTimeUser = false,
+        bool haveResumedCompletedJourney = false)
     {
         var user = await TestData.CreateUser();
         var trn = hasTrn ? TestData.GenerateTrn() : null;
@@ -91,6 +109,8 @@ public class CompleteTests : TestBase
                 new KeyValuePair<string, string>("code", "abc"),
                 new KeyValuePair<string, string>("state", "syz")
             };
+
+            authState.HaveResumedCompletedJourney = haveResumedCompletedJourney;
 
             if (hasTrn)
             {


### PR DESCRIPTION
Show an alternative final screen when the user uses the back button after successfully completing authorization.

This also 'fast forwards' users to the final screen if they attempt to go back to an earlier part of the process.