### PR TITLE
Add TrnLookupStatus to User

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -30,7 +30,7 @@ Currently the only implemented notification is when a user is changed (name, ema
 
 ### `UserUpdated`
 
-`UserUpdated` is generated when a user's email address, name, TRN and/or date of birth have been changed, whether by an API call or by the user themselves. It has the following message schema:
+`UserUpdated` is generated when a user's email address, name, TRN, TRN lookup status and/or date of birth have been changed, whether by an API call or by the user themselves. It has the following message schema:
 
 ```json
 {
@@ -40,14 +40,16 @@ Currently the only implemented notification is when a user is changed (name, ema
     "firstName": "",
     "lastName": "",
     "dateOfBirth": "",
-    "trn": ""
+    "trn": "",
+    "trnLookupStatus": "None|Pending|Found|Failed"
   },
   "changes": {
     "emailAddress": "",
     "firstName": "",
     "lastName": "",
     "dateOfBirth": "",
-    "trn": ""
+    "trn": "",
+    "trnLookupStatus": ""
   }
 }
 ```

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Handlers/SetTeacherTrnHandler.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Handlers/SetTeacherTrnHandler.cs
@@ -38,7 +38,13 @@ public class SetTeacherTrnHandler : IRequestHandler<SetTeacherTrnRequest>
             return Unit.Value;
         }
 
+        if (user.Trn is not null)
+        {
+            throw new ErrorException(ErrorRegistry.UserAlreadyHasTrnAssigned());
+        }
+
         user.Trn = request.Body.Trn;
+        user.TrnLookupStatus = TrnLookupStatus.Found;
         user.TrnAssociationSource = TrnAssociationSource.Api;
         user.Updated = _clock.UtcNow;
 
@@ -46,7 +52,7 @@ public class SetTeacherTrnHandler : IRequestHandler<SetTeacherTrnRequest>
         {
             Source = Events.UserUpdatedEventSource.Api,
             CreatedUtc = _clock.UtcNow,
-            Changes = Events.UserUpdatedEventChanges.Trn,
+            Changes = Events.UserUpdatedEventChanges.Trn | Events.UserUpdatedEventChanges.TrnLookupStatus,
             User = Events.User.FromModel(user)
         });
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/Validation/ErrorRegistry.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/Validation/ErrorRegistry.cs
@@ -9,6 +9,7 @@ public static class ErrorRegistry
         new ErrorDescriptor(10003, "User not found"),
         new ErrorDescriptor(10004, "Request is not valid"),
         new ErrorDescriptor(10005, "You are not authorized to perform this action"),
+        new ErrorDescriptor(10006, "User already has a TRN assigned"),
     }.ToDictionary(d => d.ErrorCode, d => d);
 
     public static Error UserMustBeTeacher() => CreateError(10001);
@@ -20,6 +21,8 @@ public static class ErrorRegistry
     public static Error RequestIsNotValid() => CreateError(10004);
 
     public static Error YouAreNotAuthorizedToPerformThisAction() => CreateError(10005);
+
+    public static Error UserAlreadyHasTrnAssigned() => CreateError(10006);
 
     private static Error CreateError(int errorCode, string? detail = null)
     {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -73,6 +73,8 @@ public class AuthenticationState
     public TrnLookupState TrnLookup { get; private set; }
     [JsonInclude]
     public string? TrnOwnerEmailAddress { get; private set; }
+    [JsonInclude]
+    public TrnLookupStatus? TrnLookupStatus { get; private set; }
 
     /// <summary>
     /// Whether the user has gone back to an earlier page after this journey has been completed.
@@ -114,7 +116,8 @@ public class AuthenticationState
             HaveCompletedTrnLookup = principal.GetHaveCompletedTrnLookup(throwIfMissing: false) ?? false,
             TrnLookup = principal.GetHaveCompletedTrnLookup(throwIfMissing: false) == true ? TrnLookupState.Complete : TrnLookupState.None,
             UserType = principal.GetUserType(throwIfMissing: false),
-            StaffRoles = principal.GetStaffRoles()
+            StaffRoles = principal.GetStaffRoles(),
+            TrnLookupStatus = principal.GetTrnLookupStatus(throwIfMissing: false)
         };
     }
 
