### PR TITLE
Support configuring a relative ServiceUrl for a client

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
@@ -214,10 +214,11 @@ public class AuthorizationController : Controller
             if (!HttpContext.TryGetAuthenticationState(out var authenticationState))
             {
                 authenticationState = AuthenticationState.FromClaims(
+                    claims ?? Enumerable.Empty<Claim>(),
                     GetCallbackUrl(),
                     request.ClientId!,
                     request.Scope!,
-                    claims ?? Enumerable.Empty<Claim>(),
+                    request.RedirectUri,
                     firstTimeUser);
 
                 HttpContext.Features.Set(new AuthenticationStateFeature(authenticationState));
@@ -249,7 +250,13 @@ public class AuthorizationController : Controller
                     }));
             }
 
-            var authenticationState = new AuthenticationState(journeyId: Guid.Empty, Request.GetEncodedPathAndQuery(), request.ClientId!, request.Scope!);
+            var authenticationState = new AuthenticationState(
+                journeyId: Guid.Empty,
+                Request.GetEncodedPathAndQuery(),
+                request.ClientId!,
+                request.Scope!,
+                request.RedirectUri);
+
             authenticationState.Populate(user, firstTimeUser: false);
             var claims = authenticationState.GetClaims();
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Oidc/ProcessAuthorizationResponseHandler.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Oidc/ProcessAuthorizationResponseHandler.cs
@@ -34,7 +34,6 @@ public class ProcessAuthorizationResponseHandler : IOpenIddictServerHandler<Appl
                                                                   select new KeyValuePair<string, string>(parameter.Key, value);
 
             authenticationState.AuthorizationResponseMode = context.ResponseMode;
-            authenticationState.RedirectUri = context.RedirectUri;
 
             httpContext.Response.Redirect(_linkGenerator.CompleteAuthorization());
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/TrnLookup/FindALostTrnIntegrationHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/TrnLookup/FindALostTrnIntegrationHelper.cs
@@ -32,7 +32,7 @@ public class FindALostTrnIntegrationHelper
         var clientId = authenticationState.ClientId;
         var client = (Application)(await _applicationManager.FindByClientIdAsync(clientId))!;
         var clientDisplayName = client.DisplayName;
-        var clientServiceUrl = client.ServiceUrl;
+        var clientServiceUrl = authenticationState.ResolveServiceUrl(client);
 
         var request = _httpContextAccessor.HttpContext!.Request;
         var callbackUrl = $"{request.Scheme}://{request.Host}{request.PathBase}{_linkGenerator.TrnCallback()}";
@@ -44,7 +44,7 @@ public class FindALostTrnIntegrationHelper
             { "redirect_uri", callbackUrl },  // TEMP, for back-compat
             { "client_title", clientDisplayName ?? string.Empty },
             { "journey_id", authenticationState.JourneyId.ToString() },
-            { "client_url", clientServiceUrl ?? string.Empty },
+            { "client_url", clientServiceUrl },
             { "previous_url", _linkGenerator.Trn() }
         };
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Views/Shared/_Layout.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Views/Shared/_Layout.cshtml
@@ -9,7 +9,7 @@
     if (client is not null)
     {
         serviceName = client.DisplayName;
-        serviceUrl = client.ServiceUrl ?? "/";
+        serviceUrl = Context.TryGetAuthenticationState(out var authenticationState) ? authenticationState.ResolveServiceUrl(client) : "/";
     }
 }
 <!DOCTYPE html>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Development.json
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Development.json
@@ -13,7 +13,7 @@
       "RedirectUris": [
         "https://localhost:7261/oidc/callback"
       ],
-      "ServiceUrl": "https://localhost:7261",
+      "ServiceUrl": "/",
       "Scopes": [ "get-an-identity:admin", "get-an-identity:support", "trn" ]
     }
   ],

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
@@ -32,12 +32,13 @@ public sealed class AuthenticationStateHelper
         var codeChallenge = Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes("12345")));
         var client = TestClients.Client1;
         var fullScope = $"email profile {scope}";
+        var redirectUri = client.RedirectUris.First().ToString();
 
         var authorizationUrl = $"/connect/authorize" +
             $"?client_id={client.ClientId}" +
             $"&response_type=code" +
             $"&scope=" + Uri.EscapeDataString(fullScope) +
-            $"&redirect_uri={Uri.EscapeDataString(client.RedirectUris.First().ToString())}" +
+            $"&redirect_uri={Uri.EscapeDataString(redirectUri)}" +
             $"&code_challenge={Uri.EscapeDataString(codeChallenge)}" +
             $"&code_challenge_method=S256" +
             $"&response_mode=form_post";
@@ -46,7 +47,8 @@ public sealed class AuthenticationStateHelper
             journeyId,
             authorizationUrl,
             client.ClientId!,
-            fullScope);
+            fullScope,
+            redirectUri);
 
         configureAuthenticationState?.Invoke(authenticationState);
 

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/CompleteTests.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/CompleteTests.cs
@@ -138,7 +138,6 @@ public class CompleteTests : TestBase
                 authState.UserId = user.UserId;
                 authState.Trn = user.Trn;
 
-                authState.RedirectUri = "https://dummy";
                 authState.AuthorizationResponseMode = "form_post";
                 authState.AuthorizationResponseParameters = new[]
                 {


### PR DESCRIPTION
If a relative URL is used it will be combined with the authority of the authorization request's redirect URI.