### PR TITLE
Replace role-based scopes with permission-based scopes

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Controllers/UsersController.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Controllers/UsersController.cs
@@ -12,8 +12,6 @@ namespace TeacherIdentity.AuthServer.Api.V1.Controllers;
 
 [ApiController]
 [Route("users")]
-[Route("teachers")]
-[Authorize(AuthorizationPolicies.GetAnIdentitySupportApi)]
 public class UsersController : ControllerBase
 {
     private readonly IMediator _mediator;
@@ -23,6 +21,7 @@ public class UsersController : ControllerBase
         _mediator = mediator;
     }
 
+    [Authorize(AuthorizationPolicies.ApiUserRead)]
     [HttpGet("{userId}")]
     [SwaggerOperation(summary: "Get a user's details by their user ID")]
     [ProducesResponseType(typeof(GetUserDetailResponse), StatusCodes.Status200OK)]
@@ -34,6 +33,7 @@ public class UsersController : ControllerBase
         return Ok(response);
     }
 
+    [Authorize(AuthorizationPolicies.ApiUserRead)]
     [HttpGet("")]
     [SwaggerOperation(summary: "Retrieves all users")]
     [ProducesResponseType(typeof(GetAllUsersResponse), StatusCodes.Status200OK)]
@@ -43,6 +43,7 @@ public class UsersController : ControllerBase
         return Ok(response);
     }
 
+    [Authorize(AuthorizationPolicies.ApiUserWrite)]
     [HttpPut("{userId}/trn")]
     [SwaggerOperation(summary: "Set the TRN for a teacher")]
     [ProducesResponseType(typeof(void), StatusCodes.Status204NoContent)]
@@ -62,6 +63,7 @@ public class UsersController : ControllerBase
         return NoContent();
     }
 
