### PR TITLE
Starts and stops the deployment stop

### DIFF
--- a/.github/workflows/actions/deploy-environment/action.yml
+++ b/.github/workflows/actions/deploy-environment/action.yml
@@ -95,6 +95,12 @@ runs:
         IMAGE_TAG: ${{ inputs.image_tag }}
       shell: bash
 
+    - uses: azure/CLI@v1
+      if: ${{ steps.terraform.outputs.blue_green == 'true' }}
+      with:
+        inlineScript: |
+          az webapp start  -g ${{ steps.config.outputs.resource_group_name }} -n ${{ steps.config.outputs.resource_prefix }}getanid-${{ inputs.environment_name}}-auths-app --slot ${{ steps.terraform.outputs.slot_name}}
+
     - uses: azure/webapps-deploy@v2
       with:
         app-name: ${{ steps.config.outputs.resource_prefix }}getanid-${{ inputs.environment_name}}-auths-app
@@ -106,6 +112,12 @@ runs:
       with:
         inlineScript: |
           az webapp deployment slot swap  -g ${{ steps.config.outputs.resource_group_name }} -n ${{ steps.config.outputs.resource_prefix }}getanid-${{ inputs.environment_name}}-auths-app --slot ${{ steps.terraform.outputs.slot_name}} --target-slot production
+
+    - uses: azure/CLI@v1
+      if: ${{ steps.terraform.outputs.blue_green == 'true' }}
+      with:
+        inlineScript: |
+          az webapp stop  -g ${{ steps.config.outputs.resource_group_name }} -n ${{ steps.config.outputs.resource_prefix }}getanid-${{ inputs.environment_name}}-auths-app --slot ${{ steps.terraform.outputs.slot_name}}
 
     - name: Check new site is up
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,14 +17,15 @@ on:
 env:
   CONTAINER_REGISTRY: ghcr.io
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+
 
 jobs:
   build:
     name: Build & test
     runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
 
     outputs:
       authserver: ${{ steps.image_tags.outputs.authserver }}

--- a/terraform/workspace_variables/dev.tfvars.json
+++ b/terraform/workspace_variables/dev.tfvars.json
@@ -4,10 +4,8 @@
   "resource_group_name": "s165d01-getanid-dv-rg",
   "data_protection_storage_account_name": "s165d01getaniddatadvst",
   "deploy_test_client_app": true,
-  "enable_blue_green": true,
   "keyvault_logging_enabled": true,
   "storage_log_categories": [],
   "resource_prefix": "s165d01-",
-  "app_service_plan_sku": "S1",
   "domain": "dev.teaching-identity.education.gov.uk"
 }


### PR DESCRIPTION
### Context

Background services remain running on the slot so we don't want this active outside of the deployment workflow.

### Changes proposed in this pull request

Adds steps to start and stop the slot either side of the deployment and slot swap

### Guidance to review

Review logs in deploy workflow

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history

