### PR TITLE
Suppress expected DB errors from Sentry

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/ExceptionExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/ExceptionExtensions.cs
@@ -1,11 +1,12 @@
-using EntityFramework.Exceptions.Common;
+using Microsoft.EntityFrameworkCore;
 using Npgsql;
 
 namespace TeacherIdentity.AuthServer;
 
 public static class ExceptionExtensions
 {
-    public static bool IsUniqueIndexViolation(this UniqueConstraintException ex, string indexName) =>
+    public static bool IsUniqueIndexViolation(this DbUpdateException ex, string indexName) =>
         ex.InnerException is PostgresException pgException &&
+            pgException.SqlState == PostgresErrorCodes.UniqueViolation &&
             pgException.ConstraintName == indexName;
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenSignInJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenSignInJourney.cs
@@ -1,4 +1,3 @@
-using EntityFramework.Exceptions.Common;
 using Microsoft.AspNetCore.Mvc;
 using TeacherIdentity.AuthServer.Models;
 
@@ -19,18 +18,10 @@ public class TrnTokenSignInJourney : SignInJourney
 
     public override async Task<IActionResult> CreateUser(string currentStep)
     {
-        try
-        {
-            var user = await CreateUserHelper.CreateUserWithTrnToken(AuthenticationState);
+        var user = await CreateUserHelper.CreateUserWithTrnToken(AuthenticationState);
 
-            AuthenticationState.OnUserRegistered(user);
-            await AuthenticationState.SignIn(HttpContext);
-        }
-        catch (UniqueConstraintException ex) when (ex.IsUniqueIndexViolation(User.TrnUniqueIndexName))
-        {
-            // We currently do not handle trn index violations for the trn token sign in journey
-            throw;
-        }
+        AuthenticationState.OnUserRegistered(user);
+        await AuthenticationState.SignIn(HttpContext);
 
         return new RedirectResult(GetNextStepUrl(currentStep));
     }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/TeacherIdentityServerDbContext.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/TeacherIdentityServerDbContext.cs
@@ -1,4 +1,3 @@
-using EntityFramework.Exceptions.PostgreSQL;
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Events;
 
@@ -23,7 +22,6 @@ public class TeacherIdentityServerDbContext : DbContext
         }
 
         optionsBuilder
-            .UseExceptionProcessor()
             .UseSnakeCaseNamingConvention()
             .UseOpenIddict<Application, Authorization, Scope, Token, string>();
     }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditStaffUser.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditStaffUser.cshtml.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel.DataAnnotations;
-using EntityFramework.Exceptions.Common;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
@@ -100,11 +99,12 @@ public class EditStaffUserModel : PageModel
                 Changes = changes
             });
 
+            using var suppressUniqueIndexViolationScope = SentryErrors.Suppress<DbUpdateException>(ex => ex.IsUniqueIndexViolation(Models.User.EmailAddressUniqueIndexName));
             try
             {
                 await _dbContext.SaveChangesAsync();
             }
-            catch (UniqueConstraintException ex) when (ex.IsUniqueIndexViolation(Models.User.EmailAddressUniqueIndexName))
+            catch (Exception ex) when (suppressUniqueIndexViolationScope.IsExceptionSuppressed(ex))
             {
                 ModelState.AddModelError(nameof(Email), "Another user has the specified email address");
                 return this.PageWithErrors();

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditUserEmail.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditUserEmail.cshtml.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel.DataAnnotations;
-using EntityFramework.Exceptions.Common;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
@@ -61,11 +60,12 @@ public class EditUserEmailModel : PageModel
                 Changes = changes
             });
 
+            using var suppressUniqueIndexViolationScope = SentryErrors.Suppress<DbUpdateException>(ex => ex.IsUniqueIndexViolation(Models.User.EmailAddressUniqueIndexName));
             try
             {
                 await _dbContext.SaveChangesAsync();
             }
