### PR TITLE
Ensure we read PinGenerationResult and render the appropriate error page

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/ResendEmailConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/ResendEmailConfirmation.cshtml.cs
@@ -39,14 +39,20 @@ public class ResendEmailConfirmationModel : PageModel
 
         HttpContext.GetAuthenticationState().OnEmailSet(Email!);
 
-        var result = await _emailVerificationService.GeneratePin(Email!);
-        if (result.FailedReasons == PinGenerationFailedReasons.RateLimitExceeded)
+        var pinGenerationResult = await _emailVerificationService.GeneratePin(Email!);
+
+        if (pinGenerationResult.FailedReasons != PinGenerationFailedReasons.None)
         {
-            return new ViewResult()
+            if (pinGenerationResult.FailedReasons == PinGenerationFailedReasons.RateLimitExceeded)
             {
-                StatusCode = 429,
-                ViewName = "TooManyRequests"
-            };
+                return new ViewResult()
+                {
+                    StatusCode = 429,
+                    ViewName = "TooManyRequests"
+                };
+            }
+
+            throw new NotImplementedException($"Unknown {nameof(PinGenerationFailedReasons)}: '{pinGenerationResult.FailedReasons}'.");
         }
 
         return Redirect(_linkGenerator.EmailConfirmation());

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnInUse.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnInUse.cshtml.cs
@@ -51,7 +51,22 @@ public class TrnInUseModel : PageModel
         {
             if (verifyPinFailedReasons.ShouldGenerateAnotherCode())
             {
-                await _emailVerificationService.GeneratePin(Email!);
+                var pinGenerationResult = await _emailVerificationService.GeneratePin(Email!);
+
+                if (pinGenerationResult.FailedReasons != PinGenerationFailedReasons.None)
+                {
+                    if (pinGenerationResult.FailedReasons == PinGenerationFailedReasons.RateLimitExceeded)
+                    {
+                        return new ViewResult()
+                        {
+                            StatusCode = 429,
+                            ViewName = "TooManyRequests"
+                        };
+                    }
+
+                    throw new NotImplementedException($"Unknown {nameof(PinGenerationFailedReasons)}: '{pinGenerationResult.FailedReasons}'.");
+                }
+
                 ModelState.AddModelError(nameof(Code), "The security code has expired. New code sent.");
             }
             else


### PR DESCRIPTION
There were a few places where we were not checking `PinGenerationResult` - this fixes that.

Also makes the check on `PinGenerationResult` a little more robust so if we add additional reasons in future we won't see weird behaviour.