### PR TITLE
Fix up Spy so it works better with multiple instances of the spied type

### DIFF
--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Authenticated/UpdateEmail/ConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Authenticated/UpdateEmail/ConfirmationTests.cs
@@ -228,7 +228,7 @@ public class ConfirmationTests : TestBase
         var pinResult = await emailVerificationService.GeneratePin(newEmail);
         Assert.True(pinResult.Succeeded);
         Clock.AdvanceBy(TimeSpan.FromHours(1));
-        Spy.Get(emailVerificationService).Reset();
+        Spy.Get<IEmailVerificationService>().Reset();
 
         var protectedEmail = HostFixture.Services.GetRequiredService<ProtectedStringFactory>().CreateFromPlainValue(newEmail);
 
@@ -266,7 +266,7 @@ public class ConfirmationTests : TestBase
         var pinResult = await emailVerificationService.GeneratePin(newEmail);
         Assert.True(pinResult.Succeeded);
         Clock.AdvanceBy(TimeSpan.FromHours(2) + TimeSpan.FromSeconds(emailVerificationOptions.Value.PinLifetimeSeconds));
-        Spy.Get(emailVerificationService).Reset();
+        Spy.Get<IEmailVerificationService>().Reset();
 
         var protectedEmail = HostFixture.Services.GetRequiredService<ProtectedStringFactory>().CreateFromPlainValue(newEmail);
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
@@ -163,7 +163,7 @@ public class EmailConfirmationTests : TestBase
         var emailVerificationService = HostFixture.Services.GetRequiredService<IEmailVerificationService>();
         var pinResult = await emailVerificationService.GeneratePin(email);
         Clock.AdvanceBy(TimeSpan.FromHours(1));
-        Spy.Get(emailVerificationService).Reset();
+        Spy.Get<IEmailVerificationService>().Reset();
 
         var authStateHelper = CreateAuthenticationStateHelper(email);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
@@ -193,7 +193,7 @@ public class EmailConfirmationTests : TestBase
         var emailVerificationOptions = HostFixture.Services.GetRequiredService<IOptions<EmailVerificationOptions>>();
         var pinResult = await emailVerificationService.GeneratePin(email);
         Clock.AdvanceBy(TimeSpan.FromHours(2) + TimeSpan.FromSeconds(emailVerificationOptions.Value.PinLifetimeSeconds));
-        Spy.Get(emailVerificationService).Reset();
+        Spy.Get<IEmailVerificationService>().Reset();
 
         var authStateHelper = CreateAuthenticationStateHelper(email);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnInUseTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnInUseTests.cs
@@ -291,7 +291,7 @@ public class TrnInUseTests : TestBase
         var emailVerificationService = HostFixture.Services.GetRequiredService<IEmailVerificationService>();
         var pinResult = await emailVerificationService.GeneratePin(existingTrnOwner.EmailAddress);
         Clock.AdvanceBy(TimeSpan.FromHours(1));
-        Spy.Get(emailVerificationService).Reset();
+        Spy.Get<IEmailVerificationService>().Reset();
 
         var authStateHelper = CreateAuthenticationStateHelper(email, existingTrnOwner.EmailAddress);
 
@@ -323,7 +323,7 @@ public class TrnInUseTests : TestBase
         var emailVerificationOptions = HostFixture.Services.GetRequiredService<IOptions<EmailVerificationOptions>>();
         var pinResult = await emailVerificationService.GeneratePin(existingTrnOwner.EmailAddress);
         Clock.AdvanceBy(TimeSpan.FromHours(2) + TimeSpan.FromSeconds(emailVerificationOptions.Value.PinLifetimeSeconds));
-        Spy.Get(emailVerificationService).Reset();
+        Spy.Get<IEmailVerificationService>().Reset();
 
         var authStateHelper = CreateAuthenticationStateHelper(email, existingTrnOwner.EmailAddress);
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/HostFixture.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/HostFixture.cs
@@ -40,7 +40,7 @@ public class HostFixture : WebApplicationFactory<TeacherIdentity.AuthServer.Prog
 
     public IRequestClientIpProvider RequestClientIpProvider => Services.GetRequiredService<IRequestClientIpProvider>();
 
-    public Spy<IEmailVerificationService> EmailVerificationService => Spy.Get(Services.GetRequiredService<IEmailVerificationService>());
+    public Spy<IEmailVerificationService> EmailVerificationService => Spy.Get<IEmailVerificationService>();
 
     public CaptureEventObserver EventObserver => (CaptureEventObserver)Services.GetRequiredService<IEventObserver>();
 
@@ -129,7 +129,7 @@ public class HostFixture : WebApplicationFactory<TeacherIdentity.AuthServer.Prog
             services.AddSingleton(EmailSender.Object);
             services.AddSingleton(RateLimitStore.Object);
             services.AddTransient<IRequestClientIpProvider, TestRequestClientIpProvider>();
-            services.Decorate<IEmailVerificationService>(inner => Spy.Of(inner));
+            services.Decorate<IEmailVerificationService>(inner => Spy.Get<IEmailVerificationService>().Wrap(inner));
         });
     }
 


### PR DESCRIPTION
The previous implementation assumed that spied instances were singletons; this change makes it work with multiple instances of a given type.