### PR TITLE
Persist how the TRN was associated with a User

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Handlers/SetTeacherTrnHandler.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Handlers/SetTeacherTrnHandler.cs
@@ -39,6 +39,7 @@ public class SetTeacherTrnHandler : IRequestHandler<SetTeacherTrnRequest>
         }
 
         user.Trn = request.Body.Trn;
+        user.TrnAssociationSource = TrnAssociationSource.Api;
         user.Updated = _clock.UtcNow;
 
         _dbContext.AddEvent(new Events.UserUpdatedEvent()

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Events/User.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Events/User.cs
@@ -11,6 +11,7 @@ public class User
     public required DateOnly? DateOfBirth { get; init; }
     public required UserType UserType { get; init; }
     public required string? Trn { get; init; }
+    public required TrnAssociationSource? TrnAssociationSource { get; init; }
     public required string[] StaffRoles { get; init; } = Array.Empty<string>();
 
     public static User FromModel(Models.User user) => new()
@@ -21,6 +22,7 @@ public class User
         LastName = user.LastName,
         StaffRoles = user.StaffRoles,
         Trn = user.Trn,
+        TrnAssociationSource = user.TrnAssociationSource,
         UserId = user.UserId,
         UserType = user.UserType
     };

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20221027131053_TrnAssociationSource.Designer.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20221027131053_TrnAssociationSource.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeacherIdentity.AuthServer.Models;
@@ -11,9 +12,10 @@ using TeacherIdentity.AuthServer.Models;
 namespace TeacherIdentity.AuthServer.Migrations
 {
     [DbContext(typeof(TeacherIdentityServerDbContext))]
-    partial class TeacherIdentityServerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20221027131053_TrnAssociationSource")]
+    partial class TrnAssociationSource
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20221027131053_TrnAssociationSource.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20221027131053_TrnAssociationSource.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeacherIdentity.AuthServer.Migrations
+{
+    public partial class TrnAssociationSource : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "trn_association_source",
+                table: "users",
+                type: "integer",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "trn_association_source",
+                table: "users");
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/Mappings/UserMapping.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/Mappings/UserMapping.cs
@@ -19,6 +19,7 @@ public class UserMapping : IEntityTypeConfiguration<User>
         builder.Property(u => u.CompletedTrnLookup);
         builder.Property(u => u.UserType).IsRequired();
         builder.Property(u => u.Trn).HasMaxLength(7).IsFixedLength();
+        builder.Property(u => u.TrnAssociationSource);
         builder.Property(u => u.StaffRoles).HasColumnType("varchar[]");
         builder.Property<bool>("is_deleted").IsRequired().HasDefaultValue(false);
         builder.HasQueryFilter(u => EF.Property<bool>(u, "is_deleted") == false);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/TrnAssociationSource.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/TrnAssociationSource.cs
@@ -1,0 +1,7 @@
+namespace TeacherIdentity.AuthServer.Models;
+
+public enum TrnAssociationSource
+{
+    Lookup = 0,
+    Api = 1
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/User.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/User.cs
@@ -17,5 +17,6 @@ public class User
     public DateTime? CompletedTrnLookup { get; set; }
     public UserType UserType { get; set; }
     public string? Trn { get; set; }
+    public TrnAssociationSource? TrnAssociationSource { get; set; }
     public string[] StaffRoles { get; set; } = Array.Empty<string>();
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnCallback.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnCallback.cshtml.cs
@@ -65,6 +65,7 @@ public class TrnCallbackModel : PageModel
             UserId = userId,
             UserType = UserType.Default,
             Trn = lookupState.Trn,
+            TrnAssociationSource = !string.IsNullOrEmpty(lookupState.Trn) ? TrnAssociationSource.Lookup : null,
             LastSignedIn = _clock.UtcNow
         };
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/SetTeacherTrnTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/SetTeacherTrnTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Oidc;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Api.V1;
@@ -161,6 +162,7 @@ public class SetTeacherTrnTests : TestBase
         {
             user = await dbContext.Users.SingleAsync(u => u.UserId == user.UserId);
             Assert.Equal(trn, user.Trn);
+            Assert.Equal(TrnAssociationSource.Api, user.TrnAssociationSource);
             Assert.Equal(Clock.UtcNow, user.Updated);
         });
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/TestData.CreateUser.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/TestData.CreateUser.cs
@@ -36,6 +36,7 @@ public partial class TestData
                 UserType = userType,
                 DateOfBirth = userType is UserType.Default ? DateOnly.FromDateTime(Faker.Identification.DateOfBirth()) : null,
                 Trn = hasTrn == true ? GenerateTrn() : null,
+                TrnAssociationSource = hasTrn == true ? TrnAssociationSource.Lookup : null,
                 Updated = _clock.UtcNow
             };
 


### PR DESCRIPTION
Until we have some notion of verification levels all we can do is store whether a TRN was associated with a user via TRN lookup (i.e. via Find) or whether it was associated via the API (i.e. via the Support UI).