@@ -203,6 +206,7 @@ public class AuthenticationState
         HaveCompletedTrnLookup = default;
         TrnLookup = default;
         TrnOwnerEmailAddress = default;
+        TrnLookupStatus = default;
     }
 
     public void OnEmailSet(string email)
@@ -239,6 +243,7 @@ public class AuthenticationState
             Trn = user.Trn;
             UserType = user.UserType;
             StaffRoles = user.StaffRoles;
+            TrnLookupStatus = user.TrnLookupStatus;
 
             if (HaveCompletedTrnLookup)
             {
@@ -305,6 +310,7 @@ public class AuthenticationState
         TrnLookup = TrnLookupState.Complete;
         UserType = user.UserType;
         StaffRoles = user.StaffRoles;
+        TrnLookupStatus = user.TrnLookupStatus;
     }
 
     public void OnEmailVerifiedOfExistingAccountForTrn()
@@ -363,6 +369,7 @@ public class AuthenticationState
         TrnLookup = TrnLookupState.Complete;
         UserType = user.UserType;
         StaffRoles = user.StaffRoles;
+        TrnLookupStatus = user.TrnLookupStatus;
     }
 
     public void OnEmailChanged(string email)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
@@ -400,7 +400,11 @@ public class AuthorizationController : Controller
                 yield break;
 
             case CustomClaims.Trn:
-                yield return Destinations.IdentityToken;
+            case CustomClaims.TrnLookupStatus:
+                if (principal.HasScope(CustomScopes.Trn))
+                {
+                    yield return Destinations.IdentityToken;
+                }
 
                 yield break;
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Events/User.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Events/User.cs
@@ -13,6 +13,7 @@ public record User
     public required string? Trn { get; init; }
     public required TrnAssociationSource? TrnAssociationSource { get; init; }
     public required string[] StaffRoles { get; init; } = Array.Empty<string>();
+    public required TrnLookupStatus TrnLookupStatus { get; init; }
 
     public static User FromModel(Models.User user) => new()
     {
@@ -23,6 +24,7 @@ public record User
         StaffRoles = user.StaffRoles,
         Trn = user.Trn,
         TrnAssociationSource = user.TrnAssociationSource,
+        TrnLookupStatus = user.TrnLookupStatus,
         UserId = user.UserId,
         UserType = user.UserType
     };

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Events/UserUpdatedEvent.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Events/UserUpdatedEvent.cs
@@ -16,6 +16,7 @@ public enum UserUpdatedEventChanges
     LastName = 1 << 2,
     DateOfBirth = 1 << 3,
     Trn = 1 << 4,
+    TrnLookupStatus = 1 << 5
 }
 
 public enum UserUpdatedEventSource

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20221222104147_UserTrnLookupStatus.Designer.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20221222104147_UserTrnLookupStatus.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeacherIdentity.AuthServer.Models;
@@ -11,9 +12,11 @@ using TeacherIdentity.AuthServer.Models;
 namespace TeacherIdentity.AuthServer.Migrations
 {
     [DbContext(typeof(TeacherIdentityServerDbContext))]
-    partial class TeacherIdentityServerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20221222104147_UserTrnLookupStatus")]
+    partial class UserTrnLookupStatus
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20221222104147_UserTrnLookupStatus.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20221222104147_UserTrnLookupStatus.cs
@@ -1,0 +1,31 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeacherIdentity.AuthServer.Migrations
+{
+    /// <inheritdoc />
+    public partial class UserTrnLookupStatus : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "trn_lookup_status",
+                table: "users",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.Sql("update users set trn_lookup_status = case when trn is null then 1 else 2 end where user_type = 0");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "trn_lookup_status",
+                table: "users");
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/Mappings/UserMapping.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/Mappings/UserMapping.cs
@@ -23,6 +23,7 @@ public class UserMapping : IEntityTypeConfiguration<User>
         builder.Property(u => u.StaffRoles).HasColumnType("varchar[]");
         builder.Property(u => u.RegisteredWithClientId).HasMaxLength(100);
         builder.Property<bool>("is_deleted").IsRequired().HasDefaultValue(false);
+        builder.Property(u => u.TrnLookupStatus).IsRequired();
         builder.HasOne(u => u.RegisteredWithClient).WithMany().HasForeignKey(u => u.RegisteredWithClientId).HasPrincipalKey(a => a.ClientId);
         builder.HasQueryFilter(u => EF.Property<bool>(u, "is_deleted") == false);
     }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/User.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/User.cs
