### PR TITLE
Remove the DQT API call to persist the UserId against the TRN

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Handlers/SetTeacherTrnHandler.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Handlers/SetTeacherTrnHandler.cs
@@ -3,24 +3,19 @@ using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Api.V1.Requests;
 using TeacherIdentity.AuthServer.Api.Validation;
 using TeacherIdentity.AuthServer.Models;
-using TeacherIdentity.AuthServer.Services.BackgroundJobs;
-using TeacherIdentity.AuthServer.Services.DqtApi;
 
 namespace TeacherIdentity.AuthServer.Api.V1.Handlers;
 
 public class SetTeacherTrnHandler : IRequestHandler<SetTeacherTrnRequest>
 {
     private readonly TeacherIdentityServerDbContext _dbContext;
-    private readonly IBackgroundJobScheduler _backgroundJobScheduler;
     private readonly IClock _clock;
 
     public SetTeacherTrnHandler(
         TeacherIdentityServerDbContext dbContext,
-        IBackgroundJobScheduler backgroundJobScheduler,
         IClock clock)
     {
         _dbContext = dbContext;
-        _backgroundJobScheduler = backgroundJobScheduler;
         _clock = clock;
     }
 
@@ -62,13 +57,6 @@ public class SetTeacherTrnHandler : IRequestHandler<SetTeacherTrnRequest>
         {
             throw new ErrorException(ErrorRegistry.TrnIsAssignedToAnotherUser());
         }
-
-        await _backgroundJobScheduler.Enqueue<IDqtApiClient>(
-            dqtApiClient => dqtApiClient.SetTeacherIdentityInfo(new DqtTeacherIdentityInfo()
-            {
-                Trn = user.Trn!,
-                UserId = request.UserId
-            }));
 
         return Unit.Value;
     }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/FakeDqtApiClient.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/FakeDqtApiClient.cs
@@ -40,8 +40,6 @@ public class FakeDqtApiClient : IDqtApiClient
         return result;
     }
 
-    public Task SetTeacherIdentityInfo(DqtTeacherIdentityInfo info) => Task.CompletedTask;
-
     public void SetTeacherInfo(TeacherInfo teacherInfo)
     {
         WithDatabaseFile(db => db.Teachers[teacherInfo.Trn] = teacherInfo);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/IDqtApiClient.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/IDqtApiClient.cs
@@ -3,5 +3,4 @@ namespace TeacherIdentity.AuthServer.Services.DqtApi;
 public interface IDqtApiClient
 {
     public Task<TeacherInfo?> GetTeacherByTrn(string trn);
-    public Task SetTeacherIdentityInfo(DqtTeacherIdentityInfo info);
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/SetTeacherTrnTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/SetTeacherTrnTests.cs
@@ -1,11 +1,9 @@
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Events;
 using TeacherIdentity.AuthServer.Oidc;
-using TeacherIdentity.AuthServer.Services.DqtApi;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Api.V1;
 
-[Collection(nameof(DisableParallelization))]  // Relies on mocks
 public class SetTeacherTrnTests : TestBase
 {
     public SetTeacherTrnTests(HostFixture hostFixture)
@@ -137,7 +135,7 @@ public class SetTeacherTrnTests : TestBase
 
     [Theory]
     [MemberData(nameof(PermittedScopes))]
-    public async Task Put_ValidRequest_UpdatesUserAndCallsDqtApiAndReturnsNoContent(string scope)
+    public async Task Put_ValidRequest_UpdatesUserAndReturnsNoContent(string scope)
     {
         // Arrange
         var httpClient = await CreateHttpClientWithToken(scope);
@@ -165,9 +163,6 @@ public class SetTeacherTrnTests : TestBase
             Assert.Equal(trn, user.Trn);
             Assert.Equal(Clock.UtcNow, user.Updated);
         });
-
-        HostFixture.DqtApiClient
-            .Verify(mock => mock.SetTeacherIdentityInfo(It.Is<DqtTeacherIdentityInfo>(x => x.UserId == user!.UserId && x.Trn == trn)), Times.Once);
 
         EventObserver.AssertEventsSaved(
             e =>

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnCallbackTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnCallbackTests.cs
@@ -1,7 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Events;
 using TeacherIdentity.AuthServer.Models;
-using TeacherIdentity.AuthServer.Services.DqtApi;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn;
 
@@ -182,9 +181,6 @@ public class TrnCallbackTests : TestBase
             Assert.Equal(Clock.UtcNow, user.Updated);
             Assert.Equal(Clock.UtcNow, user.LastSignedIn);
             Assert.Equal(UserType.Default, user.UserType);
-
-            var dqtApiCallExpectedTimes = hasTrn ? Times.Once() : Times.Never();
-            HostFixture.DqtApiClient.Verify(mock => mock.SetTeacherIdentityInfo(It.Is<DqtTeacherIdentityInfo>(x => x.UserId == user!.UserId && x.Trn == trn)), dqtApiCallExpectedTimes);
 
             var lookupState = await dbContext.JourneyTrnLookupStates.SingleAsync(s => s.JourneyId == authStateHelper.AuthenticationState.JourneyId);
             Assert.Equal(Clock.UtcNow, lookupState.Locked);


### PR DESCRIPTION
We will use web hooks in future if we want to store the user/contact association in DQT.