### PR TITLE
Don't override Email when resending verification email to TRN owner

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/ResendTrnOwnerEmailConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/ResendTrnOwnerEmailConfirmation.cshtml.cs
@@ -26,8 +26,6 @@ public class ResendTrnOwnerEmailConfirmationModel : PageModel
     {
         var email = HttpContext.GetAuthenticationState().TrnOwnerEmailAddress!;
 
-        HttpContext.GetAuthenticationState().OnEmailSet(email);
-
         var pinGenerationResult = await _emailVerificationService.GeneratePin(email!);
 
         if (pinGenerationResult.FailedReasons != PinGenerationFailedReasons.None)


### PR DESCRIPTION
This was getting us into an incorrect state where we have `AuthenticationState` with the email of the TRN-owning account & email verified = `true`, neither of which are correct.