### PR TITLE
Add Privacy notice content

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -90,4 +90,7 @@ public static class IdentityLinkGeneratorExtensions
         linkGenerator.PageWithAuthenticationJourneyId("/Authenticated/UpdateName", authenticationJourneyRequired: false)
             .SetQueryParam("returnUrl", returnUrl)
             .SetQueryParam("cancelUrl", cancelUrl);
+
+    public static string Privacy(this IIdentityLinkGenerator linkGenerator) =>
+        linkGenerator.PageWithAuthenticationJourneyId("/Privacy", authenticationJourneyRequired: false);
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Privacy.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Privacy.cshtml
@@ -1,0 +1,6 @@
+@page "/privacy"
+@{
+    ViewBag.Title = "Privacy notice";
+}
+
+<vc:client-scoped-partial view-name="_Privacy.{0}" />

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/_Privacy.Default.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/_Privacy.Default.cshtml
@@ -1,0 +1,88 @@
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <h1 class="govuk-heading-xl">Privacy notice</h1>
+
+        <h2 class="govuk-heading-m">Who we are</h2>
+
+        <p class="govuk-body">Get an identity to access Teacher Services is run by the <a href="https://www.gov.uk/government/organisations/teaching-regulation-agency/about">Teaching Regulation Agency (TRA)</a>, an executive agency of the Department for Education (DfE).</p>
+
+        <p>For the purpose of General Data Protection Regulation (GDPR), DfE is the data controller for the data we hold and process.</p>
+
+        <h2 class="govuk-heading-m">What data we collect</h2>
+
+        <p class="govuk-body">We collect:</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>names</li>
+            <li>email addresses</li>
+            <li>dates of birth</li>
+            <li>National Insurance number</li>
+            <li>initial teacher training (ITT) provider - where you gained qualified teacher status(QTS) or early years teacher status (EYTS).</li>
+            <li>teacher reference number (TRN)</li>
+        </ul>
+
+        <h2 class="govuk-heading-m">Why we collect this data</h2>
+
+        <p class="govuk-body">We collect this data to check if it is held in the database of qualified teachers (DQT) and to create an account. This will allow users to:</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>access many teacher services with one login</li>
+            <li>provide and update their data once across all teacher services, instead of maintaining it separately in each individual service</li>
+        </ul>
+
+        <h2 class="govuk-heading-m">Cookies</h2>
+
+        <p class="govuk-body">You can read our <a asp-page="Cookies">cookie policy</a> to find out about the cookies we use on Get an identity to access Teacher Services.</p>
+
+        <h2 class="govuk-heading-m">What we do with personal data</h2>
+
+        <p>We only collect the data we need for the purposes outlined in ‘Why we collect this data’.</p>
+
+        <p class="govuk-body">We will not:</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>sell or rent users’ data to third parties</li>
+            <li>share data with third parties for marketing purposes</li>
+        </ul>
+
+        <h2 class="govuk-heading-m">Our lawful basis for processing your personal data</h2>
+
+        <p>Running and improving Get an identity to access Teacher Services is in the Public Interest, as defined in data protection law (UK GDPR and Data Protection Act 2018).</p>
+
+        <h2 class="govuk-heading-m">How we use third parties to process your data</h2>
+
+        <p>Some of your personal information is processed by our Data Processors, listed below. They allow us to run and improve Get an identity to access Teacher Services.</p>
+
+        <p>We share your data with our data processors for the purposes of provision of this service. Data Protection Agreements are in place with each of these Processors and they are required to comply with the UK GDPR and the UK Data Protection Act 2018 as Data Processors.</p>
+
+        <h3 class="govuk-heading-s">Customer service management systems</h3>
+
+        <p>We use Zendesk to manage and respond to your queries.</p>
+
+        <p><a href="https://www.zendesk.co.uk/company/privacy-and-data-protection/#faq-general-1" rel="noreferrer noopener" target="_blank"> Visit the Zendesk website to find out how they use and look after your data (“service data”)</a>(opens in new tab)</p>
+
+        <h2 class="govuk-heading-m">How long we keep your personal data</h2>
+
+        <p>We keep your personal data for as long as you use the service. We will keep it for no longer than 7 years after you stop using the service.</p>
+
+        <h2 class="govuk-heading-m">To Raise a concern</h2>
+
+        <p class="govuk-body">You have rights under the UK GDPR and the Data Protection Act 2018. However, these rights are conditional on the lawful basis. We process your data under the lawful basis of Public Interest which grants you the following rights:</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>being informed about how your data is being used</li>
+            <li>accessing personal data</li>
+            <li>having incorrect data corrected</li>
+            <li>restricting the processing of your data (for example where the data is inaccurate or outdated)</li>
+            <li>objecting to how your data is processed in certain circumstances, including automated processing and profiling</li>
+        </ul>
+
+        <p class="govuk-body">You can find more information about how we handle personal data in our <a href="https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter">personal information charter</a>.</p>
+
+        <p class="govuk-body">Contact the Get an Identity to access Teacher Services team at <a href="mailto:QTS.enquiries@digital.education.gov.uk">QTS.enquiries@digital.education.gov.uk</a>, if you have any concerns about your personal data.</p>
+
+        <p class="govuk-body">You can also <a href="https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&amp;redirectlink=%2Fen&amp;cancelRedirectLink=%2Fen">get in touch with the Department for Education’s data protection officer through the online contact form</a>.</p>
+
+        <h2 class="govuk-heading-m">Keep up to date</h2>
+
+        <p>We periodically review this policy. We’ll notify you if we change how we use your personal data.</p>
+
+        <p>It was last updated on 19 October 2022.</p>
+    </div>
+</div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/_Privacy.RegisterForNpq.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/_Privacy.RegisterForNpq.cshtml
@@ -1,0 +1,248 @@
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">Privacy Policy</h1>
+
+        <h2 class="govuk-heading-l">Who we are and why we process personal data</h2>
+
+        <p class="govuk-body">
+            We are Teacher Continuing Professional Development (CPD), within the Department for Education (DfE).
+        </p>
+
+        <p class="govuk-body">
+            National professional qualifications (NPQs) are a national, voluntary suite of qualifications, designed to support the professional development of teachers and leaders. They are funded by CPD and delivered by teacher training providers and their delivery network.
+        </p>
+
+        <p class="govuk-body">
+            The term “teacher training providers” refers to all NPQ lead providers and their delivery networks.
+        </p>
+
+        <p class="govuk-body">
+            Mentions of “us” and “we” means CPD and “you” means anyone using this service.
+        </p>
+
+        <h2 class="govuk-heading-l">How we look after your personal data</h2>
+
+        <p class="govuk-body">
+            Any information we collect when you use our services will be used and looked after by:
+        </p>
+
+        <ul class="govuk-list govuk-list--bullet">
+            <li>the Department for Education</li>
+            <li>the teacher training providers carrying out the teacher training</li>
+            <li>the auditors and evaluators who quality assure the teacher training providers</li>
+            <li>the auditors and evaluators who quality assure the teacher training</li>
+            <li>the appropriate bodies who determine the outcomes of teacher training</li>
+        </ul>
+
+        <p class="govuk-body">
+            This means DfE is the data controller. Teacher training providers are data processors on behalf of DfE, for your information (defined by data protection law).
+        </p>
+
+        <p class="govuk-body">
+            The Register for a national professional qualification is a new service. We’re confident that it has met our security standards, but we’ll continue to run security tests as we improve the service.
+        </p>
+
+        <h2 class="govuk-heading-l">Why our use of your personal data is lawful</h2>
+
+        <p class="govuk-body">
+            In order for our use of your personal data to be lawful, we need to meet one, or more, conditions in the data protection legislation.
+        </p>
+
+        <p class="govuk-body">
+            DfE processes your data under the basis of <strong>Public Task (Article 6(1)(e) of GDPR)</strong>. In this case, it is necessary for the department to carry out this work, and to use the information for these purposes, to exercise its functions.
+        </p>
+
+        <h2 class="govuk-heading-l">What personal data we collect</h2>
+
+        <p class="govuk-body">
+            The personal data we collect will depend on whether you’re an applicant.
+        </p>
+
+        <h3 class="govuk-heading-m">
+            What personal data we collect if you’re an applicant
+        </h3>
+
+        <p class="govuk-body">
+            If you’re an applicant using the Register for a national professional qualification service we may collect the following information about you:
+        </p>
+
+        <ul class="govuk-list govuk-list--bullet">
+            <li>your name</li>
+            <li>your phone number</li>
+            <li>your email address</li>
+            <li>your teacher reference number (TRN)</li>
+            <li>your date of birth</li>
+            <li>your National Insurance number</li>
+            <li>where you work</li>
+            <li>what your role is</li>
+        </ul>
+
+        <h2 class="govuk-heading-l">How we use your personal data</h2>
+
+        <h3 class="govuk-heading-m">Processing applications</h3>
+
+        <p class="govuk-body">Processing applications includes the following:</p>
+
+        <ul class="govuk-list govuk-list--bullet">
+            <li>sending your application details to teacher training providers</li>
+            <li>validating teacher reference numbers (TRN)</li>
+            <li>working out any funding which teacher training providers are entitled to</li>
+            <li>getting in touch if there’s a security issue concerning your data</li>
+            <li>getting in touch with candidates and teacher training providers about applications</li>
+            <li>Determining outcomes of teacher training</li>
+            <li>Match, link and analyse your data along with other datasets</li>
+        </ul>
+
+        <h3 class="govuk-heading-m">Building a better teacher training application process</h3>
+
+        <p class="govuk-body">
+            We’ll use your data to help us build better processes. For example, we’ll look at any feedback you give us about our services so we can improve them.
+        </p>
+
+        <p class="govuk-body">
+            We may contact you to carry out user research.
+        </p>
+
+        <h3 class="govuk-heading-m">Getting insight to make government policy better</h3>
+
+        <p class="govuk-body">
+            We might match, link and analyse your data along with other datasets to help us inform government policy around teacher recruitment and retention.
+        </p>
+
+        <h3 class="govuk-heading-m">Quality assuring, evaluating and monitoring the policy</h3>
+
+        <p class="govuk-body">
+            We might match, link and analyse your data along with other datasets to share with auditors, evaluators and appropriate bodies in order to carry out appropriate quality assurance, evaluation and monitoring of the teacher training and induction programmes.
+        </p>
+
+        <p class="govuk-body">
+            The auditors, evaluators and appropriate bodies may contact you in the future in order to further evaluate and research activities relating to your teacher training. You will have the opportunity to opt out of this stage of the process if and when you are contacted.
+        </p>
+
+        <h2 class="govuk-heading-l">Who we share your data with</h2>
+
+        <p class="govuk-body">
+            We need to share personal data for the purposes mentioned above.
+        </p>
+
+        <p class="govuk-body">
+            We do so under section 132 of the Education Act 2002, together with regulation 5 of the Education (School Teachers’ Qualifications) (England) Regulations 2003.
+        </p>
+
+        <h3 class="govuk-heading-m">Sharing data with teacher training providers</h3>
+
+        <p class="govuk-body">
+            We share applicant data with the teacher training providers the applicant applies to.
+        </p>
+
+        <p class="govuk-body">
+            We have a data sharing agreement with teacher training providers so they can only use your data to:
+        </p>
+
+        <ul class="govuk-list govuk-list--bullet">
+            <li>process agreements, which may include contacting you</li>
+            <li>get statistics for internal use</li>
+            <li>get in touch with you if there’s a security issue concerning your data</li>
+        </ul>
+
+        <h3 class="govuk-heading-m">External organisations who process data</h3>
+
+        <h4 class="govuk-heading-s">Customer service systems</h4>
+
+        <p class="govuk-body">
+            We use a customer service management system to process some personal data, such as feedback you send us.
+        </p>
+
+        <p class="govuk-body">
+            <a class="govuk-link" href="https://www.zendesk.co.uk/company/customers-partners/master-subscription-agreement/?cta=msa#confidentiality">Zendesk is currently our preferred customer service management system</a> because it uses various safeguards to look after your data.
+        </p>
+
+        <h4 class="govuk-heading-s">Google</h4>
+
+        <p class="govuk-body">
+            We’ll ask if you agree to cookies so that we can get statistics from Google Analytics. If you consent, Google may be able to get your IP address. We use Google Analytics for statistics and will not identify you personally from these.
+        </p>
+
+        <p class="govuk-body">
+            We also use Google’s G Suite to process some personal data. Google processes your data according to our instructions.
+        </p>
+
+        <h4 class="govuk-heading-s">Hosting services</h4>
+
+        <p class="govuk-body">
+            We host our services on GOV.UK PaaS, which encrypts your data to prevent it being accessed by unauthorised people.
+        </p>
+
+        <h4 class="govuk-heading-s">Auditors</h4>
+
+        <p class="govuk-body">
+            We use external auditors to quality assure the teacher training providers to ensure that you are receiving the appropriate standard of teacher training.
+        </p>
+
+        <h4 class="govuk-heading-s">Evaluators</h4>
+
+        <p class="govuk-body">
+            We use external evaluators to understand the effectiveness of the teacher training you are receiving from teacher training providers and the impact it is having on the teacher workforce.
+        </p>
+
+        <h4 class="govuk-heading-s">Appropriate bodies</h4>
+
+        <p class="govuk-body">
+            Appropriate bodies will determine the outcome of your teacher training and notify the Teacher Regulation Agency where the teacher training will be documented against your Teaching Regulation Agency records.
+        </p>
+
+        <h2 class="govuk-heading-l">How long we keep your personal data for</h2>
+
+        <p class="govuk-body">
+            We will only keep your personal data for as long as necessary for the purpose it was obtained.
+        </p>
+
+        <h2 class="govuk-heading-l">Your rights</h2>
+
+        <p class="govuk-body">
+            Under the Data Protection Act 2018, you have the right to find out what data we have about you. This includes the right to:
+        </p>
+
+        <ul class="govuk-list govuk-list--bullet">
+            <li>be informed about how your data is being used</li>
+            <li>access personal data</li>
+            <li>have incorrect data updated</li>
+            <li>have data erased</li>
+            <li>stop or restrict the processing of your data</li>
+            <li>get and reuse your data for different services</li>
+            <li>object to how your data is processed in certain circumstances</li>
+        </ul>
+
+        <p class="govuk-body">
+            You can find more information about how we handle personal data in our <a class="govuk-link" href="https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter">personal information charter</a>.
+        </p>
+
+        <h2 class="govuk-heading-l">Getting help and raising a concern</h2>
+
+        <p class="govuk-body">
+            If you want to ask us to remove your data or get access to the data we have about you, you can email us:
+        </p>
+
+        <p class="govuk-body">
+            <a class="govuk-link" href="mailto:continuing-professional-development@digital.education.gov.uk">continuing-professional-development@digital.education.gov.uk</a>
+        </p>
+
+        <p class="govuk-body">
+            You can also use our contact form to <a class="govuk-link" href="https://form.education.gov.uk/en/AchieveForms/?form_uri=sandbox-publish://AF-Process-f1453496-7d8a-463f-9f33-1da2ac47ed76/AF-Stage-1e64d4cc-25fb-499a-a8d7-74e98203ac00/definition.json&amp;redirectlink=%2Fen&amp;cancelRedirectLink=%2Fen">get in touch with our Data Protection Officer</a>.
+        </p>
+
+        <p class="govuk-body">
+            Once an applicant has enrolled with a teacher training provider, we will not be able to ask them to remove personal data from their systems. Please contact the provider separately.
+        </p>
+
+        <p class="govuk-body">
+            For further information or to raise a concern, visit the <a class="govuk-link" href="https://ico.org.uk">Information Commissioner’s Office (ICO)</a>.
+        </p>
+
+        <h2 class="govuk-heading-l">Keeping our privacy policy up to date</h2>
+
+        <p class="govuk-body">
+            We reserve the right to update this privacy notice at any time, and we will provide you with a new privacy notice when we make any substantial updates. We will also notify you in other ways from time to time about the processing of your personal information.
+        </p>
+    </div>
+</div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/ViewComponents/RenderClientScopedPartialViewComponent.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/ViewComponents/RenderClientScopedPartialViewComponent.cs
@@ -30,21 +30,16 @@ public class RenderClientScopedPartialViewComponent : ViewComponent
 
         var client = await _currentClientProvider.GetCurrentClient();
 