@@ -23,4 +23,5 @@ public class User
     public string[] StaffRoles { get; set; } = Array.Empty<string>();
     public Application? RegisteredWithClient { get; set; }
     public string? RegisteredWithClientId { get; set; }
+    public TrnLookupStatus TrnLookupStatus { get; set; }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Notifications/Messages/User.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Notifications/Messages/User.cs
@@ -8,6 +8,7 @@ public record User
     public required string LastName { get; init; }
     public required DateOnly? DateOfBirth { get; init; }
     public required string? Trn { get; init; }
+    public required TrnLookupStatus TrnLookupStatus { get; init; }
 
     public static User FromEvent(Events.User user) => new()
     {
@@ -16,6 +17,7 @@ public record User
         FirstName = user.FirstName,
         LastName = user.LastName,
         Trn = user.Trn,
+        TrnLookupStatus = user.TrnLookupStatus,
         UserId = user.UserId
     };
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Oidc/CustomClaims.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Oidc/CustomClaims.cs
@@ -5,6 +5,7 @@ public static class CustomClaims
     public const string DateFormat = "yyyy-MM-dd";
 
     public const string Trn = "trn";
+    public const string TrnLookupStatus = "trn-lookup-status";
     public const string HaveCompletedTrnLookup = "completed-trn-lookup";
     public const string UserType = "user-type";
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnCallback.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnCallback.cshtml.cs
@@ -67,7 +67,8 @@ public class TrnCallbackModel : PageModel
             Trn = lookupState.Trn,
             TrnAssociationSource = !string.IsNullOrEmpty(lookupState.Trn) ? TrnAssociationSource.Lookup : null,
             LastSignedIn = _clock.UtcNow,
-            RegisteredWithClientId = authenticationState.OAuthState?.ClientId
+            RegisteredWithClientId = authenticationState.OAuthState?.ClientId,
+            TrnLookupStatus = lookupState.Trn is not null ? TrnLookupStatus.Found : TrnLookupStatus.Pending
         };
 
         _dbContext.Users.Add(user);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/TrnLookupStatus.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/TrnLookupStatus.cs
@@ -1,0 +1,9 @@
+namespace TeacherIdentity.AuthServer;
+
+public enum TrnLookupStatus
+{
+    None = 0,
+    Pending = 1,
+    Found = 2,
+    Failed = 3
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/UserClaimHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/UserClaimHelper.cs
@@ -38,6 +38,9 @@ public static class UserClaimHelper
     public static UserType? GetUserType(this ClaimsPrincipal principal, bool throwIfMissing = true) =>
         GetClaim(principal, CustomClaims.UserType, throwIfMissing, value => Enum.Parse<UserType>(value));
 
+    public static TrnLookupStatus? GetTrnLookupStatus(this ClaimsPrincipal principal, bool throwIfMissing = true) =>
+        GetClaim(principal, CustomClaims.TrnLookupStatus, throwIfMissing, value => Enum.Parse<TrnLookupStatus>(value));
+
     public static IEnumerable<Claim> GetInternalClaims(User user)
     {
         return GetInternalClaims(
@@ -49,7 +52,8 @@ public static class UserClaimHelper
             user.Trn,
             user.CompletedTrnLookup.HasValue,
             user.UserType,
-            user.StaffRoles);
+            user.StaffRoles,
+            user.TrnLookupStatus);
     }
 
     public static IEnumerable<Claim> GetInternalClaims(AuthenticationState authenticationState)
