### PR TITLE
Remove password grant

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
@@ -333,11 +333,6 @@ public class Program
                     .AllowAuthorizationCodeFlow()
                     .AllowClientCredentialsFlow();
 
-                if (builder.Environment.IsUnitTests())
-                {
-                    options.AllowPasswordFlow();
-                }
-
                 if (builder.Environment.IsDevelopment() ||
                     builder.Environment.IsUnitTests() ||
                     builder.Environment.IsEndToEndTests())

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/TeacherIdentity.AuthServer.csproj
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/TeacherIdentity.AuthServer.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Joonasw.AspNetCore.SecurityHeaders" Version="4.0.1" />
     <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="7.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="7.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" PrivateAssets="All" Version="7.0.0" />

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Development.json
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Development.json
@@ -5,6 +5,7 @@
       "ApiKeys": [ "stub-find" ]
     }
   ],
+  "BaseAddress": "https://localhost:7236",
   "Clients": [
     {
       "ClientId": "testclient",

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SupportApi.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SupportApi.cs
@@ -1,0 +1,75 @@
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Oidc;
+
+namespace TeacherIdentity.AuthServer.EndToEndTests;
+
+public class SupportApi : IClassFixture<HostFixture>
+{
+    private readonly HostFixture _hostFixture;
+
+    public SupportApi(HostFixture hostFixture)
+    {
+        _hostFixture = hostFixture;
+    }
+
+    [Fact]
+    public async Task SignInWithUserReadScope_CanCallReadSupportEndpointSuccessfully()
+    {
+        var email = Faker.Internet.Email();
+
+        {
+            using var scope = _hostFixture.AuthServerServices.GetRequiredService<IServiceScopeFactory>().CreateScope();
+            using var dbContext = scope.ServiceProvider.GetRequiredService<TeacherIdentityServerDbContext>();
+
+            dbContext.Users.Add(new User()
+            {
+                Created = DateTime.UtcNow,
+                EmailAddress = email,
+                FirstName = "Joe",
+                LastName = "Bloggs",
+                UserId = Guid.NewGuid(),
+                UserType = UserType.Staff,
+                StaffRoles = new[] { StaffRoles.GetAnIdentityAdmin },
+                Updated = DateTime.UtcNow
+            });
+
+            await dbContext.SaveChangesAsync();
+        }
+
+        await using var context = await _hostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        // Start on the client app and try to access a protected area with admin scope
+
+        await page.GotoAsync($"/profile?scope={CustomScopes.UserRead}");
+
+        // Fill in the sign in form (email + PIN)
+
+        await page.FillAsync("text=Enter your email address", email);
+        await page.ClickAsync("button:has-text('Continue')");
+
+        var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
+        await page.FillAsync("text=Enter your code", pin);
+        await page.ClickAsync("button:has-text('Continue')");
+
+        // Should now be on the confirmation page
+
+        Assert.Equal(1, await page.Locator("data-testid=known-user-content").CountAsync());
+        await page.ClickAsync("button:has-text('Continue')");
+
+        // Should now be back at the client, signed in
+
+        var clientAppHost = new Uri(HostFixture.ClientBaseUrl).Host;
+        var pageUrlHost = new Uri(page.Url).Host;
+        Assert.Equal(clientAppHost, pageUrlHost);
+
+        // Call API endpoint that requires user:read scope
+        using var apiHttpClient = new HttpClient()
+        {
+            BaseAddress = new Uri(HostFixture.AuthServerBaseUrl)
+        };
+        apiHttpClient.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", _hostFixture.CapturedAccessTokens.Last());
+        var apiResponse = await apiHttpClient.GetAsync("/api/v1/users");
+        apiResponse.EnsureSuccessStatusCode();
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/appsettings.json
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/appsettings.json
@@ -6,6 +6,7 @@
         "ApiKeys": [ "stub-find" ]
       }
     ],
+    "BaseAddress": "http://localhost:55341",
     "FindALostTrnIntegration": {
       "HandoverEndpoint": "/FindALostTrn/Identity",
       "SharedKey": "OKqdp0+u8QSzwk5unfZrTRZzqwYJSOuo0pOsOIVhkog=",

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/HostFixture.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/HostFixture.cs
@@ -104,10 +104,10 @@ public class HostFixture : WebApplicationFactory<TeacherIdentity.AuthServer.Prog
                 options.Filters.Add(new SignInUserPageFilter());
             });
 
-            // Add the custom test authentication handler
+            // Add the custom test cookie authentication handler
             services.AddSingleton<CurrentUserIdContainer>();
             services.PostConfigure<AuthenticationOptions>(options =>
-                options.Schemes.Single(s => s.Name == CookieAuthenticationDefaults.AuthenticationScheme).HandlerType = typeof(TestAuthenticationHandler));
+                options.Schemes.Single(s => s.Name == CookieAuthenticationDefaults.AuthenticationScheme).HandlerType = typeof(TestCookieAuthenticationHandler));
 
             // Disable tracking sign in events from the Delegated authentication handler
             services.PostConfigure<DelegatedAuthenticationOptions>("Delegated", options =>

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/HostFixture.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/HostFixture.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Microsoft.AspNetCore.Mvc.Testing;
@@ -108,6 +109,11 @@ public class HostFixture : WebApplicationFactory<TeacherIdentity.AuthServer.Prog
             services.AddSingleton<CurrentUserIdContainer>();
             services.PostConfigure<AuthenticationOptions>(options =>
                 options.Schemes.Single(s => s.Name == CookieAuthenticationDefaults.AuthenticationScheme).HandlerType = typeof(TestCookieAuthenticationHandler));
+
+            services.Configure<JwtBearerOptions>(JwtBearerDefaults.AuthenticationScheme, options =>
+            {
+                options.Backchannel = CreateClient();
+            });
 
             // Disable tracking sign in events from the Delegated authentication handler
             services.PostConfigure<DelegatedAuthenticationOptions>("Delegated", options =>

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Infrastructure/TestCookieAuthenticationHandler.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Infrastructure/TestCookieAuthenticationHandler.cs
@@ -7,11 +7,11 @@ using TeacherIdentity.AuthServer.Models;
 
 namespace TeacherIdentity.AuthServer.Tests.Infrastructure;
 
-public class TestAuthenticationHandler : CookieAuthenticationHandler
+public class TestCookieAuthenticationHandler : CookieAuthenticationHandler
 {
     private readonly CurrentUserIdContainer _currentUserIdContainer;
 
-    public TestAuthenticationHandler(
+    public TestCookieAuthenticationHandler(
         CurrentUserIdContainer currentUserIdContainer,
         IOptionsMonitor<CookieAuthenticationOptions> options,
         ILoggerFactory logger,

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/appsettings.json
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/appsettings.json
@@ -5,6 +5,7 @@
       "ApiKeys": [ "test" ]
     }
   ],
+  "BaseAddress": "http://localhost",
   "FindALostTrnIntegration": {
     "HandoverEndpoint": "/FindALostTrn",
     "SharedKey": "OKqdp0+u8QSzwk5unfZrTRZzqwYJSOuo0pOsOIVhkog="

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -48,6 +48,7 @@ locals {
       Serilog__WriteTo__2__Args__uri               = local.infrastructure_secrets.LOGSTASH_ENDPOINT
       WEBSITE_SWAP_WARMUP_PING_PATH                = "/status"
       WEBSITE_SWAP_WARMUP_PING_STATUSES            = "200"
+      BaseAddress                                  = local.infrastructure_secrets.BASE_ADDRESS
     }
   )
 


### PR DESCRIPTION
So that our tests can use a 'real' access token, we've supported the `password` grant (when running with unit tests only) since we don't want to have to use an interactive flow and `client_credentials` isn't user-bound. Having to support this flow is extra complexity that we don't want and it's being obsoleted by OAuth 2.1.

This PR removes the password grant in favour of generating our own access tokens (with the specified scopes) in tests. It also switches out the OpenIddict authentication handler in favour of the standard JWT Bearer handler (so that we don't need tokens to exist in OpenIddict's DB).