### PR TITLE
Configure logstash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 docs/.structurizr/**
+fetch_config.rb

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/TeacherIdentity.AuthServer.csproj
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/TeacherIdentity.AuthServer.csproj
@@ -42,6 +42,7 @@
     <PackageReference Include="Serilog.AspNetCore" Version="5.0.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
+    <PackageReference Include="Serilog.Sinks.Network" Version="2.0.2.68" />
     <PackageReference Include="SerilogTimings" Version="2.3.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.4.0" />

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Production.json
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Production.json
@@ -21,7 +21,11 @@
     "TracesSampleRate": 0.1
   },
   "Serilog": {
-    "Using": [ "Serilog", "Sentry" ],
+    "Using": [
+      "Serilog",
+      "Sentry",
+      "Serilog.Sinks.Network"
+    ],
     "MinimumLevel": {
       "Default": "Warning"
     },
@@ -35,6 +39,9 @@
           "minimumBreadcrumbLevel": "Debug",
           "minimumEventLevel": "Error"
         }
+      },
+      {
+        "Name": "TCPSink"
       }
     ]
   },

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -55,6 +55,7 @@ locals {
       DqtApi__ApiKey                               = local.infrastructure_secrets.DQT_API_KEY,
       DqtApi__BaseAddress                          = local.infrastructure_secrets.DQT_API_BASE_ADDRESS,
       WebHooks__QueueName                          = azurerm_servicebus_queue.webhooks.name
+      Serilog__WriteTo__2__Args__uri               = local.infrastructure_secrets.LOGSTASH_ENDPOINT
     }
   )
 


### PR DESCRIPTION
## Changes in this PR

Added Serilog settings to auth_server_env_vars

This will enable forwarding of logs to Logit.io

## Testing

The existing default minimum log level is `Warning` so you won't see any logs forwarded to Logit.io with the configuration in this PR.  To override that for testing add an app setting to the App Service in Azure with a Name of `Serilog__MinimumLevel__Default` and a Value of `Information`.

## Checklist

- [ ] Add secret to each environment