### PR TITLE
Fix infinite sign in loop for staff users

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -392,7 +392,7 @@ public class AuthenticationState
         }
 
         var claims = GetInternalClaims();
-        await httpContext.SignInCookies(claims, AuthCookieLifetime);
+        await httpContext.SignInCookies(claims, resetIssued: true, AuthCookieLifetime);
     }
 
     public enum TrnLookupState

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/HttpContextExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/HttpContextExtensions.cs
@@ -18,10 +18,11 @@ public static class HttpContextExtensions
     public static Task<ClaimsPrincipal> SignInCookies(
         this HttpContext httpContext,
         User user,
+        bool resetIssued,
         TimeSpan? minExpires = null)
     {
         var newClaims = UserClaimHelper.GetInternalClaims(user);
-        return SignInCookies(httpContext, newClaims, minExpires);
+        return SignInCookies(httpContext, newClaims, resetIssued, minExpires);
     }
 
     /// <summary>
@@ -33,6 +34,7 @@ public static class HttpContextExtensions
     public static async Task<ClaimsPrincipal> SignInCookies(
         this HttpContext httpContext,
         IEnumerable<Claim> newClaims,
+        bool resetIssued,
         TimeSpan? minExpires = null)
     {
         var scheme = CookieAuthenticationDefaults.AuthenticationScheme;
@@ -67,7 +69,7 @@ public static class HttpContextExtensions
 
         var properties = new AuthenticationProperties()
         {
-            IssuedUtc = authenticateResult.Properties?.IssuedUtc,
+            IssuedUtc = resetIssued ? DateTimeOffset.UtcNow : authenticateResult.Properties?.IssuedUtc,
             ExpiresUtc = expires
         };
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/Security/DelegatedAuthenticationHandler.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/Security/DelegatedAuthenticationHandler.cs
@@ -42,7 +42,7 @@ public class DelegatedAuthenticationHandler : IAuthenticationHandler
             // Add a claim the indicates user has authenticated via this scheme
             var markerClaim = new Claim(SignedInToDelegatedSchemeClaimType, _scheme.Name);
 
-            var principal = await _context.SignInCookies(new[] { markerClaim }, _options.Expires);
+            var principal = await _context.SignInCookies(new[] { markerClaim }, resetIssued: false, _options.Expires);
 
             if (_options.OnUserSignedIn is not null)
             {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Authenticated/UpdateName.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Authenticated/UpdateName.cshtml.cs
@@ -94,7 +94,7 @@ public class UpdateNameModel : PageModel
 
             await _dbContext.SaveChangesAsync();
 
-            await HttpContext.SignInCookies(user);
+            await HttpContext.SignInCookies(user, resetIssued: false);
 
             if (HttpContext.TryGetAuthenticationState(out var authenticationState))
             {


### PR DESCRIPTION
Our SignIn method used to maintain the original IssuedUtc property for users who were already signed in. That meant that users who were signing in again more than 20 minutes after the initial sign in were stuck as the maxage check in the authorize endpoint was always rejecting their principal as too old and restarting the journey.

This change adds an additional parameter to the SignIn method - resetIssues - which, when set, will reset the Issued property on the AuthenticationTicket. We set that to true only when signing in as part of the sign in journey.