### PR TITLE
Make FormUrlEncodedContentBuilder a little nicer to use

### DIFF
--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AddStaffUserTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AddStaffUserTests.cs
@@ -61,12 +61,13 @@ public class AddStaffUserTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, "/admin/staff/new")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Email", email)
-                .Add("FirstName", firstName)
-                .Add("LastName", lastName)
-                .Add("StaffRoles", role1)
-                .Add("StaffRoles", role2)
-                .ToContent()
+            {
+                { "Email", email },
+                { "FirstName", firstName },
+                { "LastName", lastName },
+                { "StaffRoles", role1 },
+                { "StaffRoles", role2 }
+            }
         };
 
         // Act
@@ -89,12 +90,13 @@ public class AddStaffUserTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, "/admin/staff/new")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Email", email)
-                .Add("FirstName", firstName)
-                .Add("LastName", lastName)
-                .Add("StaffRoles", role1)
-                .Add("StaffRoles", role2)
-                .ToContent()
+            {
+                { "Email", email },
+                { "FirstName", firstName },
+                { "LastName", lastName },
+                { "StaffRoles", role1 },
+                { "StaffRoles", role2 }
+            }
         };
 
         // Act

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AddWebHookTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AddWebHookTests.cs
@@ -57,9 +57,10 @@ public class AddWebHookTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, "/admin/webhooks/new")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Endpoint", endpoint)
-                .Add("Enabled", enabled)
-                .ToContent()
+            {
+                { "Endpoint", endpoint },
+                { "Enabled", enabled }
+            }
         };
 
         // Act

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/EditWebHookTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/EditWebHookTests.cs
@@ -83,9 +83,10 @@ public class EditWebHookTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/webhooks/{webHookId}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Endpoint", endpoint)
-                .Add("Enabled", enabled)
-                .ToContent()
+            {
+                { "Endpoint", endpoint },
+                { "Enabled", enabled }
+            }
         };
 
         // Act
@@ -106,9 +107,10 @@ public class EditWebHookTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/webhooks/{webHookId}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Endpoint", endpoint)
-                .Add("Enabled", enabled)
-                .ToContent()
+            {
+                { "Endpoint", endpoint },
+                { "Enabled", enabled }
+            }
         };
 
         // Act
@@ -152,10 +154,11 @@ public class EditWebHookTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/webhooks/{webHookId}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Endpoint", endpoint)
-                .Add("Enabled", enabled)
-                .Add("RegenerateSecret", false.ToString())
-                .ToContent()
+            {
+                { "Endpoint", endpoint },
+                { "Enabled", enabled },
+                { "RegenerateSecret", false.ToString() }
+            }
         };
 
         // Act
@@ -193,10 +196,11 @@ public class EditWebHookTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/webhooks/{webHookId}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Endpoint", endpoint)
-                .Add("Enabled", enabled)
-                .Add("RegenerateSecret", true.ToString())
-                .ToContent()
+            {
+                { "Endpoint", endpoint },
+                { "Enabled", enabled },
+                { "RegenerateSecret", true.ToString() }
+            }
         };
 
         // Act

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Authenticated/UpdateEmail/ConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Authenticated/UpdateEmail/ConfirmationTests.cs
@@ -78,8 +78,9 @@ public class ConfirmationTests : TestBase
             $"/update-email/confirmation?returnUrl={UrlEncode(returnUrl)}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pinResult.Pin!)
-                .ToContent()
+            {
+                { "Code", pinResult.Pin! }
+            }
         };
 
         // Act
@@ -110,8 +111,9 @@ public class ConfirmationTests : TestBase
             $"/update-email/confirmation?email={UrlEncode(protectedEmail.EncryptedValue)}&returnUrl={UrlEncode(returnUrl)}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pin)
-                .ToContent()
+            {
+                { "Code", pin }
+            }
         };
 
         // Act
@@ -140,8 +142,9 @@ public class ConfirmationTests : TestBase
             $"/update-email/confirmation?email={UrlEncode(protectedEmail.EncryptedValue)}&returnUrl={UrlEncode(returnUrl)}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pin)
-                .ToContent()
+            {
+                { "Code", pin }
+            }
         };
 
         // Act
