### PR TITLE
Use the education URL everywhere

### DIFF
--- a/.github/workflows/actions/deploy-environment/action.yml
+++ b/.github/workflows/actions/deploy-environment/action.yml
@@ -61,22 +61,6 @@ runs:
         TFVARS: ${{ inputs.terraform_vars }}
       working-directory: terraform
 
-    - name: Set environment variables
-      id: set-environment-vars
-      run: |
-        DEPLOY_ENV=${{ inputs.environment_name }}
-        if [[ $DEPLOY_ENV == "dev" ]]; then
-          URL_PREFIX="dev."
-        elif [[ $DEPLOY_ENV == "preprod" ]]; then
-          URL_PREFIX="preprod."
-        else
-          URL_PREFIX=""
-        fi
-        HOSTNAME="https://${URL_PREFIX}teaching-identity.education.gov.uk/"
-
-        echo ::set-output name=hostname::$HOSTNAME
-      shell: bash
-
     - uses: Azure/login@v1
       with:
         creds: ${{ inputs.azure_credentials }}
@@ -96,7 +80,7 @@ runs:
       id: terraform
       run: |
         make ci ${{ inputs.environment_name }} terraform-apply
-        cd terraform && echo ::set-output name=url::${{ steps.set-environment-vars.outputs.hostname }}
+        cd terraform && echo ::set-output name=url::https://$(terraform output -raw auth_server_fqdn)/
         echo ::set-output name=postgres_server_name::$(terraform output -raw postgres_server_name)
         blue_green=$(terraform output -raw blue_green)
         echo ::set-output name=blue_green::$blue_green
@@ -130,7 +114,7 @@ runs:
         attempt_counter=0
         max_attempts=60
 
-        SHA_URL="${{ steps.set-environment-vars.outputs.hostname }}_sha"
+        SHA_URL="${{ steps.terraform.outputs.url }}_sha"
         APP_SHA=$(curl $SHA_URL --silent)
         until [[ "$EXPECTED_SHA" == "$APP_SHA" ]]; do
             if [ ${attempt_counter} -eq ${max_attempts} ];then

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -28,6 +28,7 @@ locals {
         }
     ]...))
   ]...)
+
   auth_server_env_vars = merge(
     local.auth_server_clients_app_env_vars,
     local.auth_server_api_clients_app_env_vars,
@@ -59,7 +60,7 @@ locals {
     ClientId                   = "testclient",
     ClientSecret               = local.infrastructure_secrets.TESTCLIENT_SECRET,
     DOCKER_REGISTRY_SERVER_URL = "https://ghcr.io",
-    SignInAuthority            = "https://${azurerm_linux_web_app.auth-server-app.default_hostname}"
+    SignInAuthority            = "https://${var.domain}"
   }
 }
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,6 +1,7 @@
 output "auth_server_fqdn" {
-  value = azurerm_linux_web_app.auth-server-app.default_hostname
+  value = var.domain
 }
+
 output "postgres_server_name" {
   value = azurerm_postgresql_flexible_server.postgres-server.name
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -137,6 +137,10 @@ variable "statuscake_alerts" {
   default = {}
 }
 
+variable "domain" {
+  type = string
+}
+
 locals {
   hosting_environment          = var.environment_name
   auth_server_app_name         = "${var.resource_prefix}getanid-${var.environment_name}${var.app_suffix}-auths-app"

--- a/terraform/workspace_variables/dev.tfvars.json
+++ b/terraform/workspace_variables/dev.tfvars.json
@@ -6,5 +6,6 @@
   "deploy_test_client_app": true,
   "keyvault_logging_enabled": true,
   "storage_log_categories": [],
-  "resource_prefix": "s165d01-"
+  "resource_prefix": "s165d01-",
+  "domain": "dev.teaching-identity.education.gov.uk"
 }

--- a/terraform/workspace_variables/preprod.tfvars.json
+++ b/terraform/workspace_variables/preprod.tfvars.json
@@ -8,5 +8,6 @@
     "keyvault_logging_enabled": true,
     "storage_log_categories": [],
     "resource_prefix": "s165t01-",
-    "app_service_plan_sku": "S1"
+    "app_service_plan_sku": "S1",
+    "domain": "preprod.teaching-identity.education.gov.uk"
   }

--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -18,5 +18,6 @@
         "contact_group": [249142],
         "confirmations": 2
       }
-    }
+    },
+    "domain": "preprod.teaching-identity.education.gov.uk"
   }


### PR DESCRIPTION
Previously we had a mixture of the azurewebsites.net domain and the education URLs; this change uses the education URL everywhere. Notably this fixes the environment URLs on GitHub and the config in Test Client.