### PR TITLE
Add option to use alternative Notify key for emails not in allow list

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/Email/NotifyEmailSender.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/Email/NotifyEmailSender.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Options;
 using Notify.Client;
 
 namespace TeacherIdentity.AuthServer.Services.Email;
@@ -6,20 +7,51 @@ public class NotifyEmailSender : IEmailSender
 {
     private const string TemplateId = "fa26cec0-bf41-42ee-b3ac-b600f6faf8af";
 
+    private readonly NotifyOptions _options;
     private readonly NotificationClient _notificationClient;
+    private readonly NotificationClient? _noSendNotificationClient;
     private readonly ILogger<NotifyEmailSender> _logger;
 
-    public NotifyEmailSender(NotificationClient notificationClient, ILogger<NotifyEmailSender> logger)
+    public NotifyEmailSender(IOptions<NotifyOptions> notifyOptionsAccessor, ILogger<NotifyEmailSender> logger)
     {
-        _notificationClient = notificationClient;
+        _options = notifyOptionsAccessor.Value;
+        _notificationClient = new NotificationClient(_options.ApiKey);
         _logger = logger;
+
+        if (_options.ApplyDomainFiltering && !string.IsNullOrEmpty(_options.NoSendApiKey))
+        {
+            _noSendNotificationClient = new NotificationClient(_options.NoSendApiKey);
+        }
     }
 
     public async Task SendEmail(string to, string subject, string body)
     {
+        NotificationClient client = _notificationClient;
+
+        if (_options.ApplyDomainFiltering)
+        {
+            var toDomain = to[(to.IndexOf('@') + 1)..];
+
+            if (!_options.DomainAllowList.Contains(toDomain))
+            {
+                // Domain is not in allow list, use the 'no send' client instead if we have one
+
+                if (_noSendNotificationClient is not null)
+                {
+                    _logger.LogDebug("Email {email} does not have domain in the allow list; using the 'no send' client.", to);
+                    client = _noSendNotificationClient;
+                }
+                else
+                {
+                    _logger.LogInformation("Email {email} does not have domain in the allow list; skipping send.", to);
+                    return;
+                }
+            }
+        }
+
         try
         {
-            await _notificationClient.SendEmailAsync(
+            await client.SendEmailAsync(
                 to,
                 TemplateId,
                 personalisation: new Dictionary<string, dynamic>()

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/Email/NotifyOptions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/Email/NotifyOptions.cs
@@ -1,0 +1,15 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TeacherIdentity.AuthServer.Services.Email;
+
+public class NotifyOptions
+{
+    [Required]
+    public required string ApiKey { get; set; }
+
+    public bool ApplyDomainFiltering { get; set; }
+
+    public string[] DomainAllowList { get; set; } = Array.Empty<string>();
+
+    public string? NoSendApiKey { get; set; }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/Email/ServiceCollectionExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/Email/ServiceCollectionExtensions.cs
@@ -1,5 +1,3 @@
-using Notify.Client;
-
 namespace TeacherIdentity.AuthServer.Services.Email;
 
 public static class ServiceCollectionExtensions
@@ -11,7 +9,11 @@ public static class ServiceCollectionExtensions
     {
         if (environment.IsProduction())
         {
-            services.AddSingleton(new NotificationClient(configuration["NotifyApiKey"]));
+            services.AddOptions<NotifyOptions>()
+                .Bind(configuration.GetSection("Notify"))
+                .ValidateDataAnnotations()
+                .ValidateOnStart();
+
             services.AddSingleton<IEmailSender, NotifyEmailSender>();
 
             // Use Hangfire for scheduling emails in the background (so we get retries etc.).

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/EmailVerification/EmailVerificationService.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/EmailVerification/EmailVerificationService.cs
@@ -36,7 +36,7 @@ public class EmailVerificationService : IEmailVerificationService
         _logger = logger;
         _pinLifetime = TimeSpan.FromSeconds(optionsAccessor.Value.PinLifetimeSeconds);
         _rateLimiter = rateLimiter;
-        _clientIpProvider = clientIpProvider; ;
+        _clientIpProvider = clientIpProvider;
     }
 
     public async Task<PinGenerationResult> GeneratePin(string email)

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -29,9 +29,16 @@ locals {
     ]...))
   ]...)
 
+  auth_server_notify_domain_allow_list_env_vars = merge([
+    for i, v in lookup(local.infrastructure_secrets, "NOTIFY_DOMAIN_ALLOW_LIST", []) : {
+      "Notify__DomainAllowList__${i}" = v
+    }
+  ]...)
+
   auth_server_env_vars = merge(
     local.auth_server_clients_app_env_vars,
     local.auth_server_api_clients_app_env_vars,
+    local.auth_server_notify_domain_allow_list_env_vars,
     {
       EnvironmentName                              = local.hosting_environment,
       ApplicationInsights__ConnectionString        = azurerm_application_insights.insights.connection_string
@@ -45,7 +52,9 @@ locals {
       EncryptionKeys__1                            = local.infrastructure_secrets.ENCRYPTION_KEY1,
       SigningKeys__0                               = local.infrastructure_secrets.SIGNING_KEY0,
       SigningKeys__1                               = local.infrastructure_secrets.SIGNING_KEY1,
-      NotifyApiKey                                 = local.infrastructure_secrets.NOTIFY_API_KEY,
+      Notify__ApiKey                               = local.infrastructure_secrets.NOTIFY_API_KEY,
+      Notify__ApplyDomainFiltering                 = lookup(local.infrastructure_secrets, "NOTIFY_APPLY_DOMAIN_FILTERING", "false")
+      Notify__NoSendApiKey                         = lookup(local.infrastructure_secrets, "NOTIFY_NO_SEND_API_KEY", "")
       AdminCredentials__Username                   = local.infrastructure_secrets.ADMIN_CREDENTIALS_USERNAME,
       AdminCredentials__Password                   = local.infrastructure_secrets.ADMIN_CREDENTIALS_PASSWORD,
       Sentry__Dsn                                  = local.infrastructure_secrets.SENTRY_DSN,


### PR DESCRIPTION
For UR we have a bunch of dummy users in DQT, each with a dummy email. Since people can't access these dummy emails to retrieve email verification codes, we don't want to even attempt to send emails there. At the same time, we want people in the team to still get emails.

This change introduces an optional email domain allow list plus a fallback Notify client. When configured, if an email's domain is not on the allow list we will use the alternative Notify client, which will be configured to not send emails. For UR the Notify console can be used to retrieve the email verification codes.