### PR TITLE
Remove RequestClientIpProvider from DbFixture

### DIFF
--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/DbFixture.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/DbFixture.cs
@@ -24,7 +24,6 @@ public class DbFixture : IAsyncLifetime
     public TestData TestData => Services.GetRequiredService<TestData>();
 
     public TeacherIdentityServerDbContext GetDbContext() => Services.GetRequiredService<TeacherIdentityServerDbContext>();
-    public IRequestClientIpProvider RequestClientIpProvider => Services.GetRequiredService<IRequestClientIpProvider>();
 
     public async Task InitializeAsync()
     {
@@ -47,7 +46,6 @@ public class DbFixture : IAsyncLifetime
         services.AddSingleton<TestData>();
         services.AddSingleton<IClock, TestClock>();
         services.AddSingleton<IEventObserver, NoopEventObserver>();
-        services.AddSingleton<IRequestClientIpProvider, TestRequestClientIpProvider>();
 
         return services.BuildServiceProvider();
     }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Services/EmailVerificationServiceTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Services/EmailVerificationServiceTests.cs
@@ -6,6 +6,7 @@ using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Oidc;
 using TeacherIdentity.AuthServer.Services.Email;
 using TeacherIdentity.AuthServer.Services.EmailVerification;
+using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
 namespace TeacherIdentity.AuthServer.Tests.Services;
 
@@ -30,7 +31,8 @@ public class EmailVerificationServiceTests : IClassFixture<DbFixture>
         var clock = new TestClock();
         var currentClientProviderMock = new Mock<ICurrentClientProvider>();
         var rateLimiter = new Mock<IRateLimitStore>();
-        var service = CreateEmailConfirmationService(dbContext, emailSenderMock.Object, clock, currentClientProviderMock.Object, rateLimiter.Object, _dbFixture.RequestClientIpProvider);
+        var requestClientIpProvider = new TestRequestClientIpProvider();
+        var service = CreateEmailConfirmationService(dbContext, emailSenderMock.Object, clock, currentClientProviderMock.Object, rateLimiter.Object, requestClientIpProvider);
 
         var currentClientDisplayName = "Test app";
         currentClientProviderMock.Setup(mock => mock.GetCurrentClient()).ReturnsAsync(new Application() { DisplayName = currentClientDisplayName });
@@ -93,7 +95,8 @@ public class EmailVerificationServiceTests : IClassFixture<DbFixture>
         var clock = new TestClock();
         var currentClientProviderMock = new Mock<ICurrentClientProvider>();
         var rateLimiter = new Mock<IRateLimitStore>();
-        var service = CreateEmailConfirmationService(dbContext, emailSenderMock.Object, clock, currentClientProviderMock.Object, rateLimiter.Object, _dbFixture.RequestClientIpProvider);
+        var requestClientIpProvider = new TestRequestClientIpProvider();
+        var service = CreateEmailConfirmationService(dbContext, emailSenderMock.Object, clock, currentClientProviderMock.Object, rateLimiter.Object, requestClientIpProvider);
 
         var email = Faker.Internet.Email();
 
@@ -117,7 +120,8 @@ public class EmailVerificationServiceTests : IClassFixture<DbFixture>
         var currentClientProviderMock = new Mock<ICurrentClientProvider>();
         var rateLimiter = new Mock<IRateLimitStore>();
         rateLimiter.Setup(x => x.IsClientIpBlockedForPinVerification(It.IsAny<string>())).Returns(Task.FromResult(true));
-        var service = CreateEmailConfirmationService(dbContext, emailSenderMock.Object, clock, currentClientProviderMock.Object, rateLimiter.Object, _dbFixture.RequestClientIpProvider);
+        var requestClientIpProvider = new TestRequestClientIpProvider();
+        var service = CreateEmailConfirmationService(dbContext, emailSenderMock.Object, clock, currentClientProviderMock.Object, rateLimiter.Object, requestClientIpProvider);
 
         var email = Faker.Internet.Email();
 
@@ -140,7 +144,8 @@ public class EmailVerificationServiceTests : IClassFixture<DbFixture>
         var clock = new TestClock();
         var currentClientProviderMock = new Mock<ICurrentClientProvider>();
         var rateLimiter = new Mock<IRateLimitStore>();
-        var service = CreateEmailConfirmationService(dbContext, emailSenderMock.Object, clock, currentClientProviderMock.Object, rateLimiter.Object, _dbFixture.RequestClientIpProvider);
+        var requestClientIpProvider = new TestRequestClientIpProvider();
+        var service = CreateEmailConfirmationService(dbContext, emailSenderMock.Object, clock, currentClientProviderMock.Object, rateLimiter.Object, requestClientIpProvider);
 
         var email = Faker.Internet.Email();
         var pinResult = await service.GeneratePin(email);
@@ -163,7 +168,8 @@ public class EmailVerificationServiceTests : IClassFixture<DbFixture>
         var clock = new TestClock();
         var currentClientProviderMock = new Mock<ICurrentClientProvider>();
         var rateLimiter = new Mock<IRateLimitStore>();
-        var service = CreateEmailConfirmationService(dbContext, emailSenderMock.Object, clock, currentClientProviderMock.Object, rateLimiter.Object, _dbFixture.RequestClientIpProvider);
+        var requestClientIpProvider = new TestRequestClientIpProvider();
+        var service = CreateEmailConfirmationService(dbContext, emailSenderMock.Object, clock, currentClientProviderMock.Object, rateLimiter.Object, requestClientIpProvider);
 
         var email = Faker.Internet.Email();
         var anotherEmail = Faker.Internet.Email();
@@ -185,7 +191,8 @@ public class EmailVerificationServiceTests : IClassFixture<DbFixture>
         var clock = new TestClock();
         var currentClientProviderMock = new Mock<ICurrentClientProvider>();
         var rateLimiter = new Mock<IRateLimitStore>();
-        var service = CreateEmailConfirmationService(dbContext, emailSenderMock.Object, clock, currentClientProviderMock.Object, rateLimiter.Object, _dbFixture.RequestClientIpProvider);
+        var requestClientIpProvider = new TestRequestClientIpProvider();
+        var service = CreateEmailConfirmationService(dbContext, emailSenderMock.Object, clock, currentClientProviderMock.Object, rateLimiter.Object, requestClientIpProvider);
 
         var email = Faker.Internet.Email();
         var pinResult = await service.GeneratePin(email);
@@ -217,7 +224,8 @@ public class EmailVerificationServiceTests : IClassFixture<DbFixture>
             PinGenerationMaxFailures = 5,
             PinGenerationTimeoutSeconds = 120
         });
-        var service = CreateEmailConfirmationService(dbContext, emailSenderMock.Object, clock, currentClientProviderMock.Object, rateLimiter.Object, _dbFixture.RequestClientIpProvider);
+        var requestClientIpProvider = new TestRequestClientIpProvider();
+        var service = CreateEmailConfirmationService(dbContext, emailSenderMock.Object, clock, currentClientProviderMock.Object, rateLimiter.Object, requestClientIpProvider);
 
         var email = Faker.Internet.Email();
         var pinResult = await service.GeneratePin(email);


### PR DESCRIPTION
The services on `DbFixture` are intended to be only those required for the Db infrastructure to work.