### PR TITLE
Auth journey timeout fixes

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/Filters/RequireAuthenticationStateFilter.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/Filters/RequireAuthenticationStateFilter.cs
@@ -59,10 +59,12 @@ public class RequireAuthenticationStateFilter : IAuthorizationFilter
 
                     authenticationState.OnHaveResumedCompletedJourney();
                     context.Result = new RedirectResult(completeUrl);
+                    return;
                 }
             }
         }
-        else if (authenticationState.HasExpired(_clock.UtcNow))
+
+        if (authenticationState.HasExpired(_clock.UtcNow))
         {
             if (context.HttpContext.GetEndpoint()?.Metadata.Contains(AllowExpiredAuthenticationJourneyMarker.Instance) != true)
             {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Authenticated/UpdateName.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Authenticated/UpdateName.cshtml.cs
@@ -94,7 +94,7 @@ public class UpdateNameModel : PageModel
 
             await _dbContext.SaveChangesAsync();
 
-            await HttpContext.ReSignInCookies(user);
+            await HttpContext.SignInCookies(user);
 
             if (HttpContext.TryGetAuthenticationState(out var authenticationState))
             {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Reset.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Reset.cshtml.cs
@@ -4,7 +4,7 @@ using TeacherIdentity.AuthServer.State;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn;
 
-[AllowExpiredAuthenticationJourney]
+[AllowExpiredAuthenticationJourney, AllowCompletedAuthenticationJourney]
 public class ResetModel : PageModel
 {
     private readonly IClock _clock;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
@@ -154,8 +154,6 @@ public class Program
 
         builder.Services.Configure<DelegatedAuthenticationOptions>("Delegated", options =>
         {
-            options.DelegatedAuthenticationScheme = CookieAuthenticationDefaults.AuthenticationScheme;
-
             options.OnUserSignedIn = async (httpContext, principal) =>
             {
                 await httpContext.SaveUserSignedInEvent(principal);
@@ -231,6 +229,7 @@ public class Program
             options.Cookie.HttpOnly = true;
             options.Cookie.IsEssential = true;
             options.Cookie.SecurePolicy = CookieSecurePolicy.SameAsRequest;
+            options.IdleTimeout = TimeSpan.FromDays(5);
         });
 
         var pgConnectionString = builder.Configuration.GetConnectionString("DefaultConnection") ??

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/CompleteTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/CompleteTests.cs
@@ -30,10 +30,10 @@ public class CompleteTests : TestBase
     }
 
     [Fact]
-    public async Task Get_JourneyHasExpired_DoesNotRenderErrorPage()
+    public async Task Get_JourneyHasExpired_RendersErrorPage()
     {
         var user = await TestData.CreateUser(hasTrn: true);
-        await JourneyHasExpired_DoesNotRenderErrorPage(c => c.Completed(user), HttpMethod.Get, "/sign-in/complete");
+        await JourneyHasExpired_RendersErrorPage(c => c.Completed(user), HttpMethod.Get, "/sign-in/complete");
     }
 
     [Fact]

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Infrastructure/TestAuthenticationHandler.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Infrastructure/TestAuthenticationHandler.cs
@@ -30,8 +30,12 @@ public class TestAuthenticationHandler : CookieAuthenticationHandler
 
             var claims = UserClaimHelper.GetInternalClaims(user);
             var principal = AuthenticationState.CreatePrincipal(claims);
+            var properties = new AuthenticationProperties()
+            {
+                ExpiresUtc = DateTimeOffset.UtcNow.AddMinutes(10)
+            };
 
-            return AuthenticateResult.Success(new AuthenticationTicket(principal, Scheme.Name));
+            return AuthenticateResult.Success(new AuthenticationTicket(principal, properties, Scheme.Name));
         }
 
         return await base.HandleAuthenticateAsync();


### PR DESCRIPTION
Fixes accessing the complete page when a journey has expired.

Also refactors all our sign in methods to go through a single extension method. This will augment an already-signed in user with the provided claims to be support 'progressive enhancement' of user info. It also handles competing expiry times by taking the greater of the existing and requested.

Also changes the `authorize` endpoint to enforce a `max_age` in line with our journey lifetime.