### PR TITLE
Updated website_url on StatusCake alert

### DIFF
--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -14,7 +14,7 @@
     "statuscake_alerts": {
       "get-an-identity-prod": {
         "website_name": "get-an-identity-prod",
-        "website_url": "https://s165p01-getanid-production-auths-app.azurewebsites.net/status",
+        "website_url": "https://teaching-identity.education.gov.uk/status",
         "contact_group": [249142],
         "confirmations": 2
       }


### PR DESCRIPTION
This needs to be changed to the custom hostname after access to the azurewebsites.net address was blocked.