### PR TITLE
Ping /status on slot swap

### DIFF
--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -56,6 +56,8 @@ locals {
       DqtApi__BaseAddress                          = local.infrastructure_secrets.DQT_API_BASE_ADDRESS,
       WebHooks__QueueName                          = azurerm_servicebus_queue.webhooks.name
       Serilog__WriteTo__2__Args__uri               = local.infrastructure_secrets.LOGSTASH_ENDPOINT
+      WEBSITE_SWAP_WARMUP_PING_PATH                = "/status"
+      WEBSITE_SWAP_WARMUP_PING_STATUSES            = "200"
     }
   )
 


### PR DESCRIPTION
## Change

By default the App Service swap slot process pings the application root and accepts any status code as confirmation the staging app is ready to swap to production.  The app has implemented health checks so we should ping the `/status` endpoint for a 200 response which will provide more reliable confirmation the app is ready to be swapped to the production slot.

## Testing
Enabled blue green deployment for dev, temporarily upgraded app service plan to S1 and [deployed](https://github.com/DFE-Digital/get-an-identity/actions/runs/3274325523/jobs/5387770662) to that environment.