@@ -68,7 +72,8 @@ public static class UserClaimHelper
             authenticationState.Trn,
             authenticationState.HaveCompletedTrnLookup,
             authenticationState.UserType!.Value,
-            authenticationState.StaffRoles);
+            authenticationState.StaffRoles,
+            authenticationState.TrnLookupStatus!.Value);
     }
 
     public static IEnumerable<Claim> GetPublicClaims(User user, Func<string, bool> hasScope)
@@ -80,7 +85,8 @@ public static class UserClaimHelper
             user.FirstName,
             user.LastName,
             user.DateOfBirth,
-            user.Trn);
+            user.Trn,
+            user.TrnLookupStatus);
     }
 
     public static IEnumerable<Claim> GetPublicClaims(AuthenticationState authenticationState, Func<string, bool> hasScope)
@@ -97,7 +103,8 @@ public static class UserClaimHelper
             authenticationState.FirstName!,
             authenticationState.LastName!,
             authenticationState.DateOfBirth,
-            authenticationState.Trn);
+            authenticationState.Trn,
+            authenticationState.TrnLookupStatus!.Value);
     }
 
     private static string? GetClaim(ClaimsPrincipal principal, string claimType, bool throwIfMissing)
@@ -148,7 +155,8 @@ public static class UserClaimHelper
         string? trn,
         bool haveCompletedTrnLookup,
         UserType userType,
-        string[]? staffRoles)
+        string[]? staffRoles,
+        TrnLookupStatus trnLookupStatus)
     {
         yield return new Claim(Claims.Subject, userId.ToString()!);
         yield return new Claim(Claims.Email, email);
@@ -158,6 +166,7 @@ public static class UserClaimHelper
         yield return new Claim(Claims.FamilyName, lastName);
         yield return new Claim(CustomClaims.HaveCompletedTrnLookup, haveCompletedTrnLookup.ToString());
         yield return new Claim(CustomClaims.UserType, userType.ToString());
+        yield return new Claim(CustomClaims.TrnLookupStatus, trnLookupStatus.ToString());
 
         if (dateOfBirth.HasValue)
         {
@@ -182,7 +191,8 @@ public static class UserClaimHelper
         string firstName,
         string lastName,
         DateOnly? dateOfBirth,
-        string? trn)
+        string? trn,
+        TrnLookupStatus trnLookupStatus)
     {
         yield return new Claim(Claims.Subject, userId.ToString()!);
         yield return new Claim(Claims.Email, email);
@@ -196,9 +206,14 @@ public static class UserClaimHelper
             yield return new Claim(Claims.Birthdate, dateOfBirth!.Value.ToString(CustomClaims.DateFormat));
         }
 
-        if (trn is not null && hasScope(CustomScopes.Trn))
+        if (hasScope(CustomScopes.Trn))
         {
-            yield return new Claim(CustomClaims.Trn, trn);
+            yield return new Claim(CustomClaims.TrnLookupStatus, trnLookupStatus.ToString());
+
+            if (trn is not null)
+            {
+                yield return new Claim(CustomClaims.Trn, trn);
+            }
         }
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateTests.cs
@@ -34,7 +34,8 @@ public partial class AuthenticationStateTests
             new Claim(Claims.Birthdate, dateOfBirth.ToString("yyyy-MM-dd")),
             new Claim(CustomClaims.HaveCompletedTrnLookup, haveCompletedTrnLookup.ToString()),
             new Claim(CustomClaims.Trn, trn),
-            new Claim(CustomClaims.UserType, userType.ToString())
+            new Claim(CustomClaims.UserType, userType.ToString()),
+            new Claim(CustomClaims.TrnLookupStatus, TrnLookupStatus.Found.ToString())
         };
         var principal = new ClaimsPrincipal(new ClaimsIdentity(claims));
 
