### PR TITLE
Ensure the signed in user's UserType is compatible with UserRequirements

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
@@ -79,10 +79,18 @@ public class AuthorizationController : Controller
                     }));
             }
 
+            // If the user is signed in with an incompatible UserType then force the user to sign in again
+            var principal = authenticateResult?.Principal ?? new ClaimsPrincipal();
+            var permittedUserTypes = userRequirements.GetPermittedUserTypes();
+            if (principal.GetUserType(throwIfMissing: false) is UserType userType && !permittedUserTypes.Contains(userType))
+            {
+                principal = new ClaimsPrincipal();
+            }
+
             authenticationState = AuthenticationState.FromInternalClaims(
                 journeyId,
                 userRequirements,
-                authenticateResult?.Principal ?? new ClaimsPrincipal(),
+                principal,
                 GetCallbackUrl(journeyId),
                 new OAuthAuthorizationState(request.ClientId!, request.Scope!, request.RedirectUri),
                 firstTimeSignInForEmail: authenticateResult?.Succeeded != true);


### PR DESCRIPTION
When we start a new journey we 'absorb' any existing claims from an already-signed in user. We shouldn't do that if that user's `UserType` doesn't meet the `UserRequirements`; we should start again instead.