@@ -170,8 +173,9 @@ public class ConfirmationTests : TestBase
             $"/update-email/confirmation?email={UrlEncode(protectedEmail.EncryptedValue)}&returnUrl={UrlEncode(returnUrl)}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pin)
-                .ToContent()
+            {
+                { "Code", pin }
+            }
         };
 
         // Act
@@ -200,8 +204,9 @@ public class ConfirmationTests : TestBase
             $"/update-email/confirmation?email={UrlEncode(protectedEmail.EncryptedValue)}&returnUrl={UrlEncode(returnUrl)}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pin)
-                .ToContent()
+            {
+                { "Code", pin }
+            }
         };
 
         // Act
@@ -234,8 +239,9 @@ public class ConfirmationTests : TestBase
             $"/update-email/confirmation?email={UrlEncode(protectedEmail.EncryptedValue)}&returnUrl={UrlEncode(returnUrl)}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pinResult.Pin!)
-                .ToContent()
+            {
+                { "Code", pinResult.Pin! }
+            }
         };
 
         // Act
@@ -271,8 +277,9 @@ public class ConfirmationTests : TestBase
             $"/update-email/confirmation?email={UrlEncode(protectedEmail.EncryptedValue)}&returnUrl={UrlEncode(returnUrl)}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pinResult.Pin!)
-                .ToContent()
+            {
+                { "Code", pinResult.Pin! }
+            }
         };
 
         // Act
@@ -305,8 +312,9 @@ public class ConfirmationTests : TestBase
             $"/update-email/confirmation?email={UrlEncode(protectedEmail.EncryptedValue)}&returnUrl={UrlEncode(returnUrl)}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pinResult.Pin!)
-                .ToContent()
+            {
+                { "Code", pinResult.Pin! }
+            }
         };
 
         // Act

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Authenticated/UpdateEmail/IndexTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Authenticated/UpdateEmail/IndexTests.cs
@@ -44,8 +44,9 @@ public class IndexTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/update-email?returnUrl={UrlEncoder.Default.Encode(returnUrl)}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Email", newEmail)
-                .ToContent()
+            {
+                { "Email", newEmail }
+            }
         };
 
         // Act
@@ -70,8 +71,9 @@ public class IndexTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/update-email?returnUrl={UrlEncoder.Default.Encode(returnUrl)}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Email", newEmail)
-                .ToContent()
+            {
+                { "Email", newEmail }
+            }
         };
 
         // Act
@@ -93,8 +95,9 @@ public class IndexTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/update-email?returnUrl={UrlEncoder.Default.Encode(returnUrl)}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Email", user.EmailAddress)
-                .ToContent()
+            {
+                { "Email", user.EmailAddress }
+            }
         };
 
         // Act
@@ -118,8 +121,9 @@ public class IndexTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/update-email?returnUrl={UrlEncoder.Default.Encode(returnUrl)}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Email", newEmail)
-                .ToContent()
+            {
+                { "Email", newEmail }
+            }
         };
 
         // Act
@@ -150,8 +154,9 @@ public class IndexTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/update-email?returnUrl={UrlEncoder.Default.Encode(returnUrl)}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Email", newEmail)
-                .ToContent()
+            {
+                { "Email", newEmail }
+            }
         };
 
         // Act

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Authenticated/UpdateNameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Authenticated/UpdateNameTests.cs
@@ -51,9 +51,10 @@ public class UpdateNameTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/update-name?returnUrl={UrlEncoder.Default.Encode(returnUrl)}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("FirstName", firstName)
-                .Add("LastName", lastName)
-                .ToContent()
+            {
+                { "FirstName", firstName },
+                { "LastName", lastName }
+            }
         };
 
         // Act
@@ -77,9 +78,10 @@ public class UpdateNameTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/update-name?returnUrl={UrlEncoder.Default.Encode(returnUrl)}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("FirstName", firstName)
-                .Add("LastName", lastName)
-                .ToContent()
+            {
+                { "FirstName", firstName },
+                { "LastName", lastName }
+            }
         };
 
         // Act

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
@@ -73,8 +73,9 @@ public class EmailConfirmationTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pin)
-                .ToContent()
+            {
+                { "Code", pin }
+            }
         };
 
         // Act