+    [Authorize(AuthorizationPolicies.ApiUserWrite)]
     [HttpPatch("{userId}")]
     [SwaggerOperation(summary: "Updates a user")]
     [ProducesResponseType(typeof(UserInfo), StatusCodes.Status200OK)]

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/Security/AuthorizationPolicies.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/Security/AuthorizationPolicies.cs
@@ -2,8 +2,9 @@ namespace TeacherIdentity.AuthServer.Infrastructure.Security;
 
 public static class AuthorizationPolicies
 {
+    public const string ApiUserRead = "API:UserRead";
+    public const string ApiUserWrite = "API:UserWrite";
     public const string Authenticated = "Authenticated";
     public const string GetAnIdentityAdmin = "GetAnIdentityAdmin";
-    public const string GetAnIdentitySupportApi = "API:GetAnIdentitySupport";
     public const string TrnLookupApi = "API:TrnLookup";
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/Security/RequireScopeAuthorizationHandler.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/Security/RequireScopeAuthorizationHandler.cs
@@ -16,7 +16,7 @@ public class RequireScopeAuthorizationHandler : AuthorizationHandler<ScopeAuthor
 
         var scopes = scopeClaim.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
 
-        if (scopes.Any(s => s == requirement.Scope))
+        if (requirement.Scopes.Any(s => scopes.Contains(s)))
         {
             context.Succeed(requirement);
         }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/Security/ScopeAuthorizationRequirement.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/Security/ScopeAuthorizationRequirement.cs
@@ -2,12 +2,20 @@ using Microsoft.AspNetCore.Authorization;
 
 namespace TeacherIdentity.AuthServer.Infrastructure.Security;
 
+/// <summary>
+/// Defines a requirement that the calling client must have at least one of the specified scopes.
+/// </summary>
 public class ScopeAuthorizationRequirement : IAuthorizationRequirement
 {
     public ScopeAuthorizationRequirement(string scope)
+        : this(new[] { scope })
     {
-        Scope = scope;
     }
 
-    public string Scope { get; }
+    public ScopeAuthorizationRequirement(params string[] scopes)
+    {
+        Scopes = scopes;
+    }
+
+    public string[] Scopes { get; }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Oidc/CustomScopes.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Oidc/CustomScopes.cs
@@ -2,19 +2,21 @@ namespace TeacherIdentity.AuthServer.Oidc;
 
 public static class CustomScopes
 {
-    public const string GetAnIdentityAdmin = "get-an-identity:admin";
     public const string GetAnIdentitySupport = "get-an-identity:support";
+    public const string UserRead = "user:read";
+    public const string UserWrite = "user:write";
     public const string Trn = "trn";
 
-    public static string[] All => AdminScopes.Concat(TeacherScopes).ToArray();
+    public static string[] All => StaffUserTypeScopes.Concat(DefaultUserTypesScopes).ToArray();
 
-    public static string[] AdminScopes { get; } = new[]
+    public static string[] StaffUserTypeScopes { get; } = new[]
     {
-        GetAnIdentityAdmin,
-        GetAnIdentitySupport
+        GetAnIdentitySupport,
+        UserRead,
+        UserWrite
     };
 
-    public static string[] TeacherScopes { get; } = new[]
+    public static string[] DefaultUserTypesScopes { get; } = new[]
     {
         Trn
     };

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/UserRequirements.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/UserRequirements.cs
@@ -63,12 +63,17 @@ public static class UserRequirementsExtensions
             userRequirements = UserRequirements.DefaultUserType | UserRequirements.TrnHolder;
         }
 
-        if (hasScope(CustomScopes.GetAnIdentityAdmin))
+        if (hasScope(CustomScopes.GetAnIdentitySupport))
         {
-            userRequirements = UserRequirements.StaffUserType | UserRequirements.GetAnIdentityAdmin;
+            userRequirements = UserRequirements.StaffUserType | UserRequirements.GetAnIdentitySupport;
         }
 
-        if (hasScope(CustomScopes.GetAnIdentitySupport))
+        if (hasScope(CustomScopes.UserRead))
+        {
+            userRequirements = UserRequirements.StaffUserType | UserRequirements.GetAnIdentitySupport;
+        }
+
+        if (hasScope(CustomScopes.UserWrite))
         {
             userRequirements = UserRequirements.StaffUserType | UserRequirements.GetAnIdentitySupport;
         }
@@ -111,9 +116,12 @@ public static class UserRequirementsExtensions
             return false;
         }
 
-        if (userRequirements.HasFlag(UserRequirements.GetAnIdentitySupport) && !principal.IsInRole(StaffRoles.GetAnIdentitySupport))
+        if (userRequirements.HasFlag(UserRequirements.GetAnIdentitySupport))
         {
-            return false;
+            if (!(principal.IsInRole(StaffRoles.GetAnIdentitySupport) || principal.IsInRole(StaffRoles.GetAnIdentityAdmin)))
+            {
+                return false;
+            }
         }
 
         return true;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Development.json
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Development.json
@@ -17,7 +17,7 @@
         "https://localhost:7261/oidc/signout-callback"
       ],
       "ServiceUrl": "/",
