### PR TITLE
Fix sending updated name/email to client during sign in

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/EmailConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/EmailConfirmation.cshtml.cs
@@ -100,8 +100,8 @@ public class EmailConfirmationModel : PageModel
             return new ForbidResult(authenticationScheme: CookieAuthenticationDefaults.AuthenticationScheme);
         }
 
-        // We don't support registering Staff users
-        if (permittedUserTypes.Length == 1 && permittedUserTypes.Single() == UserType.Staff && user is null)
+        // We only support registering users with the TRN requirement currently
+        if (user is null && !authenticationState.UserRequirements.HasFlag(UserRequirements.TrnHolder))
         {
             return new ForbidResult(authenticationScheme: CookieAuthenticationDefaults.AuthenticationScheme);
         }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/EmailConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/EmailConfirmation.cshtml.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel.DataAnnotations;
-using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -97,13 +96,13 @@ public class EmailConfirmationModel : PageModel
         // If the UserType is not allowed then return an error
         if (user is not null && !permittedUserTypes.Contains(user.UserType))
         {
-            return new ForbidResult(authenticationScheme: CookieAuthenticationDefaults.AuthenticationScheme);
+            return new ForbidResult();
         }
 
         // We only support registering users with the TRN requirement currently
         if (user is null && !authenticationState.UserRequirements.HasFlag(UserRequirements.TrnHolder))
         {
-            return new ForbidResult(authenticationScheme: CookieAuthenticationDefaults.AuthenticationScheme);
+            return new ForbidResult();
         }
 
         authenticationState.OnEmailVerified(user);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
@@ -105,7 +105,7 @@ public class Program
             options.DefaultButtonPreventDoubleClick = true;
         });
 