-            catch (UniqueConstraintException ex) when (ex.IsUniqueIndexViolation(Models.User.EmailAddressUniqueIndexName))
+            catch (Exception ex) when (suppressUniqueIndexViolationScope.IsExceptionSuppressed(ex))
             {
                 ModelState.AddModelError(nameof(Email), "This email address is already in use - Enter a different email address");
                 return this.PageWithErrors();

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
@@ -63,7 +63,18 @@ public class Program
 
         if (builder.Environment.IsProduction())
         {
-            builder.WebHost.UseSentry();
+            builder.WebHost.UseSentry(options =>
+            {
+                options.SetBeforeSend((Sentry.SentryEvent e) =>
+                {
+                    if (e.Exception is not null && !SentryErrors.ShouldReport(e.Exception))
+                    {
+                        return null;
+                    }
+
+                    return e;
+                });
+            });
 
             builder.Services.Configure<SentryAspNetCoreOptions>(options =>
             {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/SentryErrors.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/SentryErrors.cs
@@ -1,0 +1,54 @@
+namespace TeacherIdentity.AuthServer;
+
+public static class SentryErrors
+{
+    private static readonly AsyncLocal<List<Func<Exception, bool>>> _exceptionsToSkip = new();
+
+    public static bool ShouldReport(Exception ex) => _exceptionsToSkip.Value is null ||
+        !_exceptionsToSkip.Value.Any(f => f(ex));
+
+    public static ISuppressScope Suppress<TException>()
+        where TException : Exception
+    {
+        return Suppress<TException>(_ => true);
+    }
+
+    public static ISuppressScope Suppress<TException>(Func<TException, bool> filter)
+        where TException : Exception
+    {
+        return Suppress(ex => ex is TException typedException && filter(typedException));
+    }
+
+    public static ISuppressScope Suppress(Func<Exception, bool> filter)
+    {
+        _exceptionsToSkip.Value ??= new();
+        _exceptionsToSkip.Value.Add(filter);
+        return new SuppressScope(filter, () => _exceptionsToSkip.Value.Remove(filter));
+    }
+
+    private class SuppressScope : ISuppressScope
+    {
+        private readonly Func<Exception, bool> _filter;
+        private readonly Action _onDispose;
+
+        public SuppressScope(Func<Exception, bool> filter, Action onDispose)
+        {
+            _filter = filter;
+            _onDispose = onDispose;
+        }
+
+        public Func<Exception, bool> ExceptionPredicate => _filter;
+
+        public void Dispose()
+        {
+            _onDispose();
+        }
+
+        public bool IsExceptionSuppressed(Exception ex) => _filter(ex);
+    }
+
+    public interface ISuppressScope : IDisposable
+    {
+        bool IsExceptionSuppressed(Exception ex);
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/UserImport/UserImportProcessor.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/UserImport/UserImportProcessor.cs
@@ -3,7 +3,6 @@ using System.Globalization;
 using System.Text.RegularExpressions;
 using CsvHelper;
 using CsvHelper.Configuration;
-using EntityFramework.Exceptions.Common;
 using Microsoft.EntityFrameworkCore;
 using Polly;
 using TeacherIdentity.AuthServer.Events;
@@ -283,7 +282,7 @@ public class UserImportProcessor : IUserImportProcessor
                     await _dbContext.SaveChangesAsync();
                     await txn.CommitAsync();
                 }
-                catch (UniqueConstraintException ex)
+                catch (DbUpdateException ex)
                 {
                     await txn.RollbackAsync();
                     _dbContext.ChangeTracker.Clear();

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/TeacherIdentity.AuthServer.csproj
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/TeacherIdentity.AuthServer.csproj
@@ -17,7 +17,6 @@
     <PackageReference Include="CsvHelper" Version="30.0.1" />
     <PackageReference Include="Dfe.Analytics.AspNetCore" Version="0.1.0" />
     <PackageReference Include="EFCore.NamingConventions" Version="7.0.2" />
-    <PackageReference Include="EntityFrameworkCore.Exceptions.PostgreSQL" Version="6.0.3" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.5.1" />
     <PackageReference Include="Flurl" Version="3.0.7" />
     <PackageReference Include="GovUk.Frontend.AspNetCore" Version="1.0.1" />

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Register.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Register.cs
@@ -468,7 +468,7 @@ public class Register : IClassFixture<HostFixture>
     public async Task NewUser_WithInstitutionEmail_CanRegister(bool useInstitutionEmail)
     {
         var invalidEmailSuffix = "invalid.sch.uk";
-        await _hostFixture.TestData.AddEstablishmentDomain(invalidEmailSuffix);
+        await _hostFixture.TestData.EnsureEstablishmentDomain(invalidEmailSuffix);
 
         var institutionEmail = $"james@{invalidEmailSuffix}";
         var personalEmail = Faker.Internet.Email();

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/TrnTokenSignInJourney.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/TrnTokenSignInJourney.cs
@@ -648,7 +648,7 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
             });
 
         var invalidEmailSuffix = "invalid.sch.uk";
-        await _hostFixture.TestData.AddEstablishmentDomain(invalidEmailSuffix);
+        await _hostFixture.TestData.EnsureEstablishmentDomain(invalidEmailSuffix);
 
         var newInstitutionEmail = $"james@{invalidEmailSuffix}";
         var newPersonalEmail = Faker.Internet.Email();

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TestData.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TestData.cs
@@ -1,7 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Security.Cryptography;
-using EntityFramework.Exceptions.Common;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using TeacherIdentity.AuthServer.Models;
@@ -150,7 +149,7 @@ public partial class TestData
         return trnToken;
     }
 
-    public async Task AddEstablishmentDomain(string invalidEmailSuffix)
+    public async Task EnsureEstablishmentDomain(string invalidEmailSuffix)
     {
         await WithDbContext(async dbContext =>
         {
@@ -164,7 +163,7 @@ public partial class TestData
                 dbContext.EstablishmentDomains.Add(establishmentDomain);
                 await dbContext.SaveChangesAsync();
             }
-            catch (UniqueConstraintException ex) when (ex.IsUniqueIndexViolation("pk_establishment_domains"))
+            catch (DbUpdateException ex) when (ex.IsUniqueIndexViolation("pk_establishment_domains"))
             {
                 // ignored
             }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Email/EmailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Email/EmailTests.cs
@@ -184,7 +184,7 @@ public class EmailTests : TestBase
     {
         // Arrange
         var invalidSuffix = "myschool1231.sch.uk";
-        await TestData.AddEstablishmentDomain(invalidSuffix);
+        await TestData.EnsureEstablishmentDomain(invalidSuffix);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/account/email")
         {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Email/ResendTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Email/ResendTests.cs
@@ -198,7 +198,7 @@ public class ResendTests : TestBase
         // Arrange
         var invalidSuffix = "myschool1231.sch.uk";
         var email = Faker.Internet.Email();
-        await TestData.AddEstablishmentDomain(invalidSuffix);
+        await TestData.EnsureEstablishmentDomain(invalidSuffix);
 
         var request = new HttpRequestMessage(HttpMethod.Post, AppendQueryParameterSignature($"/account/email/resend?email={email}"))
         {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Authenticated/UpdateEmail/IndexTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Authenticated/UpdateEmail/IndexTests.cs
@@ -175,7 +175,7 @@ public class IndexTests : TestBase
     {
         // Arrange
         var invalidSuffix = "myschool1231.sch.uk";
-        await TestData.AddEstablishmentDomain(invalidSuffix);
+        await TestData.EnsureEstablishmentDomain(invalidSuffix);
 
         var returnUrl = "/_tests/empty";
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailTests.cs
@@ -174,7 +174,7 @@ public class EmailTests : TestBase
     {
         // Arrange
         var invalidEmailSuffix = "myschool3211.sch.uk";
-        await TestData.AddEstablishmentDomain(invalidEmailSuffix);
+        await TestData.EnsureEstablishmentDomain(invalidEmailSuffix);
 
         var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email?{authStateHelper.ToQueryParam()}")
@@ -197,7 +197,7 @@ public class EmailTests : TestBase
     {
         // Arrange
         var invalidEmailSuffix = "myschool3212.sch.uk";
-        await TestData.AddEstablishmentDomain(invalidEmailSuffix);
+        await TestData.EnsureEstablishmentDomain(invalidEmailSuffix);
 
         var user = await TestData.CreateUser(email: $"john.doe22@{invalidEmailSuffix}");
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailTests.cs
@@ -164,7 +164,7 @@ public class EmailTests : TestBase
     {
         // Arrange
         var invalidEmailSuffix = "invalid.sch.uk";
-        await TestData.AddEstablishmentDomain(invalidEmailSuffix);
+        await TestData.EnsureEstablishmentDomain(invalidEmailSuffix);
 
         var email = $"principal@{invalidEmailSuffix}";
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/InstitutionEmailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/InstitutionEmailTests.cs
@@ -205,7 +205,7 @@ public class InstitutionEmailTests : TestBase
     {
         // Arrange
         var invalidEmailSuffix = "invalid.sch.uk";
-        await TestData.AddEstablishmentDomain(invalidEmailSuffix);
+        await TestData.EnsureEstablishmentDomain(invalidEmailSuffix);
 
         var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
         var email = "admin@invalid.sch.uk";

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ResendEmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ResendEmailConfirmationTests.cs
@@ -225,7 +225,7 @@ public class ResendEmailConfirmationTests : TestBase
     {
         // Arrange
         var invalidEmailSuffix = "invalid.sch.uk";
-        await TestData.AddEstablishmentDomain(invalidEmailSuffix);
+        await TestData.EnsureEstablishmentDomain(invalidEmailSuffix);
 
         var email = $"headteacher@{invalidEmailSuffix}";
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/ResendEmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/ResendEmailConfirmationTests.cs
@@ -304,7 +304,7 @@ public class ResendEmailConfirmationTests : TestBase
     {
         // Arrange
         var invalidEmailSuffix = "myschool4561.sch.uk";
-        await TestData.AddEstablishmentDomain(invalidEmailSuffix);
+        await TestData.EnsureEstablishmentDomain(invalidEmailSuffix);
 
         var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/resend-email-confirmation?{authStateHelper.ToQueryParam()}")
@@ -327,7 +327,7 @@ public class ResendEmailConfirmationTests : TestBase
     {
         // Arrange
         var invalidEmailSuffix = "myschool4562.sch.uk";
-        await TestData.AddEstablishmentDomain(invalidEmailSuffix);
+        await TestData.EnsureEstablishmentDomain(invalidEmailSuffix);
 
 
         var user = await TestData.CreateUser(email: $"john.doe32@{invalidEmailSuffix}");


### PR DESCRIPTION
We handle duplicates by catching the the Exception thrown by unique index violations but these errors are still getting to Sentry. This change adds a mechanism for suppressing these errors so we keep our Sentry logs clean.

Unfortunately I've had to remove the `EntityFrameworkCore.Exceptions.PostgreSQL` package as part of this so we're no longer getting error-specific Exception types. This is because this package maps the errors _after_ they're logged so we would have had to have two different predicates for suppressing the Sentry error and in our own `catch` clauses, which seems very undesirable.