### PR TITLE
Redirect /admin to /admin/clients

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Index.cshtml
@@ -1,0 +1,4 @@
+@page "/admin"
+@model TeacherIdentity.AuthServer.Pages.Admin.IndexModel
+@{
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Index.cshtml.cs
@@ -1,0 +1,9 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeacherIdentity.AuthServer.Pages.Admin;
+
+public class IndexModel : PageModel
+{
+    public IActionResult OnGet() => RedirectToPage("/Admin/Clients");
+}


### PR DESCRIPTION
Currently there's no 'home page' for admin UI; this adds `/admin` and makes it redirect to `/admin/clients` for now.