### PR TITLE
Amend SetTeacherTrn endpoint to allow null

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Requests/SetTeacherTrnRequest.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Requests/SetTeacherTrnRequest.cs
@@ -10,5 +10,5 @@ public record SetTeacherTrnRequest : IRequest
 
 public record SetTeacherTrnRequestBody
 {
-    public required string Trn { get; init; }
+    public required string? Trn { get; init; }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Validators/SetTeacherTrnRequestValidator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Validators/SetTeacherTrnRequestValidator.cs
@@ -8,9 +8,7 @@ public class SetTeacherTrnRequestValidator : AbstractValidator<SetTeacherTrnRequ
     public SetTeacherTrnRequestValidator()
     {
         RuleFor(r => r.Body.Trn)
-            .NotEmpty()
-                .WithMessage("TRN is required.")
-            .Must(trn => trn?.Length == 7 && trn.All(c => c >= '0' && c <= '9'))
+            .Must(trn => trn is null || (trn.Length == 7 && trn.All(Char.IsAsciiDigit)))
                 .WithMessage("TRN is not valid.");
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/TestData.CreateUser.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/TestData.CreateUser.cs
@@ -9,7 +9,8 @@ public partial class TestData
             bool? hasTrn = null,
             bool? haveCompletedTrnLookup = null,
             UserType userType = UserType.Default,
-            string? registeredWithClientId = null) =>
+            string? registeredWithClientId = null,
+            TrnLookupStatus? trnLookupStatus = null) =>
         WithDbContext(async dbContext =>
         {
             if (hasTrn is null && userType == UserType.Default)
@@ -19,6 +20,11 @@ public partial class TestData
             else if (hasTrn == true && userType != UserType.Default)
             {
                 throw new ArgumentException($"Only {UserType.Default} users should have a TRN.");
+            }
+
+            if (hasTrn == true && (trnLookupStatus ?? TrnLookupStatus.Found) != TrnLookupStatus.Found)
+            {
+                throw new ArgumentException($"{nameof(TrnLookupStatus)} must be {TrnLookupStatus.Found} when the user has a TRN.");
             }
 
             if (haveCompletedTrnLookup == true && userType == UserType.Default)
@@ -42,7 +48,7 @@ public partial class TestData
                 DateOfBirth = userType is UserType.Default ? DateOnly.FromDateTime(Faker.Identification.DateOfBirth()) : null,
                 Trn = hasTrn == true ? GenerateTrn() : null,
                 TrnAssociationSource = hasTrn == true ? TrnAssociationSource.Lookup : null,
-                TrnLookupStatus = userType == UserType.Default ? (hasTrn == true ? TrnLookupStatus.Found : TrnLookupStatus.None) : null,
+                TrnLookupStatus = trnLookupStatus ?? (userType == UserType.Default ? (hasTrn == true ? TrnLookupStatus.Found : TrnLookupStatus.None) : null),
                 Updated = _clock.UtcNow,
                 RegisteredWithClientId = registeredWithClientId
             };


### PR DESCRIPTION
`null` is when the support agent tried to find the TRN manually but could not. In this case, we set `TrnLookupStatus` to failed.