### PR TITLE
Don't redeploy DB schema when running tests unless it's changed

### DIFF
--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/DbHelper.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/DbHelper.cs
@@ -1,6 +1,8 @@
+using System.Data.Common;
+using System.Security.Cryptography;
+using System.Text;
 using Microsoft.EntityFrameworkCore;
 using Respawn;
-using Respawn.Graph;
 using TeacherIdentity.AuthServer.Models;
 
 namespace TeacherIdentity.AuthServer.TestCommon;
@@ -8,21 +10,22 @@ namespace TeacherIdentity.AuthServer.TestCommon;
 public class DbHelper
 {
     private readonly string _connectionString;
-    private Checkpoint _checkpoint;
+    private Respawner? _respawner;
     private readonly SemaphoreSlim _schemaLock = new(1, 1);
     private bool _haveResetSchema = false;
 
     public DbHelper(string connectionString)
     {
         _connectionString = connectionString;
-        _checkpoint = CreateRespawner();
     }
 
     public async Task ClearData()
     {
         using var dbContext = TeacherIdentityServerDbContext.Create(_connectionString);
         await dbContext.Database.OpenConnectionAsync();
-        await _checkpoint.Reset(dbContext.Database.GetDbConnection());
+        var connection = dbContext.Database.GetDbConnection();
+        await EnsureRespawner(connection);
+        await _respawner!.ResetAsync(connection);
     }
 
     public async Task EnsureSchema()
@@ -46,18 +49,47 @@ public class DbHelper
     public async Task ResetSchema()
     {
         using var dbContext = TeacherIdentityServerDbContext.Create(_connectionString);
+
+        var connection = dbContext.Database.GetDbConnection();
+        var dbName = connection.Database;
+
+        var cachedMigrationsVersionPath = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+            "TeacherIdentity.Tests",
+            $"{dbName}-dbversion.txt");
+
+        var currentDbVersion = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(dbContext.Database.GenerateCreateScript())));
+
+        if (currentDbVersion == GetPreviousMigrationsVersion())
+        {
+            await ClearData();
+            return;
+        }
+
         await dbContext.Database.EnsureDeletedAsync();
         await dbContext.Database.MigrateAsync();
 
-        _checkpoint = CreateRespawner();
+        WriteMigrationsVersion();
+
+        await connection.OpenAsync();
+        await EnsureRespawner(connection);
+
+        string? GetPreviousMigrationsVersion() =>
+            File.Exists(cachedMigrationsVersionPath) ? File.ReadAllText(cachedMigrationsVersionPath) : null;
+
+        void WriteMigrationsVersion()
+        {
+            var directory = Path.GetDirectoryName(cachedMigrationsVersionPath)!;
+            Directory.CreateDirectory(directory);
+            File.WriteAllText(cachedMigrationsVersionPath, currentDbVersion);
+        }
     }
 
-    private static Checkpoint CreateRespawner() => new Checkpoint()
-    {
-        DbAdapter = DbAdapter.Postgres,
-        TablesToIgnore = new Table[]
-        {
-            "applications"
-        }
-    };
+    private async Task EnsureRespawner(DbConnection connection) =>
+        _respawner = await Respawner.CreateAsync(
+            connection,
+            new RespawnerOptions()
+            {
+                DbAdapter = DbAdapter.Postgres
+            });
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TeacherIdentity.AuthServer.TestCommon.csproj
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TeacherIdentity.AuthServer.TestCommon.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Respawn" Version="5.0.1" />
+    <PackageReference Include="Respawn" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Deleting and rebuilding the DB whenever tests are run is becoming slow. This change means we only rebuild the DB if the model has changed.