### PR TITLE
Move away from using 'teacher' in endpoints and code

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/ApiModels/UserInfo.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/ApiModels/UserInfo.cs
@@ -1,6 +1,6 @@
 namespace TeacherIdentity.AuthServer.Api.V1.ApiModels;
 
-public class TeacherInfo
+public class UserInfo
 {
     public Guid UserId { get; set; }
     public string? Email { get; set; }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Controllers/TeachersController.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Controllers/TeachersController.cs
@@ -36,7 +36,7 @@ public class TeachersController : ControllerBase
     public async Task<IActionResult> GetTeacherDetail([FromRoute] Guid teacherId)
     {
         var teacher = await _dbContext.Users
-            .Where(u => u.UserType == UserType.Teacher && u.UserId == teacherId)
+            .Where(u => u.UserType == UserType.Default && u.UserId == teacherId)
             .OrderBy(u => u.LastName)
             .ThenBy(u => u.FirstName)
             .Select(u => new GetTeacherDetailResponse()
@@ -65,7 +65,7 @@ public class TeachersController : ControllerBase
     public async Task<IActionResult> GetAllTeachers()
     {
         var teachers = await _dbContext.Users
-            .Where(u => u.UserType == UserType.Teacher)
+            .Where(u => u.UserType == UserType.Default)
             .OrderBy(u => u.LastName)
             .ThenBy(u => u.FirstName)
             .Select(u => new TeacherInfo()
@@ -104,7 +104,7 @@ public class TeachersController : ControllerBase
             return NotFound();
         }
 
-        if (user.UserType != UserType.Teacher)
+        if (user.UserType != UserType.Default)
         {
             throw new ErrorException(ErrorRegistry.UserMustBeTeacher());
         }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Responses/GetAllUsersResponse.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Responses/GetAllUsersResponse.cs
@@ -2,7 +2,7 @@ using TeacherIdentity.AuthServer.Api.V1.ApiModels;
 
 namespace TeacherIdentity.AuthServer.Api.V1.Responses;
 
-public class GetAllTeachersResponse
+public class GetAllUsersResponse
 {
-    public TeacherInfo[]? Teachers { get; set; }
+    public UserInfo[]? Users { get; set; }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Responses/GetTeacherDetailResponse.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Responses/GetTeacherDetailResponse.cs
@@ -3,7 +3,7 @@ using TeacherIdentity.AuthServer.Api.V1.ApiModels;
 
 namespace TeacherIdentity.AuthServer.Api.V1.Responses;
 
-public class GetTeacherDetailResponse : TeacherInfo
+public class GetTeacherDetailResponse : UserInfo
 {
     public class TrnRequestInfoExample : IExamplesProvider<GetTeacherDetailResponse>
     {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -214,7 +214,7 @@ public class AuthenticationState
         {
             if (HasScope(scope))
             {
-                userTypes.Add(UserType.Admin);
+                userTypes.Add(UserType.Staff);
                 userTypeConstrainedClaims.Add(scope);
             }
         }
@@ -223,7 +223,7 @@ public class AuthenticationState
         {
             if (HasScope(scope))
             {
-                userTypes.Add(UserType.Teacher);
+                userTypes.Add(UserType.Default);
                 userTypeConstrainedClaims.Add(scope);
             }
         }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/UserType.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/UserType.cs
@@ -2,6 +2,7 @@ namespace TeacherIdentity.AuthServer.Models;
 
 public enum UserType
 {
+    Default = 0,
     Teacher = 0,
-    Admin = 1
+    Staff = 1
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Complete.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Complete.cshtml
@@ -87,7 +87,7 @@ else
             <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
             <govuk-summary-list-row-value>@Model.Name</govuk-summary-list-row-value>
           </govuk-summary-list-row>
-          @if (Model.UserType == UserType.Teacher)
+          @if (Model.UserType == UserType.Default)
           {
             <govuk-summary-list-row data-testid="trn-row">
               <govuk-summary-list-row-key>TRN</govuk-summary-list-row-key>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/EmailConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/EmailConfirmation.cshtml.cs
@@ -86,7 +86,7 @@ public class EmailConfirmationModel : PageModel
         else
         {
             // We don't support registering admins
-            if (requiredUserType == UserType.Admin)
+            if (requiredUserType == UserType.Staff)
             {
                 return new ForbidResult(authenticationScheme: CookieAuthenticationDefaults.AuthenticationScheme);
             }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnCallback.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnCallback.cshtml.cs
@@ -69,7 +69,7 @@ public class TrnCallbackModel : PageModel
                 FirstName = lookupState.FirstName,
                 LastName = lookupState.LastName,
                 UserId = userId,
-                UserType = UserType.Teacher,
+                UserType = UserType.Default,
                 Trn = lookupState.Trn,
                 CompletedTrnLookup = _clock.UtcNow
             };

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.EndToEndTests/SignIn.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.EndToEndTests/SignIn.cs
@@ -32,7 +32,7 @@ public class SignIn : IClassFixture<HostFixture>
                 FirstName = "Joe",
                 LastName = "Bloggs",
                 UserId = userId,
-                UserType = UserType.Teacher,
+                UserType = UserType.Default,
                 DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
                 Trn = trn
             });
@@ -90,7 +90,7 @@ public class SignIn : IClassFixture<HostFixture>
                 FirstName = "Joe",
                 LastName = "Bloggs",
                 UserId = userId,
-                UserType = UserType.Admin
+                UserType = UserType.Staff
             });
 
             await dbContext.SaveChangesAsync();

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.EndToEndTests/SignOut.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.EndToEndTests/SignOut.cs
@@ -29,7 +29,7 @@ public class SignOut : IClassFixture<HostFixture>
                 FirstName = "Joe",
                 LastName = "Bloggs",
                 UserId = userId,
-                UserType = UserType.Teacher,
+                UserType = UserType.Default,
                 DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
                 Trn = trn
             });

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/AuthenticationStateTests.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/AuthenticationStateTests.cs
@@ -329,9 +329,9 @@ public partial class AuthenticationStateTests
 
     public static TheoryData<string, UserType> GetUserTypeData => new TheoryData<string, UserType>
     {
-        { CustomScopes.Trn, UserType.Teacher },
-        { CustomScopes.GetAnIdentityAdmin, UserType.Admin },
-        { CustomScopes.GetAnIdentitySupport, UserType.Admin }
+        { CustomScopes.Trn, UserType.Default },
+        { CustomScopes.GetAnIdentityAdmin, UserType.Staff },
+        { CustomScopes.GetAnIdentitySupport, UserType.Staff }
     };
 
     public static TheoryData<string, bool, string?> ValidateClaimsData => new TheoryData<string, bool, string?>

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/GetAllUsersTests.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/GetAllUsersTests.cs
@@ -4,9 +4,9 @@ using TeacherIdentity.AuthServer.Oidc;
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Api.V1;
 
 [Collection(nameof(DisableParallelization))]
-public class GetAllTeachersTests : ApiTestBase, IAsyncLifetime
+public class GetAllUsersTests : ApiTestBase, IAsyncLifetime
 {
-    public GetAllTeachersTests(HostFixture hostFixture)
+    public GetAllUsersTests(HostFixture hostFixture)
         : base(hostFixture)
     {
     }
@@ -27,7 +27,7 @@ public class GetAllTeachersTests : ApiTestBase, IAsyncLifetime
         var httpClient = await CreateHttpClientWithToken(scope);
 
         // Act
-        var response = await httpClient.GetAsync("/api/v1/teachers");
+        var response = await httpClient.GetAsync("/api/v1/users");
 
         // Assert
         Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
@@ -46,13 +46,13 @@ public class GetAllTeachersTests : ApiTestBase, IAsyncLifetime
         var sortedUsers = new[] { user1, user2, user3 }.OrderBy(u => u.LastName).ThenBy(u => u.FirstName).ToArray();
 
         // Act
-        var response = await httpClient.GetAsync("/api/v1/teachers");
+        var response = await httpClient.GetAsync("/api/v1/users");
 
         // Assert
-        var responseObj = await AssertEx.JsonResponse<GetAllTeachersResponse>(response);
+        var responseObj = await AssertEx.JsonResponse<GetAllUsersResponse>(response);
 
         Assert.Collection(
-            responseObj.Teachers,
+            responseObj.Users,
             user =>
             {
                 Assert.Equal(sortedUsers[0].UserId, user.UserId);

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/GetUserTests.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/GetUserTests.cs
@@ -3,9 +3,9 @@ using TeacherIdentity.AuthServer.Oidc;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Api.V1;
 
-public class GetTeacherTests : ApiTestBase
+public class GetUserTests : ApiTestBase
 {
-    public GetTeacherTests(HostFixture hostFixture)
+    public GetUserTests(HostFixture hostFixture)
         : base(hostFixture)
     {
     }
@@ -18,7 +18,7 @@ public class GetTeacherTests : ApiTestBase
         var httpClient = await CreateHttpClientWithToken(scope);
 
         // Act
-        var response = await httpClient.GetAsync("/api/v1/teachers");
+        var response = await httpClient.GetAsync("/api/v1/users");
 
         // Assert
         Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
@@ -33,7 +33,7 @@ public class GetTeacherTests : ApiTestBase
         var userId = Guid.NewGuid();
 
         // Act
-        var response = await httpClient.GetAsync($"/api/v1/teachers/{userId}");
+        var response = await httpClient.GetAsync($"/api/v1/users/{userId}");
 
         // Assert
         Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
@@ -41,7 +41,7 @@ public class GetTeacherTests : ApiTestBase
 
     [Theory]
     [MemberData(nameof(PermittedScopes))]
-    public async Task Get_ValidRequest_ReturnsAllTeacher(string scope)
+    public async Task Get_ValidRequest_ReturnsUser(string scope)
     {
         // Arrange
         var httpClient = await CreateHttpClientWithToken(scope);
@@ -49,7 +49,7 @@ public class GetTeacherTests : ApiTestBase
         var user = await TestData.CreateUser(hasTrn: true);
 
         // Act
-        var response = await httpClient.GetAsync($"/api/v1/teachers/{user.UserId}");
+        var response = await httpClient.GetAsync($"/api/v1/users/{user.UserId}");
 
         // Assert
         var responseObj = await AssertEx.JsonResponse<GetTeacherDetailResponse>(response);

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/SetTeacherTrnTests.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/SetTeacherTrnTests.cs
@@ -67,7 +67,7 @@ public class SetTeacherTrnTests : ApiTestBase
         // Arrange
         var httpClient = await CreateHttpClientWithToken(scope: PermittedScopes.First());
 
-        var user = await TestData.CreateUser(userType: Models.UserType.Admin);
+        var user = await TestData.CreateUser(userType: Models.UserType.Staff);
         var trn = "1234567";
 
         var request = new HttpRequestMessage(HttpMethod.Put, $"/api/v1/teachers/{user.UserId}/trn")

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/SetTeacherTrnTests.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/SetTeacherTrnTests.cs
@@ -22,7 +22,7 @@ public class SetTeacherTrnTests : ApiTestBase
         var user = await TestData.CreateUser(hasTrn: false);
         var trn = "1234567";
 
-        var request = new HttpRequestMessage(HttpMethod.Put, $"/api/v1/teachers/{user.UserId}/trn")
+        var request = new HttpRequestMessage(HttpMethod.Put, $"/api/v1/users/{user.UserId}/trn")
         {
             Content = JsonContent.Create(new
             {
@@ -46,7 +46,7 @@ public class SetTeacherTrnTests : ApiTestBase
         var userId = Guid.NewGuid();
         var trn = "1234567";
 
-        var request = new HttpRequestMessage(HttpMethod.Put, $"/api/v1/teachers/{userId}/trn")
+        var request = new HttpRequestMessage(HttpMethod.Put, $"/api/v1/users/{userId}/trn")
         {
             Content = JsonContent.Create(new
             {
@@ -70,7 +70,7 @@ public class SetTeacherTrnTests : ApiTestBase
         var user = await TestData.CreateUser(userType: Models.UserType.Staff);
         var trn = "1234567";
 
-        var request = new HttpRequestMessage(HttpMethod.Put, $"/api/v1/teachers/{user.UserId}/trn")
+        var request = new HttpRequestMessage(HttpMethod.Put, $"/api/v1/users/{user.UserId}/trn")
         {
             Content = JsonContent.Create(new
             {
@@ -94,7 +94,7 @@ public class SetTeacherTrnTests : ApiTestBase
 
         var user = await TestData.CreateUser(hasTrn: false);
 
-        var request = new HttpRequestMessage(HttpMethod.Put, $"/api/v1/teachers/{user.UserId}/trn")
+        var request = new HttpRequestMessage(HttpMethod.Put, $"/api/v1/users/{user.UserId}/trn")
         {
             Content = JsonContent.Create(new
             {
@@ -119,7 +119,7 @@ public class SetTeacherTrnTests : ApiTestBase
         var otherUser = await TestData.CreateUser(hasTrn: true);
         var trn = otherUser.Trn!;
 
-        var request = new HttpRequestMessage(HttpMethod.Put, $"/api/v1/teachers/{user.UserId}/trn")
+        var request = new HttpRequestMessage(HttpMethod.Put, $"/api/v1/users/{user.UserId}/trn")
         {
             Content = JsonContent.Create(new
             {
@@ -147,7 +147,7 @@ public class SetTeacherTrnTests : ApiTestBase
         A.CallTo(() => HostFixture.DqtApiClient!.SetTeacherIdentityInfo(A<DqtTeacherIdentityInfo>.That.Matches(i => i.Trn == trn)))
             .Returns(Task.CompletedTask);
 
-        var request = new HttpRequestMessage(HttpMethod.Put, $"/api/v1/teachers/{user.UserId}/trn")
+        var request = new HttpRequestMessage(HttpMethod.Put, $"/api/v1/users/{user.UserId}/trn")
         {
             Content = JsonContent.Create(new
             {

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
@@ -291,7 +291,7 @@ public class EmailConfirmationTests : TestBase
     public async Task Post_ValidPinForAdminScopeWithNonAdminUser_ReturnsForbidden()
     {
         // Arrange
-        var user = await TestData.CreateUser(userType: Models.UserType.Teacher);
+        var user = await TestData.CreateUser(userType: Models.UserType.Default);
 
         var emailVerificationService = HostFixture.Services.GetRequiredService<IEmailVerificationService>();
         var pin = await emailVerificationService.GeneratePin(user.EmailAddress);
@@ -315,7 +315,7 @@ public class EmailConfirmationTests : TestBase
     public async Task Post_ValidPinForAdminScopeForKnownUserWithTrn_UpdatesAuthenticationStateSignsInAndRedirects()
     {
         // Arrange
-        var user = await TestData.CreateUser(userType: Models.UserType.Admin);
+        var user = await TestData.CreateUser(userType: Models.UserType.Staff);
 
         var emailVerificationService = HostFixture.Services.GetRequiredService<IEmailVerificationService>();
         var pin = await emailVerificationService.GeneratePin(user.EmailAddress);
@@ -344,7 +344,7 @@ public class EmailConfirmationTests : TestBase
     public async Task Post_ValidPinForNonAdminScopeWithAdminUser_ReturnsForbidden()
     {
         // Arrange
-        var user = await TestData.CreateUser(userType: Models.UserType.Admin);
+        var user = await TestData.CreateUser(userType: Models.UserType.Staff);
 
         var emailVerificationService = HostFixture.Services.GetRequiredService<IEmailVerificationService>();
         var pin = await emailVerificationService.GeneratePin(user.EmailAddress);

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnCallbackTests.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnCallbackTests.cs
@@ -72,7 +72,7 @@ public class TrnCallbackTests : TestBase
             Assert.Equal(dateOfBirth, user!.DateOfBirth);
             Assert.Equal(Clock.UtcNow, user.Created);
             Assert.Equal(Clock.UtcNow, user.CompletedTrnLookup);
-            Assert.Equal(UserType.Teacher, user.UserType);
+            Assert.Equal(UserType.Default, user.UserType);
 
             if (hasTrn)
             {

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/TestData.CreateUser.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/TestData.CreateUser.cs
@@ -4,19 +4,19 @@ namespace TeacherIdentity.AuthServer.Tests;
 
 public partial class TestData
 {
-    public Task<User> CreateUser(string? email = null, bool? hasTrn = null, bool? haveCompletedTrnLookup = null, UserType userType = UserType.Teacher) =>
+    public Task<User> CreateUser(string? email = null, bool? hasTrn = null, bool? haveCompletedTrnLookup = null, UserType userType = UserType.Default) =>
         WithDbContext(async dbContext =>
         {
-            if (hasTrn is null && userType == UserType.Teacher)
+            if (hasTrn is null && userType == UserType.Default)
             {
                 hasTrn = true;
             }
-            else if (hasTrn == true && userType != UserType.Teacher)
+            else if (hasTrn == true && userType != UserType.Default)
             {
-                throw new ArgumentException($"Only {UserType.Teacher} users should have a TRN.");
+                throw new ArgumentException($"Only {UserType.Default} users should have a TRN.");
             }
 
-            if (haveCompletedTrnLookup == true && userType == UserType.Teacher)
+            if (haveCompletedTrnLookup == true && userType == UserType.Default)
             {
                 throw new ArgumentException($"{userType} users should not have {nameof(User.CompletedTrnLookup)} set.");
             }
@@ -32,9 +32,9 @@ public partial class TestData
                 FirstName = Faker.Name.First(),
                 LastName = Faker.Name.Last(),
                 Created = _clock.UtcNow,
-                CompletedTrnLookup = userType is UserType.Teacher && haveCompletedTrnLookup != false ? _clock.UtcNow : null,
+                CompletedTrnLookup = userType is UserType.Default && haveCompletedTrnLookup != false ? _clock.UtcNow : null,
                 UserType = userType,
-                DateOfBirth = userType is UserType.Teacher ? DateOnly.FromDateTime(Faker.Identification.DateOfBirth()) : null,
+                DateOfBirth = userType is UserType.Default ? DateOnly.FromDateTime(Faker.Identification.DateOfBirth()) : null,
                 Trn = hasTrn == true ? GenerateTrn() : null
             };
 

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/TestUsers.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/TestUsers.cs
@@ -12,7 +12,7 @@ public static class TestUsers
         EmailAddress = Faker.Internet.Email(),
         FirstName = Faker.Name.First(),
         LastName = Faker.Name.Last(),
-        UserType = UserType.Admin
+        UserType = UserType.Staff
     };
 
     public static async Task CreateUsers(TeacherIdentityServerDbContext dbContext)

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/UserClaimHelperTests.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/UserClaimHelperTests.cs
@@ -22,7 +22,7 @@ public class UserClaimHelperTests
             DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
             Trn = "1234567",
             Created = DateTime.UtcNow,
-            UserType = UserType.Teacher
+            UserType = UserType.Default
         };
 
         var helper = new UserClaimHelper();


### PR DESCRIPTION
Not all users will be teachers and many of the endpoints are (or will be) generic to all user types.