### PR TITLE
Add HA for postgres

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -31,6 +31,11 @@ variable "postgres_flexible_server_storage_mb" {
   type    = number
   default = 32768
 }
+
+variable "enable_postgres_high_availability" {
+  type    = bool
+  default = false
+}
 variable "key_vault_name" {
   type = string
 }

--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -9,6 +9,8 @@
     "resource_prefix": "s165p01-",
     "app_service_plan_sku": "P1v2",
     "worker_count": 3,
+    "postgres_flexible_server_sku": "GP_Standard_D2s_v3",
+    "enable_postgres_high_availability": true,
     "statuscake_alerts": {
       "get-an-identity-prod": {
         "website_name": "get-an-identity-prod",


### PR DESCRIPTION
### Context

High availability deployment for the Postgres database is required in production. This enables a standby server to be available if the primary server is offline. This commit adds the terraform configuration to enable HA for database.

###

https://trello.com/c/NwZyL3xe