### PR TITLE
Deploy app settings to staging slot

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+### Context
+
+Include relevant motivation and context.
+
+### Changes proposed in this pull request
+
+Include a summary of the change.
+
+### Guidance to review
+
+Inlude any useful information needed to review this change.
+Inlude any dependencies that are required for this change.
+
+### Checklist
+
+-   [ ] Attach to Trello card
+-   [ ] Rebased master
+-   [ ] Cleaned commit history
+-   [ ] Tested by running locally
+-   [ ] Reminder created to manually clean any removed app settings post deployment

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -78,6 +78,12 @@ locals {
   }
 }
 
+data "azurerm_linux_web_app" "auth-server-app" {
+  provider            = azurerm
+  name                = local.auth_server_app_name
+  resource_group_name = data.azurerm_resource_group.group.name
+}
+
 resource "azurerm_postgresql_flexible_server" "postgres-server" {
   name                   = local.postgres_server_name
   location               = data.azurerm_resource_group.group.location
@@ -210,7 +216,11 @@ resource "azurerm_linux_web_app" "auth-server-app" {
     }]
   }
 
-  app_settings = local.auth_server_env_vars
+  sticky_settings {
+    app_setting_names = keys(data.azurerm_linux_web_app.auth-server-app.app_settings)
+  }
+
+  app_settings = data.azurerm_linux_web_app.auth-server-app.app_settings
 
   lifecycle {
     ignore_changes = [

--- a/terraform/workspace_variables/dev.tfvars.json
+++ b/terraform/workspace_variables/dev.tfvars.json
@@ -4,8 +4,10 @@
   "resource_group_name": "s165d01-getanid-dv-rg",
   "data_protection_storage_account_name": "s165d01getaniddatadvst",
   "deploy_test_client_app": true,
+  "enable_blue_green": true,
   "keyvault_logging_enabled": true,
   "storage_log_categories": [],
   "resource_prefix": "s165d01-",
+  "app_service_plan_sku": "S1",
   "domain": "dev.teaching-identity.education.gov.uk"
 }


### PR DESCRIPTION
## Context

When an app setting is removed the application in the production slot will restart during or shortly after the terraform deployment.  If this app setting is required for the app to start then the app in the production slot will fail to start.  Only after the subsequent deployment of the new version of the code will the app start.  This will cause downtime.

## Changes in this PR
- Enabled blue green in dev
- Set prod app settings from currently running settings
- Added sticky_settings to auth-server-app resource

NOTE: as app settings are copied from the currently running version any app settings that are removed will need to be manually deleted post deployment.

## Testing
1. Polled the `/status` endpoint every second using `while ($true) {Write-Host "$((Invoke-WebRequest -Uri https://dev.teaching-identity.education.gov.uk/status).StatusCode) $(Get-Date)"; Start-Sleep -Seconds 1}`
2. Added the following to Program.cs:
```
var testSetting = builder.Configuration["SOME_NEW_SETTING_A"];
        if (testSetting == null)
            throw new Exception("Setting doesn't exist");
```
3. Deployed the app with and without `SOME_NEW_SETTING_A = "SOME VALUE"` in `auth_server_env_vars` of `/terraform/app/tf`