### PR TITLE
Fix GitHub actions warnings

### DIFF
--- a/.github/workflows/actions/deploy-environment/action.yml
+++ b/.github/workflows/actions/deploy-environment/action.yml
@@ -25,7 +25,6 @@ outputs:
     description: The name of the postgres server deployed
     value: ${{ steps.terraform.outputs.postgres_server_name }}
 
-
 runs:
   using: composite
 
@@ -52,9 +51,9 @@ runs:
           exit 1
         fi
 
-        echo ::set-output name=resource_group_name::$RESOURCE_GROUP_NAME
-        echo ::set-output name=key_vault_name::$KEY_VAULT_NAME
-        echo ::set-output name=resource_prefix::$RESOURCE_PREFIX
+        echo resource_group_name=$RESOURCE_GROUP_NAME >> $GITHUB_OUTPUT
+        echo key_vault_name=$KEY_VAULT_NAME >> $GITHUB_OUTPUT
+        echo resource_prefix=$RESOURCE_PREFIX >> $GITHUB_OUTPUT
 
       shell: bash
       env:
@@ -80,15 +79,15 @@ runs:
       id: terraform
       run: |
         make ci ${{ inputs.environment_name }} terraform-apply
-        cd terraform && echo ::set-output name=url::https://$(terraform output -raw auth_server_fqdn)/
-        echo ::set-output name=postgres_server_name::$(terraform output -raw postgres_server_name)
+        cd terraform && echo url=https://$(terraform output -raw auth_server_fqdn)/ >> $GITHUB_OUTPUT
+        echo postgres_server_name=$(terraform output -raw postgres_server_name) >> $GITHUB_OUTPUT
         blue_green=$(terraform output -raw blue_green)
-        echo ::set-output name=blue_green::$blue_green
+        echo blue_green=$blue_green >> $GITHUB_OUTPUT
 
         if [ "$blue_green" = "true" ]; then
-          echo ::set-output name=slot_name::$(terraform output -raw web_app_slot_name)
+          echo slot_name=$(terraform output -raw web_app_slot_name) >> $GITHUB_OUTPUT
         else
-          echo ::set-output name=slot_name::production
+          echo slot_name=production >> $GITHUB_OUTPUT
         fi
       env:
         ARM_ACCESS_KEY: ${{ steps.get_secrets.outputs.TFSTATE-CONTAINER-ACCESS-KEY }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,8 +108,8 @@ jobs:
     - name: Get Docker image tags
       id: image_tags
       run: |
-        echo ::set-output name=authserver::$CONTAINER_REGISTRY/$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]'):authserver-$GITHUB_SHA
-        echo ::set-output name=testclient::$CONTAINER_REGISTRY/$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]'):testclient-$GITHUB_SHA
+        echo authserver=$CONTAINER_REGISTRY/$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]'):authserver-$GITHUB_SHA >> $GITHUB_OUTPUT
+        echo testclient=$CONTAINER_REGISTRY/$(echo $GITHUB_REPOSITORY | tr '[:upper:]' '[:lower:]'):testclient-$GITHUB_SHA >> $GITHUB_OUTPUT
 
     - name: Set KV environment variables
       working-directory: terraform


### PR DESCRIPTION
`set-output` is being deprecated https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/