-      "Scopes": [ "get-an-identity:admin", "get-an-identity:support", "trn" ],
+      "Scopes": [ "trn", "get-an-identity:support", "user:read", "user:write" ],
       "PostSignInMessage": "continue with the Test Client"
     },
     {
@@ -26,7 +26,7 @@
       "RedirectUris": [
         "https://localhost:7236/swagger/oauth2-redirect.html"
       ],
-      "Scopes": [ "get-an-identity:admin", "get-an-identity:support", "trn" ]
+      "Scopes": [ "trn", "get-an-identity:support", "user:read", "user:write" ]
     }
   ],
   "FindALostTrnIntegration": {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignIn.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignIn.cs
@@ -1,6 +1,7 @@
 using FakeItEasy;
 using Microsoft.Playwright;
 using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Oidc;
 
 namespace TeacherIdentity.AuthServer.EndToEndTests;
 
@@ -355,7 +356,7 @@ public class SignIn : IClassFixture<HostFixture>
 
         // Start on the client app and try to access a protected area with admin scope
 
-        await page.GotoAsync("/profile?scope=get-an-identity:admin");
+        await page.GotoAsync($"/profile?scope={CustomScopes.UserRead}");
 
         // Fill in the sign in form (email + PIN)
 
@@ -497,7 +498,7 @@ public class SignIn : IClassFixture<HostFixture>
 
         // Start on the client app and try to access a protected area with admin scope
 
-        await page.GotoAsync("/profile?scope=get-an-identity:admin");
+        await page.GotoAsync($"/profile?scope={CustomScopes.UserRead}");
 
         // Fill in the sign in form (email + PIN)
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/appsettings.json
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/appsettings.json
@@ -28,7 +28,7 @@
       "PostLogoutRedirectUris": [
         "http://localhost:55342/oidc/signout-callback"
       ],
-      "Scopes": [ "get-an-identity:admin", "get-an-identity:support", "trn" ]
+      "Scopes": [ "trn", "user:read", "user:write" ]
     }
   ]
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AddClientTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AddClientTests.cs
@@ -61,8 +61,8 @@ public class AddClientTests : TestBase
         var redirectUri2 = serviceUrl + "/callback2";
         var postLogoutRedirectUri1 = serviceUrl + "/logout-callback";
         var postLogoutRedirectUri2 = serviceUrl + "/logout-callback2";
