### PR TITLE
Remove the environment property from the build job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,8 +30,6 @@ jobs:
     name: Build
     needs: [setup]
     runs-on: ubuntu-latest
-    environment:
-      name: dev
 
     outputs:
       authserver: ${{ steps.image_tags.outputs.authserver }}
@@ -122,7 +120,7 @@ jobs:
     - uses: azure/login@v1
       if: github.actor != 'dependabot[bot]'
       with:
-        creds: ${{ secrets.AZURE_CREDENTIALS }}
+        creds: ${{ secrets.AZURE_CREDENTIALS_DEV }}
 
     - uses: DfE-Digital/keyvault-yaml-secret@v1
       id: get_monitoring_secret
@@ -131,7 +129,7 @@ jobs:
         secret: MONITORING
         key: SLACK_WEBHOOK
       env:
-        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - uses: DFE-Digital/keyvault-yaml-secret@v1
       if: github.actor != 'dependabot[bot]'
@@ -177,7 +175,7 @@ jobs:
         tags: ${{ steps.image_tags.outputs.testclient }}
 
     - name: Notify Slack channel on build or scan failure
-      if: failure()
+      if: failure() && steps.get_monitoring_secret.outcome == 'success'
       uses: rtCamp/action-slack-notify@v2
       env:
         SLACK_USERNAME: CI Deployment


### PR DESCRIPTION
Having `environment` set on the build job means GitHub creates a deployment record for every build, even though we're not actually deploying anything there. This removes the `environment` property and uses a repository-level secret to get at the dev Key Vault.

Also amended Slack notify step to only run if retrieving the webhook secret succeeded.