### PR TITLE
Fix flaky test

### DIFF
--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/UpdateUserTests.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/UpdateUserTests.cs
@@ -4,6 +4,7 @@ using TeacherIdentity.AuthServer.Oidc;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Api.V1;
 
+[Collection(nameof(DisableParallelization))]  // Changes the clock
 public class UpdateUserTests : TestBase
 {
     public UpdateUserTests(HostFixture hostFixture)

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
@@ -5,7 +5,7 @@ using TeacherIdentity.AuthServer.Services.EmailVerification;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn;
 
-[Collection(nameof(DisableParallelization))]  // Depends on mocks
+[Collection(nameof(DisableParallelization))]  // Depends on mocks and changes the clock
 public class EmailConfirmationTests : TestBase
 {
     public EmailConfirmationTests(HostFixture hostFixture)

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnInUseTests.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnInUseTests.cs
@@ -5,7 +5,7 @@ using TeacherIdentity.AuthServer.Services.EmailVerification;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn;
 
-[Collection(nameof(DisableParallelization))]  // Relies on mocks
+[Collection(nameof(DisableParallelization))]  // Relies on mocks and changes the clock
 public class TrnInUseTests : TestBase
 {
     public TrnInUseTests(HostFixture hostFixture)

--- a/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/Services/EmailVerificationServiceTests.cs
+++ b/dotnet-authserver/test/TeacherIdentity.AuthServer.Tests/Services/EmailVerificationServiceTests.cs
@@ -9,7 +9,7 @@ using TeacherIdentity.AuthServer.Services.EmailVerification;
 
 namespace TeacherIdentity.AuthServer.Tests.Services;
 
-[Collection(nameof(DisableParallelization))]
+[Collection(nameof(DisableParallelization))]  // Changes the clock
 public class EmailVerificationServiceTests : IClassFixture<DbFixture>
 {
     private static readonly TimeSpan _pinLifetime = TimeSpan.FromSeconds(120);


### PR DESCRIPTION
One test that amended the clock was allowed to run in parallel with other tests that read the clock.