### PR TITLE
Forward headers from App Service & Front Door

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
@@ -307,7 +307,9 @@ public class Program
 
         builder.Services.Configure<ForwardedHeadersOptions>(options =>
         {
-            options.ForwardedHeaders = ForwardedHeaders.XForwardedProto;
+            options.ForwardedHeaders = ForwardedHeaders.All;
+            options.KnownNetworks.Clear();
+            options.KnownProxies.Clear();
         });
 
         builder.Services.AddOptions<FindALostTrnIntegrationOptions>()

--- a/dotnet-authserver/src/TeacherIdentity.TestClient/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.TestClient/Program.cs
@@ -93,7 +93,9 @@ public class Program
 
         builder.Services.Configure<ForwardedHeadersOptions>(options =>
         {
-            options.ForwardedHeaders = ForwardedHeaders.XForwardedProto;
+            options.ForwardedHeaders = ForwardedHeaders.All;
+            options.KnownNetworks.Clear();
+            options.KnownProxies.Clear();
         });
 
         var app = builder.Build();


### PR DESCRIPTION
This allows the app to see the correct client IP address and request host name.