-        var scope1 = CustomScopes.GetAnIdentityAdmin;
-        var scope2 = CustomScopes.GetAnIdentitySupport;
+        var scope1 = CustomScopes.UserRead;
+        var scope2 = CustomScopes.UserWrite;
 
         var request = new HttpRequestMessage(HttpMethod.Post, "/admin/clients/new")
         {
@@ -98,8 +98,8 @@ public class AddClientTests : TestBase
         var redirectUri2 = serviceUrl + "/callback2";
         var postLogoutRedirectUri1 = serviceUrl + "/logout-callback";
         var postLogoutRedirectUri2 = serviceUrl + "/logout-callback2";
-        var scope1 = CustomScopes.GetAnIdentityAdmin;
-        var scope2 = CustomScopes.GetAnIdentitySupport;
+        var scope1 = CustomScopes.UserRead;
+        var scope2 = CustomScopes.UserWrite;
 
         var request = new HttpRequestMessage(HttpMethod.Post, "/admin/clients/new")
         {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/EditClientTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/EditClientTests.cs
@@ -103,7 +103,7 @@ public class EditClientTests : TestBase
         var newRedirectUri2 = newServiceUrl + "/callback2";
         var newPostLogoutRedirectUri1 = newServiceUrl + "/logout-callback";
         var newPostLogoutRedirectUri2 = newServiceUrl + "/logout-callback2";
-        var newScope = CustomScopes.GetAnIdentitySupport;
+        var newScope = CustomScopes.UserWrite;
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/clients/{clientId}")
         {
@@ -186,7 +186,7 @@ public class EditClientTests : TestBase
         var serviceUrl = $"https://{Faker.Internet.DomainName()}/";
         var redirectUri1 = serviceUrl + "/callback";
         var postLogoutRedirectUri1 = serviceUrl + "/logout-callback";
-        var scope1 = CustomScopes.GetAnIdentityAdmin;
+        var scope1 = CustomScopes.UserRead;
 
         var appManager = HostFixture.Services.GetRequiredService<TeacherIdentityApplicationManager>();
         await appManager.CreateAsync(

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/ScopeTheoryData.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/ScopeTheoryData.cs
@@ -6,14 +6,16 @@ public static class ScopeTheoryData
 {
     public static string First(this TheoryData<string> data) => (string)Enumerable.First(data)[0];
 
-    public static TheoryData<string> GetAdminScopes() =>
-        FromScopes(CustomScopes.AdminScopes);
+    public static TheoryData<string> FromScopes(params string[] scopes) => FromScopes((IEnumerable<string>)scopes);
 
-    public static TheoryData<string> GetAllAdminScopesExcept(TheoryData<string> scopes) =>
-        FromScopes(CustomScopes.AdminScopes.Except(scopes.Select(d => (string)d.Single())).Append(""));
+    public static TheoryData<string> GetStaffUserScopes() =>
+        FromScopes(CustomScopes.StaffUserTypeScopes);
 
-    public static TheoryData<string> GetAllAdminScopesExcept(IEnumerable<string> scopes) =>
-        FromScopes(CustomScopes.AdminScopes.Except(scopes));
+    public static TheoryData<string> GetAllStaffUserScopesExcept(TheoryData<string> scopes) =>
+        FromScopes(CustomScopes.StaffUserTypeScopes.Except(scopes.Select(d => (string)d.Single())).Append(""));
+
+    public static TheoryData<string> GetAllStaffUserScopesExcept(IEnumerable<string> scopes) =>
+        FromScopes(CustomScopes.StaffUserTypeScopes.Except(scopes));
 
     public static TheoryData<string> Single(string scope) => FromScopes(new[] { scope });
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/TestBase.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/TestBase.cs
@@ -24,7 +24,7 @@ public class TestBase
 
     public HttpClient ApiKeyHttpClient { get; }
 
-    public Task<HttpClient> CreateHttpClientWithToken(string scope)
+    public Task<HttpClient> CreateHttpClientWithToken(string? scope)
     {
         var scopes = !string.IsNullOrEmpty(scope) ? new[] { scope } : Array.Empty<string>();
         return CreateHttpClientWithToken(scopes);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/GetAllUsersTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/GetAllUsersTests.cs
@@ -73,7 +73,7 @@ public class GetAllUsersTests : TestBase
             });
     }
 
-    public static TheoryData<string> NotPermittedScopes => ScopeTheoryData.GetAllAdminScopesExcept(PermittedScopes);
+    public static TheoryData<string> NotPermittedScopes => ScopeTheoryData.GetAllStaffUserScopesExcept(PermittedScopes);
 
-    public static TheoryData<string> PermittedScopes => ScopeTheoryData.Single(CustomScopes.GetAnIdentitySupport);
+    public static TheoryData<string> PermittedScopes => ScopeTheoryData.FromScopes(CustomScopes.UserRead, CustomScopes.UserWrite);
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/GetUserDetailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/GetUserDetailTests.cs
@@ -65,7 +65,7 @@ public class GetUserDetailTests : TestBase
         Assert.Equal(registeredWithClient.DisplayName, responseObj.RegisteredWithClientDisplayName);
     }
 
-    public static TheoryData<string> NotPermittedScopes => ScopeTheoryData.GetAllAdminScopesExcept(PermittedScopes);
+    public static TheoryData<string> NotPermittedScopes => ScopeTheoryData.GetAllStaffUserScopesExcept(PermittedScopes);
 
-    public static TheoryData<string> PermittedScopes => ScopeTheoryData.Single(CustomScopes.GetAnIdentitySupport);
+    public static TheoryData<string> PermittedScopes => ScopeTheoryData.FromScopes(CustomScopes.UserRead, CustomScopes.UserWrite);
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/SetTeacherTrnTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/SetTeacherTrnTests.cs
@@ -186,7 +186,7 @@ public class SetTeacherTrnTests : TestBase
         { "12345678" }
     };
 
-    public static TheoryData<string> NotPermittedScopes => ScopeTheoryData.GetAllAdminScopesExcept(PermittedScopes);
+    public static TheoryData<string> NotPermittedScopes => ScopeTheoryData.GetAllStaffUserScopesExcept(PermittedScopes);
 
-    public static TheoryData<string> PermittedScopes => ScopeTheoryData.Single(CustomScopes.GetAnIdentitySupport);
+    public static TheoryData<string> PermittedScopes => ScopeTheoryData.Single(CustomScopes.UserWrite);
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/UpdateUserTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/UpdateUserTests.cs
@@ -208,9 +208,9 @@ public class UpdateUserTests : TestBase
         Assert.Equal(user.Created, user.Updated);
     }
 
