### PR TITLE
Improved word wrapping of long emails

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/HtmlHelperExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/HtmlHelperExtensions.cs
@@ -1,0 +1,17 @@
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc.Rendering;
+
+namespace TeacherIdentity.AuthServer;
+
+public static partial class HtmlHelperExtensions
+{
+    public static HtmlString ShyEmail(this IHtmlHelper htmlHelper, string email)
+    {
+        var escaped = new HtmlString(email).Value!;
+        return new HtmlString(string.Join("&shy;", ShyEmailSplitPattern().Matches(escaped)));
+    }
+
+    [GeneratedRegex("\\W?\\w+")]
+    private static partial Regex ShyEmailSplitPattern();
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Complete.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Complete.cshtml
@@ -42,7 +42,7 @@
                     <span data-testid="known-trn-content"></span>
                     <p>Thank you, we’ve finished checking our records.</p>
 
-                    <p>We’ll only need your email address <strong>(@Model.Email)</strong> to find your details in future.</p>
+                    <p>We’ll only need your email address <strong>(@Html.ShyEmail(Model.Email!))</strong> to find your details in future.</p>
                 }
                 else
                 {
@@ -70,7 +70,7 @@
                     </govuk-summary-list-row>
                     <govuk-summary-list-row>
                         <govuk-summary-list-row-key>Email address</govuk-summary-list-row-key>
-                        <govuk-summary-list-row-value>@Model.Email</govuk-summary-list-row-value>
+                        <govuk-summary-list-row-value>@Html.ShyEmail(Model.Email!)</govuk-summary-list-row-value>
                         <govuk-summary-list-row-actions>
                             <govuk-summary-list-row-action visually-hidden-text="email" href="@LinkGenerator.UpdateEmail(returnUrl: LinkGenerator.CompleteAuthorization(), cancelUrl: LinkGenerator.CompleteAuthorization())">Change</govuk-summary-list-row-action>
                         </govuk-summary-list-row-actions>


### PR DESCRIPTION
Long emails are wrapped in a not-so-great way by default. This change mirrors what Find does to wrap on non-word characters.

Before:
![image](https://user-images.githubusercontent.com/2041280/208661117-d594d1b5-308d-40b5-8748-15fd4262c7f0.png)


After:
![localhost_7236_sign-in_complete_asid=f4c83d65-3735-478f-9c31-4388d15a42b2](https://user-images.githubusercontent.com/2041280/208661093-50884e28-e6fd-4a86-a045-0708b0e7a344.png)
