### PR TITLE
Provide an error to the client when trn scope is missing

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -136,10 +136,7 @@ public class AuthenticationState
         }
 
         // For now we only support flows that have the trn scope specified
-        if (!request.HasScope(CustomScopes.Trn))
-        {
-            throw new NotSupportedException($"The '{CustomScopes.Trn}' scope must be specified.");
-        }
+        Debug.Assert(request.HasScope(CustomScopes.Trn));
 
         // trn scope is specified; launch the journey to collect TRN
         if (request.HasScope(CustomScopes.Trn) && Trn is null && !HaveCompletedTrnLookup)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
@@ -41,6 +41,19 @@ public class AuthorizationController : Controller
         var request = HttpContext.GetOpenIddictServerRequest() ??
             throw new InvalidOperationException("The OpenID Connect request cannot be retrieved.");
 
+        // trn scope is required for now
+        if (!request.HasScope(CustomScopes.Trn))
+        {
+            return Forbid(
+                authenticationSchemes: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme,
+                properties: new AuthenticationProperties(new Dictionary<string, string?>()
+                {
+                    [OpenIddictServerAspNetCoreConstants.Properties.Error] = Errors.InvalidScope,
+                    [OpenIddictServerAspNetCoreConstants.Properties.ErrorDescription] =
+                        "The trn scope is required."
+                }));
+        }
+
         // Try to retrieve the user principal stored in the authentication cookie and redirect
         // the user agent to the login page (or to an external provider) in the following cases:
         //


### PR DESCRIPTION
Previously we threw an exception that was invisible to the client.