### PR TITLE
Move service configuration into separate methods

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/ServiceCollectionExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/ServiceCollectionExtensions.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+using MediatR;
+
+namespace TeacherIdentity.AuthServer.Api;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddApiServices(this IServiceCollection services)
+    {
+        services.AddMediatR(typeof(Program));
+
+        services.AddValidatorsFromAssemblyContaining(typeof(Program));
+
+        return services;
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/Swagger/ServiceCollectionExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/Swagger/ServiceCollectionExtensions.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using Swashbuckle.AspNetCore.Filters;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace TeacherIdentity.AuthServer.Infrastructure.Swagger;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddApiSwagger(this IServiceCollection services)
+    {
+        services.AddSwaggerGen(c =>
+        {
+            c.SwaggerDoc("v1", new Microsoft.OpenApi.Models.OpenApiInfo() { Title = "Get an identity to access Teacher Services API", Version = "v1" });
+
+            c.DocInclusionPredicate((docName, api) => docName.Equals(api.GroupName, StringComparison.OrdinalIgnoreCase));
+            c.EnableAnnotations();
+            c.ExampleFilters();
+            c.OperationFilter<ResponseContentTypeOperationFilter>();
+            c.OperationFilter<RateLimitOperationFilter>();
+        });
+
+        services.AddSwaggerExamplesFromAssemblyOf<Program>();
+
+        services.AddTransient<ISerializerDataContractResolver>(sp =>
+        {
+            var serializerOptions = sp.GetRequiredService<IOptions<JsonOptions>>().Value.JsonSerializerOptions;
+            return new JsonSerializerDataContractResolver(serializerOptions);
+        });
+
+        return services;
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Notifications/ServiceCollectionExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Notifications/ServiceCollectionExtensions.cs
@@ -1,0 +1,57 @@
+using Azure.Messaging.ServiceBus;
+using TeacherIdentity.AuthServer.Notifications.WebHooks;
+
+namespace TeacherIdentity.AuthServer.Notifications;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddNotifications(
+        this IServiceCollection services,
+        IWebHostEnvironment environment,
+        IConfiguration configuration)
+    {
+        if (!environment.IsUnitTests())
+        {
+            if (environment.IsProduction() ||
+                configuration.GetValue<bool?>("ServiceBusWebHookNotificationPublisher") == true)
+            {
+                var sbClient = new ServiceBusClient(configuration.GetConnectionString("ServiceBus"));
+
+                services.AddSingleton(sbClient);
+                services.AddSingleton<ServiceBusWebHookNotificationPublisher>();
+                services.AddSingleton<INotificationPublisher>(sp => sp.GetRequiredService<ServiceBusWebHookNotificationPublisher>());
+                services.AddHostedService(sp => sp.GetRequiredService<ServiceBusWebHookNotificationPublisher>());
+
+                services.AddOptions<ServiceBusWebHookOptions>()
+                    .Bind(configuration.GetSection("WebHooks"))
+                    .ValidateDataAnnotations()
+                    .ValidateOnStart();
+            }
+            else
+            {
+                services.AddSingleton<INotificationPublisher, WebHookNotificationPublisher>();
+            }
+
+            services.AddOptions<WebHookOptions>()
+                .Bind(configuration.GetSection("WebHooks"))
+                .ValidateDataAnnotations()
+                .ValidateOnStart();
+
+            services
+                .AddSingleton<IWebHookNotificationSender, WebHookNotificationSender>()
+                .AddHttpClient<IWebHookNotificationSender, WebHookNotificationSender>(httpClient =>
+                {
+                    httpClient.Timeout = TimeSpan.FromSeconds(30);
+                    httpClient.DefaultRequestHeaders.UserAgent.ParseAdd("Teacher Identity");
+                })
+                .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler()
+                {
+                    UseCookies = false,
+                    AllowAutoRedirect = false,
+                    PreAuthenticate = true
+                });
+        }
+
+        return services;
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/BackgroundJobs/ServiceCollectionExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/BackgroundJobs/ServiceCollectionExtensions.cs
@@ -1,0 +1,38 @@
+using Hangfire;
+using Hangfire.PostgreSql;
+using TeacherIdentity.AuthServer.Jobs;
+
+namespace TeacherIdentity.AuthServer.Services.BackgroundJobs;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddBackgroundJobs(
+        this IServiceCollection services,
+        IWebHostEnvironment environment,
+        string postgresConnectionString)
+    {
+        if (!environment.IsUnitTests())
+        {
+            services.AddHangfire(configuration => configuration
+                .SetDataCompatibilityLevel(CompatibilityLevel.Version_170)
+                .UseSimpleAssemblyNameTypeSerializer()
+                .UseRecommendedSerializerSettings()
+                .UsePostgreSqlStorage(postgresConnectionString));
+
+            services.AddHangfireServer();
+
+            services.AddSingleton<IHostedService, RegisterRecurringJobsHostedService>();
+        }
+
+        if (environment.IsProduction())
+        {
+            services.AddSingleton<IBackgroundJobScheduler, HangfireBackgroundJobScheduler>();
+        }
+        else
+        {
+            services.AddSingleton<IBackgroundJobScheduler, ExecuteImmediatelyJobScheduler>();
+        }
+
+        return services;
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/ServiceCollectionExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/ServiceCollectionExtensions.cs
@@ -1,0 +1,36 @@
+using System.Net.Http.Headers;
+using Microsoft.Extensions.Options;
+
+namespace TeacherIdentity.AuthServer.Services.DqtApi;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddDqtApi(
+        this IServiceCollection services,
+        IWebHostEnvironment environment,
+        IConfiguration configuration)
+    {
+        if (environment.IsProduction())
+        {
+            services.AddOptions<DqtApiOptions>()
+                .Bind(configuration.GetSection("DqtApi"))
+                .ValidateDataAnnotations()
+                .ValidateOnStart();
+
+            services
+                .AddSingleton<IDqtApiClient, DqtApiClient>()
+                .AddHttpClient<IDqtApiClient, DqtApiClient>((sp, httpClient) =>
+                {
+                    var options = sp.GetRequiredService<IOptions<DqtApiOptions>>();
+                    httpClient.BaseAddress = new Uri(options.Value.BaseAddress);
+                    httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", options.Value.ApiKey);
+                });
+        }
+        else
+        {
+            services.AddSingleton<IDqtApiClient, FakeDqtApiClient>();
+        }
+
+        return services;
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/Email/ServiceCollectionExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/Email/ServiceCollectionExtensions.cs
@@ -1,0 +1,30 @@
+using Notify.Client;
+
+namespace TeacherIdentity.AuthServer.Services.Email;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddEmail(
+        this IServiceCollection services,
+        IWebHostEnvironment environment,
+        IConfiguration configuration)
+    {
+        if (environment.IsProduction())
+        {
+            services.AddSingleton(new NotificationClient(configuration["NotifyApiKey"]));
+            services.AddSingleton<IEmailSender, NotifyEmailSender>();
+
+            // Use Hangfire for scheduling emails in the background (so we get retries etc.).
+            // As the implementation needs to be able to resolve itself we need two service registrations here;
+            // one for the interface (that decorates the 'base' notify implementation) and another for the concrete type.
+            services.Decorate<IEmailSender, BackgroundEmailSender>();
+            services.AddSingleton<BackgroundEmailSender>(sp => (BackgroundEmailSender)sp.GetRequiredService<IEmailSender>());
+        }
+        else
+        {
+            services.AddSingleton<IEmailSender, NoopEmailSender>();
+        }
+
+        return services;
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/EmailVerification/ServiceCollectionExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/EmailVerification/ServiceCollectionExtensions.cs
@@ -1,0 +1,35 @@
+namespace TeacherIdentity.AuthServer.Services.EmailVerification;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddEmailVerification(
+        this IServiceCollection services,
+        IWebHostEnvironment environment,
+        IConfiguration configuration)
+    {
+        services.AddTransient<IEmailVerificationService, EmailVerificationService>();
+
+        services.AddOptions<EmailVerificationOptions>()
+            .Bind(configuration.GetSection("EmailVerification"))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        services.AddOptions<RateLimitStoreOptions>()
+            .Bind(configuration.GetSection("EmailVerificationRateLimit"))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        services.AddSingleton<PinValidator>();
+
+        if (environment.IsProduction())
+        {
+            services.AddSingleton<IRateLimitStore, RateLimitStore>();
+        }
+        else
+        {
+            services.AddSingleton<IRateLimitStore, NoopRateLimitStore>();
+        }
+
+        return services;
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/ServiceCollectionExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/ServiceCollectionExtensions.cs
@@ -1,0 +1,25 @@
+using TeacherIdentity.AuthServer.Services.BackgroundJobs;
+using TeacherIdentity.AuthServer.Services.DqtApi;
+using TeacherIdentity.AuthServer.Services.Email;
+using TeacherIdentity.AuthServer.Services.EmailVerification;
+using TeacherIdentity.AuthServer.Services.TrnLookup;
+
+namespace TeacherIdentity.AuthServer.Services;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddAuthServerServices(
+        this IServiceCollection services,
+        IWebHostEnvironment environment,
+        IConfiguration configuration,
+        string postgresConnectionString)
+    {
+        return services
+            .AddBackgroundJobs(environment, postgresConnectionString)
+            .AddDqtApi(environment, configuration)
+            .AddEmail(environment, configuration)
+            .AddEmailVerification(environment, configuration)
+            .AddTrnLookup(configuration)
+            .AddSingleton<Redactor>();
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/TrnLookup/ServiceCollectionExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/TrnLookup/ServiceCollectionExtensions.cs
@@ -1,0 +1,18 @@
+namespace TeacherIdentity.AuthServer.Services.TrnLookup;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddTrnLookup(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.AddOptions<FindALostTrnIntegrationOptions>()
+            .Bind(configuration.GetSection("FindALostTrnIntegration"))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        services.AddTransient<FindALostTrnIntegrationHelper>();
+
+        return services;
+    }
+}


### PR DESCRIPTION
Our DI configuration in Program.cs is getting huge; this starts to move some of the configuration into extension methods that live with the related types and namespaces.