### PR TITLE
Avoid using response DTOs in tests

### DIFF
--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AssertEx.Http.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AssertEx.Http.cs
@@ -5,7 +5,7 @@ namespace TeacherIdentity.AuthServer.Tests;
 
 public static partial class AssertEx
 {
-    public static async Task<T> JsonResponse<T>(HttpResponseMessage response, int expectedStatusCode = StatusCodes.Status200OK)
+    public static async Task<JsonDocument> JsonResponse(HttpResponseMessage response, int expectedStatusCode = StatusCodes.Status200OK)
     {
         if (response is null)
         {
@@ -15,7 +15,7 @@ public static partial class AssertEx
         Assert.Equal(expectedStatusCode, (int)response.StatusCode);
         Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
 
-        var result = await response.Content.ReadFromJsonAsync<T>(SerializerOptions);
+        var result = await response.Content.ReadFromJsonAsync<JsonDocument>(SerializerOptions);
         Assert.NotNull(result);
         return result!;
     }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AssertEx.Json.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AssertEx.Json.cs
@@ -20,7 +20,10 @@ public static partial class AssertEx
     public static void JsonEquals(string expected, string actual) =>
         JsonEquals(JsonNode.Parse(expected), JsonNode.Parse(actual));
 
-    public static void JsonObjectEquals(object actual, object expected) =>
+    public static void JsonObjectEquals(JsonDocument expected, object actual) =>
+        JsonEquals(JsonSerializer.SerializeToNode(expected.RootElement), JsonSerializer.SerializeToNode(actual, SerializerOptions));
+
+    public static void JsonObjectEquals(object expected, object actual) =>
         JsonEquals(JsonSerializer.SerializeToNode(expected, SerializerOptions), JsonSerializer.SerializeToNode(actual, SerializerOptions));
 
     public static void JsonEquals(JsonNode? expected, JsonNode? actual)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/GetUserDetailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/GetUserDetailTests.cs
@@ -1,4 +1,3 @@
-using TeacherIdentity.AuthServer.Api.V1.Responses;
 using TeacherIdentity.AuthServer.Oidc;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Api.V1;
@@ -53,16 +52,22 @@ public class GetUserDetailTests : TestBase
         var response = await httpClient.GetAsync($"/api/v1/users/{user.UserId}");
 
         // Assert
-        var responseObj = await AssertEx.JsonResponse<GetUserDetailResponse>(response);
+        var responseObj = await AssertEx.JsonResponse(response);
 
-        Assert.Equal(user.UserId, responseObj.UserId);
-        Assert.Equal(user.EmailAddress, responseObj.Email);
-        Assert.Equal(user.FirstName, responseObj.FirstName);
-        Assert.Equal(user.LastName, responseObj.LastName);
-        Assert.Equal(user.Trn, responseObj.Trn);
-        Assert.Equal(user.Created, responseObj.Created);
-        Assert.Equal(registeredWithClient.ClientId, responseObj.RegisteredWithClientId);
-        Assert.Equal(registeredWithClient.DisplayName, responseObj.RegisteredWithClientDisplayName);
+        AssertEx.JsonObjectEquals(
+            responseObj,
+            new
+            {
+                userId = user.UserId,
+                email = user.EmailAddress,
+                firstName = user.FirstName,
+                lastName = user.LastName,
+                dateOfBirth = user.DateOfBirth,
+                trn = user.Trn,
+                created = user.Created,
+                registeredWithClientId = registeredWithClient.ClientId,
+                registeredWithClientDisplayName = registeredWithClient.DisplayName
+            });
     }
 
     public static TheoryData<string> NotPermittedScopes => ScopeTheoryData.GetAllStaffUserScopesExcept(PermittedScopes);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/UpdateUserTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/UpdateUserTests.cs
@@ -1,5 +1,4 @@
 using Microsoft.EntityFrameworkCore;
-using TeacherIdentity.AuthServer.Api.V1.ApiModels;
 using TeacherIdentity.AuthServer.Events;
 using TeacherIdentity.AuthServer.Oidc;
 
@@ -158,11 +157,11 @@ public class UpdateUserTests : TestBase
         var response = await httpClient.SendAsync(request);
 
         // Assert
-        var responseObj = await AssertEx.JsonResponse<UserInfo>(response);
-        Assert.Equal(user.UserId, responseObj.UserId);
-        Assert.Equal(updatedEmail, responseObj.Email);
-        Assert.Equal(updatedFirstName, responseObj.FirstName);
-        Assert.Equal(updatedLastName, responseObj.LastName);
+        var responseObj = await AssertEx.JsonResponse(response);
+        Assert.Equal(user.UserId, responseObj.RootElement.GetProperty("userId").GetGuid());
+        Assert.Equal(updatedEmail, responseObj.RootElement.GetProperty("email").GetString());
+        Assert.Equal(updatedFirstName, responseObj.RootElement.GetProperty("firstName").GetString());
+        Assert.Equal(updatedLastName, responseObj.RootElement.GetProperty("lastName").GetString());
 
         user = await TestData.WithDbContext(dbContext => dbContext.Users.SingleAsync(u => u.UserId == user.UserId));
         Assert.Equal(Clock.UtcNow, user.Updated);
@@ -198,11 +197,11 @@ public class UpdateUserTests : TestBase
         var response = await httpClient.SendAsync(request);
 
         // Assert
-        var responseObj = await AssertEx.JsonResponse<UserInfo>(response);
-        Assert.Equal(user.UserId, responseObj.UserId);
-        Assert.Equal(user.EmailAddress, responseObj.Email);
-        Assert.Equal(user.FirstName, responseObj.FirstName);
-        Assert.Equal(user.LastName, responseObj.LastName);
+        var responseObj = await AssertEx.JsonResponse(response);
+        Assert.Equal(user.UserId, responseObj.RootElement.GetProperty("userId").GetGuid());
+        Assert.Equal(user.EmailAddress, responseObj.RootElement.GetProperty("email").GetString());
+        Assert.Equal(user.FirstName, responseObj.RootElement.GetProperty("firstName").GetString());
+        Assert.Equal(user.LastName, responseObj.RootElement.GetProperty("lastName").GetString());
 
         user = await TestData.WithDbContext(dbContext => dbContext.Users.SingleAsync(u => u.UserId == user.UserId));
         Assert.Equal(user.Created, user.Updated);


### PR DESCRIPTION
It's easier to notice when we break an API contract if we *don't* deserialize to response DTOs in tests.