-        builder.Services.AddAuthentication()
+        builder.Services.AddAuthentication(options => options.DefaultForbidScheme = CookieAuthenticationDefaults.AuthenticationScheme)
             .AddCookie(options =>
             {
                 options.Cookie.Name = "tis-auth";

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/HostFixture.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/HostFixture.cs
@@ -94,7 +94,10 @@ public class HostFixture : IAsyncLifetime
 
         _playright = await Playwright.CreateAsync();
 
-        var browserOptions = new BrowserTypeLaunchOptions();
+        var browserOptions = new BrowserTypeLaunchOptions()
+        {
+            Timeout = 10000
+        };
 
         if (Debugger.IsAttached)
         {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/UpdateDetails.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/UpdateDetails.cs
@@ -1,0 +1,179 @@
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.EndToEndTests;
+
+public class UpdateDetails : IClassFixture<HostFixture>
+{
+    private readonly HostFixture _hostFixture;
+
+    public UpdateDetails(HostFixture hostFixture)
+    {
+        _hostFixture = hostFixture;
+    }
+
+    [Fact]
+    public async Task UpdateNameWithinOAuthFlow()
+    {
+        var email = Faker.Internet.Email();
+        var firstName = Faker.Name.First();
+        var lastName = Faker.Name.Last();
+
+        var newFirstName = Faker.Name.First();
+        var newLastName = Faker.Name.Last();
+
+        {
+            using var scope = _hostFixture.AuthServerServices.GetRequiredService<IServiceScopeFactory>().CreateScope();
+            using var dbContext = scope.ServiceProvider.GetRequiredService<TeacherIdentityServerDbContext>();
+
+            var userId = Guid.NewGuid();
+
+            dbContext.Users.Add(new User()
+            {
+                Created = DateTime.UtcNow,
+                EmailAddress = email,
+                FirstName = firstName,
+                LastName = lastName,
+                UserId = userId,
+                UserType = UserType.Default,
+                DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
+                CompletedTrnLookup = DateTime.UtcNow,
+                Updated = DateTime.UtcNow
+            });
+
+            await dbContext.SaveChangesAsync();
+        }
+
+        await using var context = await _hostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        // Test client app
+
+        await page.GotoAsync("/");
+        await page.ClickAsync("text=Profile");
+
+        // Fill in the sign in form (email + PIN)
+
+        await page.FillAsync("text=Enter your email address", email);
+        await page.ClickAsync("button:has-text('Continue')");
+
+        var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
+        await page.FillAsync("text=Enter your code", pin);
+        await page.ClickAsync("button:has-text('Continue')");
+
+        // Confirm your details page
+
+        await page.WaitForSelectorAsync("h1:has-text('Confirm your details')");
+        await page.ClickAsync("a:has-text('Update details')");
+
+        // Update your details page
+
+        await page.WaitForSelectorAsync("h1:has-text('Update your details')");
+        await page.ClickAsync("a:right-of(:text('Preferred name'))");
+
+        // Update your preferred name page
+
+        await page.WaitForSelectorAsync("h1:has-text('Update your preferred name')");
+        await page.FillAsync("text=Preferred first name", newFirstName);
+        await page.FillAsync("text=Preferred last name", newLastName);
+        await page.ClickAsync("button:has-text('Continue')");
+
+        // Confirm your details
+
+        await page.WaitForSelectorAsync("h1:has-text('Confirm your details')");
+        await page.ClickAsync("button:has-text('Continue')");
+
+        // Test Client app
+
+        var clientAppHost = new Uri(HostFixture.ClientBaseUrl).Host;
+        var pageUrlHost = new Uri(page.Url).Host;
+        Assert.Equal(clientAppHost, pageUrlHost);
+
+        Assert.Equal(newFirstName, await page.InnerTextAsync("data-testid=first-name"));
+        Assert.Equal(newLastName, await page.InnerTextAsync("data-testid=last-name"));
+    }
+
+    [Fact]
+    public async Task UpdateEmailWithinOAuthFlow()
+    {
+        var email = Faker.Internet.Email();
+        var firstName = Faker.Name.First();
+        var lastName = Faker.Name.Last();
+
+        var newEmail = Faker.Internet.Email();
+
+        {
+            using var scope = _hostFixture.AuthServerServices.GetRequiredService<IServiceScopeFactory>().CreateScope();
+            using var dbContext = scope.ServiceProvider.GetRequiredService<TeacherIdentityServerDbContext>();
+
+            var userId = Guid.NewGuid();
+
+            dbContext.Users.Add(new User()
+            {
+                Created = DateTime.UtcNow,
+                EmailAddress = email,
+                FirstName = firstName,
+                LastName = lastName,
+                UserId = userId,
+                UserType = UserType.Default,
+                DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
+                CompletedTrnLookup = DateTime.UtcNow,
+                Updated = DateTime.UtcNow
+            });
+
+            await dbContext.SaveChangesAsync();
+        }
+
+        await using var context = await _hostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        // Test client app
+
+        await page.GotoAsync("/");
+        await page.ClickAsync("text=Profile");
+
+        // Fill in the sign in form (email + PIN)
+
+        await page.FillAsync("text=Enter your email address", email);
+        await page.ClickAsync("button:has-text('Continue')");
+
+        var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
+        await page.FillAsync("text=Enter your code", pin);
+        await page.ClickAsync("button:has-text('Continue')");
+
+        // Confirm your details page
+
+        await page.WaitForSelectorAsync("h1:has-text('Confirm your details')");
+        await page.ClickAsync("a:has-text('Update details')");
+
+        // Update your details page
+
+        await page.WaitForSelectorAsync("h1:has-text('Update your details')");
+        await page.ClickAsync($"a:right-of(:text('{email}'))");
+
+        // Update your email page
+
+        await page.WaitForSelectorAsync("h1:has-text('Change your email address')");
+        await page.FillAsync("text=Enter your new email address", newEmail);
+        await page.ClickAsync("button:has-text('Continue')");
+
+        // Confirm your email address page
+
+        await page.WaitForSelectorAsync("h1:has-text('Confirm your email address')");
+        pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
+        await page.FillAsync("text=Enter your code", pin);
+        await page.ClickAsync("button:has-text('Continue')");
+
+        // Confirm your details page
+
+        await page.WaitForSelectorAsync("h1:has-text('Confirm your details')");
+        await page.ClickAsync("button:has-text('Continue')");
+
+        // Test Client app
+
+        var clientAppHost = new Uri(HostFixture.ClientBaseUrl).Host;
+        var pageUrlHost = new Uri(page.Url).Host;
+        Assert.Equal(clientAppHost, pageUrlHost);
+
+        Assert.Equal(newEmail, await page.InnerTextAsync("data-testid=email"));
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Infrastructure/TestAuthenticationHandler.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Infrastructure/TestAuthenticationHandler.cs
@@ -7,26 +7,18 @@ using TeacherIdentity.AuthServer.Models;
 
 namespace TeacherIdentity.AuthServer.Tests.Infrastructure;
 
-public class TestAuthenticationHandler : AuthenticationHandler<AuthenticationSchemeOptions>
+public class TestAuthenticationHandler : CookieAuthenticationHandler
 {
     private readonly CurrentUserIdContainer _currentUserIdContainer;
 
     public TestAuthenticationHandler(
         CurrentUserIdContainer currentUserIdContainer,
-        IOptionsMonitor<AuthenticationSchemeOptions> options,
+        IOptionsMonitor<CookieAuthenticationOptions> options,
         ILoggerFactory logger,
         UrlEncoder encoder,
-        ISystemClock clock)
-        : base(options, logger, encoder, clock)
+        ISystemClock clock) : base(options, logger, encoder, clock)
     {
         _currentUserIdContainer = currentUserIdContainer;
-    }
-
-    protected override Task InitializeHandlerAsync()
-    {
-        Options.ForwardChallenge = CookieAuthenticationDefaults.AuthenticationScheme;
-
-        return base.InitializeHandlerAsync();
     }
 
     protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
@@ -42,14 +34,7 @@ public class TestAuthenticationHandler : AuthenticationHandler<AuthenticationSch
             return AuthenticateResult.Success(new AuthenticationTicket(principal, Scheme.Name));
         }
 
-        return AuthenticateResult.NoResult();
-    }
-
-    protected override Task HandleForbiddenAsync(AuthenticationProperties properties)
-    {
-        // Allow the cookies handler to own handle this
-
-        return Task.CompletedTask;
+        return await base.HandleAuthenticateAsync();
     }
 }
 


### PR DESCRIPTION
Since claims are attached to an authorization code before a user changes their name and/or email, the user data received by the client after sign in contained stale values. We fix that here by re-signing in a user and redirecting back to the `authorize` endpoint, which re-assigns claims based on the signed in user.

To make this work in tests was problematic because of the custom `Test` scheme we were using to short-circuit cookie auth. This has been removed and replaced a wrapper around the standard cookie auth handler so we can assign the current user from a test in the same way.