-        if (client is null)
-        {
-            throw new InvalidOperationException("OIDC client could not be retrieved.");
-        }
-
         // By convention, pascal case the client ID to get the view suffix
         // e.g. register-for-npq -> RegisterForNpq
-        var clientViewName = ConvertKebabCaseToPascalCase(client.ClientId!);
+        var clientViewName = client is not null ? ConvertKebabCaseToPascalCase(client.ClientId!) : null;
 
         // Look for a client-specific view and or the Default fallback
-        var viewResult = FindView(clientViewName) ?? FindView("Default");
+        var viewResult = (clientViewName is not null ? FindView(clientViewName) : null) ?? FindView("Default");
 
         if (viewResult is null)
         {
-            throw new InvalidOperationException($"Could not find view '{viewName}' for client '{client.ClientId}' or the 'Default' fallback.");
+            throw new InvalidOperationException($"Could not find view '{viewName}' for client '{client?.ClientId ?? "(none)"}' or the 'Default' fallback.");
         }
 
         var view = viewResult.View!;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Views/Shared/_Layout.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Views/Shared/_Layout.cshtml
@@ -1,4 +1,5 @@
 @inject TeacherIdentity.AuthServer.Oidc.ICurrentClientProvider CurrentClientProvider
+@inject TeacherIdentity.AuthServer.IIdentityLinkGenerator LinkGenerator
 @{
     if (string.IsNullOrEmpty(ViewBag.Title))
     {
@@ -78,6 +79,11 @@
                         <li class="govuk-footer__inline-list-item">
                             <a class="govuk-footer__link" asp-page="/Cookies">
                                 Cookies
+                            </a>
+                        </li>
+                        <li class="govuk-footer__inline-list-item">
+                            <a class="govuk-footer__link" href="@LinkGenerator.Privacy()">
+                                Privacy
                             </a>
                         </li>
                     </ul>


### PR DESCRIPTION
https://trello.com/c/vlSuUJT5/275-privacy-notice-page-for-get-an-identity

We have two versions; one for pages that are used when inside a sign in journey for NPQ and another for everywhere else.