@@ -63,6 +64,7 @@ public partial class AuthenticationStateTests
         Assert.Equal(userId, authenticationState.UserId);
         Assert.Equal(AuthenticationState.TrnLookupState.Complete, authenticationState.TrnLookup);
         Assert.Equal(userType, authenticationState.UserType);
+        Assert.Equal(TrnLookupStatus.Found, authenticationState.TrnLookupStatus);
     }
 
     [Fact]
@@ -90,7 +92,8 @@ public partial class AuthenticationStateTests
             new Claim(Claims.Birthdate, dateOfBirth.ToString("yyyy-MM-dd")),
             new Claim(Claims.Role, StaffRoles.GetAnIdentityAdmin),
             new Claim(Claims.Role, StaffRoles.GetAnIdentitySupport),
-            new Claim(CustomClaims.UserType, userType.ToString())
+            new Claim(CustomClaims.UserType, userType.ToString()),
+            new Claim(CustomClaims.TrnLookupStatus, TrnLookupStatus.None.ToString())
         };
         var principal = new ClaimsPrincipal(new ClaimsIdentity(claims));
 
@@ -117,6 +120,7 @@ public partial class AuthenticationStateTests
         Assert.Equal(staffRoles, authenticationState.StaffRoles);
         Assert.Equal(userId, authenticationState.UserId);
         Assert.Equal(userType, authenticationState.UserType);
+        Assert.Equal(TrnLookupStatus.None, authenticationState.TrnLookupStatus);
     }
 
     [Fact]
@@ -132,6 +136,7 @@ public partial class AuthenticationStateTests
         var trn = "2345678";
         var userId = Guid.NewGuid();
         var userType = UserType.Default;
+        var trnLookupStatus = TrnLookupStatus.Found;
 
         var user = new User()
         {
@@ -144,7 +149,8 @@ public partial class AuthenticationStateTests
             Trn = trn,
             Updated = DateTime.UtcNow,
             UserId = userId,
-            UserType = userType
+            UserType = userType,
+            TrnLookupStatus = trnLookupStatus
         };
 
         var journeyId = Guid.NewGuid();
@@ -174,7 +180,8 @@ public partial class AuthenticationStateTests
             new Claim(Claims.Birthdate, dateOfBirth.ToString("yyyy-MM-dd")),
             new Claim(CustomClaims.HaveCompletedTrnLookup, haveCompletedTrnLookup.ToString()),
             new Claim(CustomClaims.Trn, trn),
-            new Claim(CustomClaims.UserType, userType.ToString())
+            new Claim(CustomClaims.UserType, userType.ToString()),
+            new Claim(CustomClaims.TrnLookupStatus, trnLookupStatus.ToString())
         };
         Assert.Equal(expectedClaims.OrderBy(c => c.Type), claims.OrderBy(c => c.Type), new ClaimTypeAndValueEqualityComparer());
     }
@@ -233,7 +240,8 @@ public partial class AuthenticationStateTests
             new Claim(Claims.Role, StaffRoles.GetAnIdentityAdmin),
             new Claim(Claims.Role, StaffRoles.GetAnIdentitySupport),
             new Claim(CustomClaims.HaveCompletedTrnLookup, bool.FalseString),
-            new Claim(CustomClaims.UserType, userType.ToString())
+            new Claim(CustomClaims.UserType, userType.ToString()),
+            new Claim(CustomClaims.TrnLookupStatus, TrnLookupStatus.None.ToString())
         };
         Assert.Equal(expectedClaims.OrderBy(c => c.Type), claims.OrderBy(c => c.Type), new ClaimTypeAndValueEqualityComparer());
     }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnCallbackTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnCallbackTests.cs