@@ -95,8 +96,9 @@ public class EmailConfirmationTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pin)
-                .ToContent()
+            {
+                { "Code", pin }
+            }
         };
 
         // Act
@@ -117,8 +119,9 @@ public class EmailConfirmationTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pin)
-                .ToContent()
+            {
+                { "Code", pin }
+            }
         };
 
         // Act
@@ -139,8 +142,9 @@ public class EmailConfirmationTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pin)
-                .ToContent()
+            {
+                { "Code", pin }
+            }
         };
 
         // Act
@@ -165,8 +169,9 @@ public class EmailConfirmationTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pinResult.Pin!)
-                .ToContent()
+            {
+                { "Code", pinResult.Pin! }
+            }
         };
 
         // Act
@@ -194,8 +199,9 @@ public class EmailConfirmationTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pinResult.Pin!)
-                .ToContent()
+            {
+                { "Code", pinResult.Pin! }
+            }
         };
 
         // Act
@@ -220,8 +226,9 @@ public class EmailConfirmationTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pinResult.Pin!)
-                .ToContent()
+            {
+                { "Code", pinResult.Pin! }
+            }
         };
 
         // Act
@@ -250,8 +257,9 @@ public class EmailConfirmationTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pinResult.Pin!)
-                .ToContent()
+            {
+                { "Code", pinResult.Pin! }
+            }
         };
 
         // Act
@@ -280,8 +288,9 @@ public class EmailConfirmationTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pinResult.Pin!)
-                .ToContent()
+            {
+                { "Code", pinResult.Pin! }
+            }
         };
 
         // Act
@@ -305,8 +314,9 @@ public class EmailConfirmationTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pinResult.Pin!)
-                .ToContent()
+            {
+                { "Code", pinResult.Pin! }
+            }
         };
 
         // Act
@@ -329,8 +339,9 @@ public class EmailConfirmationTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pinResult.Pin!)
-                .ToContent()
+            {
+                { "Code", pinResult.Pin! }
+            }
         };
 
         // Act
@@ -358,8 +369,9 @@ public class EmailConfirmationTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pinResult.Pin!)
-                .ToContent()
+            {
+                { "Code", pinResult.Pin! }
+            }
         };
 
         // Act
@@ -382,8 +394,9 @@ public class EmailConfirmationTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pinResult.Pin!)
-                .ToContent()
+            {
+                { "Code", pinResult.Pin! }
+            }
         };
 
         // Act

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailTests.cs
@@ -44,8 +44,9 @@ public class EmailTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Email", email)
-                .ToContent()
+            {
+                { "Email", email }
+            }
         };
 
         // Act
@@ -63,7 +64,7 @@ public class EmailTests : TestBase
         var authStateHelper = CreateAuthenticationStateHelper();
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email?{authStateHelper.ToQueryParam()}")
         {
-            Content = new FormUrlEncodedContentBuilder().ToContent()
+            Content = new FormUrlEncodedContentBuilder()
         };
 
         // Act
@@ -81,8 +82,9 @@ public class EmailTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Email", "xxx")
-                .ToContent()
+            {
+                { "Email", "xxx" }
+            }
         };
 
         // Act
@@ -109,8 +111,9 @@ public class EmailTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Email", email)
-                .ToContent()
+            {
+                { "Email", email }
+            }
         };
 
         // Act

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/ResendEmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/ResendEmailConfirmationTests.cs
@@ -82,8 +82,9 @@ public class ResendEmailConfirmationTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/resend-email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Email", differentEmail)
-                .ToContent()
+            {
+                { "Email", differentEmail }
+            }
         };
 
         // Act
@@ -108,8 +109,9 @@ public class ResendEmailConfirmationTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/resend-email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Email", email)
-                .ToContent()
+            {
+                { "Email", email }
+            }
         };
 
         // Act
@@ -130,8 +132,9 @@ public class ResendEmailConfirmationTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/resend-email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Email", differentEmail)
-                .ToContent()
+            {
+                { "Email", differentEmail }
+            }
         };
 
         // Act
