### PR TITLE
Add firewall workflow

### DIFF
--- a/.github/workflows/actions/delete-extra-firewall-rules/action.yml
+++ b/.github/workflows/actions/delete-extra-firewall-rules/action.yml
@@ -1,0 +1,33 @@
+name: Delete extra firewall rules
+
+inputs:
+  AzureCredentials:
+    description: Azure Credentials
+    required: true
+  ResourceGroupName:
+    description: Postgres resource group name
+    required: true
+  PostgresServerName:
+    description: Flexible Postgres server name
+    required: true
+
+runs:
+  using: composite
+
+  steps:
+  - uses: Azure/login@v1
+    with:
+      creds: ${{ inputs.AzureCredentials }}
+      enable-AzPSSession: true
+
+  - name: Run script to delete extra firewall rules
+    uses: azure/powershell@v1
+    with:
+      inlineScript: |
+        $Rules = Get-AzPostgreSqlFlexibleServerFirewallRule -ResourceGroupName ${{ inputs.ResourceGroupName }} -ServerName ${{ inputs.PostgresServerName }}
+        $ExtraRules = $Rules | Where-Object { $_.Name -ne "AllowAzure" }
+
+        foreach ($Rule in $ExtraRules) {
+          Remove-AzPostgreSqlFlexibleServerFirewallRule -Name $Rule.Name -ResourceGroupName ${{ inputs.ResourceGroupName }} -ServerName ${{ inputs.PostgresServerName }}
+        }
+      azPSVersion: latest

--- a/.github/workflows/postgres-firewall-preprod.yml
+++ b/.github/workflows/postgres-firewall-preprod.yml
@@ -1,0 +1,24 @@
+name: Delete extra firewall rules in preprod
+
+on:
+  schedule: # 01:00 UTC on Sundays
+    - cron: "0 1 * * 0"
+  workflow_dispatch:
+
+jobs:
+  firewall:
+    name: Delete extra firewall rules in preprod
+    runs-on: ubuntu-latest
+    environment:
+      name: preprod
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Delete extra firewall rules
+        uses: ./.github/workflows/actions/delete-extra-firewall-rules
+        with:
+          AzureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
+          ResourceGroupName: s165t01-getanid-pp-rg
+          PostgresServerName: s165t01-getanid-preprod-psql

--- a/.github/workflows/postgres-firewall-prod.yml
+++ b/.github/workflows/postgres-firewall-prod.yml
@@ -1,0 +1,24 @@
+name: Delete extra firewall rules in production
+
+on:
+  schedule: # 01:00 UTC every day
+    - cron: "0 1 * * *"
+  workflow_dispatch:
+
+jobs:
+  firewall:
+    name: Delete extra firewall rules in production
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Delete extra firewall rules
+        uses: ./.github/workflows/actions/delete-extra-firewall-rules
+        with:
+          AzureCredentials: ${{ secrets.AZURE_CREDENTIALS }}
+          ResourceGroupName: s165p01-getanid-pd-rg
+          PostgresServerName: s165p01-getanid-production-psql


### PR DESCRIPTION
### Context
When firewall rules are added manually to postgres for troubleshooting, they remain and this may be a security risk.

### Changes proposed in this pull request
Delete all extra firewall rules in preprod and production on a schedule

### Guidance to review
Successful run: https://github.com/DFE-Digital/get-an-identity/actions/runs/3893187784
You can add a new firewall rule and rerun the job