@@ -82,10 +82,8 @@ public class TrnCallbackTests : TestBase
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public async Task Get_ValidCallbackWithPreferredNames_CreatesUserWithPreferredNames(bool hasTrn)
+    [Fact]
+    public async Task Get_ValidCallbackWithPreferredNames_CreatesUserWithPreferredNames()
     {
         // Arrange
         var email = Faker.Internet.Email();
@@ -94,7 +92,7 @@ public class TrnCallbackTests : TestBase
         var preferredFirstName = Faker.Name.First();
         var preferredLastName = Faker.Name.Last();
         var dateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
-        var trn = hasTrn ? TestData.GenerateTrn() : null;
+        var trn = TestData.GenerateTrn();
 
         var authStateHelper = await CreateAuthenticationStateHelper(
             c => c.TrnLookupCallbackCompleted(email, trn, dateOfBirth, firstName, lastName, preferredFirstName, preferredLastName));
@@ -115,15 +113,6 @@ public class TrnCallbackTests : TestBase
             Assert.NotNull(user);
             Assert.Equal(preferredFirstName, user.FirstName);
             Assert.Equal(preferredLastName, user.LastName);
-
-            if (hasTrn)
-            {
-                Assert.Equal(TrnAssociationSource.Lookup, user.TrnAssociationSource);
-            }
-            else
-            {
-                Assert.Null(user.TrnAssociationSource);
-            }
         });
     }
 
@@ -172,10 +161,12 @@ public class TrnCallbackTests : TestBase
             if (hasTrn)
             {
                 Assert.Equal(TrnAssociationSource.Lookup, user.TrnAssociationSource);
+                Assert.Equal(TrnLookupStatus.Found, user.TrnLookupStatus);
             }
             else
             {
                 Assert.Null(user.TrnAssociationSource);
+                Assert.Equal(TrnLookupStatus.Pending, user.TrnLookupStatus);
             }
 
             var lookupState = await dbContext.JourneyTrnLookupStates.SingleAsync(s => s.JourneyId == authStateHelper.AuthenticationState.JourneyId);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/UserClaimHelperTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/UserClaimHelperTests.cs
@@ -23,7 +23,8 @@ public class UserClaimHelperTests
             Trn = "1234567",
             Created = DateTime.UtcNow,
             UserType = UserType.Default,
-            Updated = DateTime.UtcNow
+            Updated = DateTime.UtcNow,
+            TrnLookupStatus = TrnLookupStatus.Found
         };
 
         // Act
@@ -46,6 +47,7 @@ public class UserClaimHelperTests
         if (haveTrnScope)
         {
             expectedClaims.Add(new Claim(CustomClaims.Trn, user.Trn));
+            expectedClaims.Add(new Claim(CustomClaims.TrnLookupStatus, user.TrnLookupStatus.ToString()));
         }
 
         Assert.Equal(expectedClaims.OrderBy(c => c.Type), result.OrderBy(c => c.Type), new ClaimTypeAndValueEqualityComparer());
@@ -68,7 +70,8 @@ public class UserClaimHelperTests
             CompletedTrnLookup = DateTime.UtcNow,
             Created = DateTime.UtcNow,
             UserType = UserType.Default,
-            Updated = DateTime.UtcNow
+            Updated = DateTime.UtcNow,
+            TrnLookupStatus = TrnLookupStatus.Found
         };
 
         Func<string, bool> hasScope = s => s == CustomScopes.Trn && haveTrnScope;
@@ -106,6 +109,7 @@ public class UserClaimHelperTests
         if (haveTrnScope)
         {
             expectedClaims.Add(new Claim(CustomClaims.Trn, authenticationState.Trn!));
+            expectedClaims.Add(new Claim(CustomClaims.TrnLookupStatus, authenticationState.TrnLookupStatus!.Value.ToString()));
         }
 
         Assert.Equal(expectedClaims.OrderBy(c => c.Type), result.OrderBy(c => c.Type), new ClaimTypeAndValueEqualityComparer());


### PR DESCRIPTION
We need to be able to track when we've raised support tickets to resolve a user's TRN and whether that process is completed (either successfully or not) and whether it's still pending. `TrnLookupStatus` tracks that state.