-    public static TheoryData<string> NotPermittedScopes => ScopeTheoryData.GetAllAdminScopesExcept(PermittedScopes);
+    public static TheoryData<string> NotPermittedScopes => ScopeTheoryData.GetAllStaffUserScopesExcept(PermittedScopes);
 
-    public static TheoryData<string> PermittedScopes => ScopeTheoryData.Single(CustomScopes.GetAnIdentitySupport);
+    public static TheoryData<string> PermittedScopes => ScopeTheoryData.Single(CustomScopes.UserWrite);
 
     public static IEnumerable<object[]> GetInvalidRequestData()
     {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/CompleteTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/CompleteTests.cs
@@ -115,7 +115,7 @@ public class CompleteTests : TestBase
     {
         // Arrange
         var user = await TestData.CreateUser(userType: UserType.Staff);
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Completed(user, firstTimeSignIn: false), additionalScopes: CustomScopes.GetAnIdentityAdmin);
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Completed(user, firstTimeSignIn: false), additionalScopes: CustomScopes.UserRead);
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/complete?{authStateHelper.ToQueryParam()}");
 
         // Act

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
@@ -318,7 +318,7 @@ public class EmailConfirmationTests : TestBase
         var emailVerificationService = HostFixture.Services.GetRequiredService<IEmailVerificationService>();
         var pinResult = await emailVerificationService.GeneratePin(email);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email), CustomScopes.GetAnIdentityAdmin);
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email), CustomScopes.UserRead);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -343,7 +343,7 @@ public class EmailConfirmationTests : TestBase
         var emailVerificationService = HostFixture.Services.GetRequiredService<IEmailVerificationService>();
         var pinResult = await emailVerificationService.GeneratePin(user.EmailAddress);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(user.EmailAddress), CustomScopes.GetAnIdentityAdmin);
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(user.EmailAddress), CustomScopes.UserRead);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -367,7 +367,7 @@ public class EmailConfirmationTests : TestBase
         var emailVerificationService = HostFixture.Services.GetRequiredService<IEmailVerificationService>();
         var pinResult = await emailVerificationService.GeneratePin(user.EmailAddress);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(user.EmailAddress), CustomScopes.GetAnIdentityAdmin);
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(user.EmailAddress), CustomScopes.UserRead);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/UpdateDetailsTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/UpdateDetailsTests.cs
@@ -53,7 +53,7 @@ public class UpdateDetailsTests : TestBase
     {
         // Arrange
         var user = await TestData.CreateUser(userType: UserType.Staff);
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Completed(user, firstTimeSignIn: false), additionalScopes: CustomScopes.GetAnIdentityAdmin);
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Completed(user, firstTimeSignIn: false), additionalScopes: CustomScopes.UserRead);
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/update-details?{authStateHelper.ToQueryParam()}");
 
         // Act

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/TestClients.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/TestClients.cs
@@ -27,8 +27,9 @@ public static class TestClients
             Permissions.ResponseTypes.Code,
             Permissions.Scopes.Email,
             Permissions.Scopes.Profile,
-            $"{Permissions.Prefixes.Scope}{CustomScopes.GetAnIdentityAdmin}",
             $"{Permissions.Prefixes.Scope}{CustomScopes.GetAnIdentitySupport}",
+            $"{Permissions.Prefixes.Scope}{CustomScopes.UserRead}",
+            $"{Permissions.Prefixes.Scope}{CustomScopes.UserWrite}",
             $"{Permissions.Prefixes.Scope}{CustomScopes.Trn}",
         },
         Requirements =


### PR DESCRIPTION
Previously admin scopes were defined by roles; `get-an-identity:support`, `get-an-identity:admin` etc. but they should be defined by permissions e.g. `user:read`, `user:write` etc. This PR makes that change.

Authorization for the API endpoints is amended to have separate policies for read and write.