@@ -151,8 +154,9 @@ public class ResendEmailConfirmationTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/resend-email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Email", differentEmail)
-                .ToContent()
+            {
+                { "Email", differentEmail }
+            }
         };
 
         // Act
@@ -173,8 +177,9 @@ public class ResendEmailConfirmationTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/resend-email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Email", differentEmail)
-                .ToContent()
+            {
+                { "Email", differentEmail }
+            }
         };
 
         // Act
@@ -194,8 +199,9 @@ public class ResendEmailConfirmationTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/resend-email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Email", differentEmail)
-                .ToContent()
+            {
+                { "Email", differentEmail }
+            }
         };
 
         // Act

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnInUseChooseEmailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnInUseChooseEmailTests.cs
@@ -164,8 +164,9 @@ public class TrnInUseChooseEmailTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/choose-email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Email", email)
-                .ToContent()
+            {
+                { "Email", email }
+            }
         };
 
         // Act
@@ -191,7 +192,6 @@ public class TrnInUseChooseEmailTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/choose-email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .ToContent()
         };
 
         // Act
@@ -217,8 +217,9 @@ public class TrnInUseChooseEmailTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/choose-email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Email", submittedEmail)
-                .ToContent()
+            {
+                { "Email", submittedEmail }
+            }
         };
 
         // Act
@@ -246,8 +247,9 @@ public class TrnInUseChooseEmailTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/choose-email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Email", chosenEmail)
-                .ToContent()
+            {
+                { "Email", chosenEmail }
+            }
         };
 
         // Act

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnInUseTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnInUseTests.cs
@@ -167,8 +167,9 @@ public class TrnInUseTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/different-email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pin)
-                .ToContent()
+            {
+                { "Code", pin }
+            }
         };
 
         // Act
@@ -194,8 +195,9 @@ public class TrnInUseTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/different-email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pin)
-                .ToContent()
+            {
+                { "Code", pin }
+            }
         };
 
         // Act
@@ -218,8 +220,9 @@ public class TrnInUseTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/different-email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pin)
-                .ToContent()
+            {
+                { "Code", pin }
+            }
         };
 
         // Act
@@ -242,8 +245,9 @@ public class TrnInUseTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/different-email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pin)
-                .ToContent()
+            {
+                { "Code", pin }
+            }
         };
 
         // Act
@@ -266,8 +270,9 @@ public class TrnInUseTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/different-email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pin)
-                .ToContent()
+            {
+                { "Code", pin }
+            }
         };
 
         // Act
@@ -293,8 +298,9 @@ public class TrnInUseTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/different-email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pinResult.Pin!)
-                .ToContent()
+            {
+                { "Code", pinResult.Pin! }
+            }
         };
 
         // Act
@@ -324,8 +330,9 @@ public class TrnInUseTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/different-email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pinResult.Pin!)
-                .ToContent()
+            {
+                { "Code", pinResult.Pin! }
+            }
         };
 
         // Act
@@ -351,8 +358,9 @@ public class TrnInUseTests : TestBase
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/different-email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
-                .Add("Code", pinResult.Pin!)
-                .ToContent()
+            {
+                { "Code", pinResult.Pin! }
+            }
         };
 
         // Act

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/FormUrlEncodedContentBuilder.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/FormUrlEncodedContentBuilder.cs
@@ -1,6 +1,8 @@
+using System.Collections;
+
 namespace TeacherIdentity.AuthServer.Tests;
 
-public class FormUrlEncodedContentBuilder
+public class FormUrlEncodedContentBuilder : IEnumerable<KeyValuePair<string, string?>>
 {
     private readonly List<KeyValuePair<string, string?>> _values;
 
@@ -38,5 +40,11 @@ public class FormUrlEncodedContentBuilder
         return this;
     }
 
-    public FormUrlEncodedContent ToContent() => new(_values);
+    public static implicit operator FormUrlEncodedContent(FormUrlEncodedContentBuilder builder) => builder.Build();
+
+    public FormUrlEncodedContent Build() => new(_values);
+
+    public IEnumerator<KeyValuePair<string, string?>> GetEnumerator() => _values.GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 }


### PR DESCRIPTION
Remove the need to call `Build()` and support initializer syntax.