### PR TITLE
Date of birth data fix

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230110180844_UserSearchAttributes.Designer.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230110180844_UserSearchAttributes.Designer.cs
@@ -12,7 +12,7 @@ using TeacherIdentity.AuthServer.Models;
 namespace TeacherIdentity.AuthServer.Migrations
 {
     [DbContext(typeof(TeacherIdentityServerDbContext))]
-    [Migration("20230110133528_UserSearchAttributes")]
+    [Migration("20230110180844_UserSearchAttributes")]
     partial class UserSearchAttributes
     {
         /// <inheritdoc />
@@ -446,8 +446,10 @@ namespace TeacherIdentity.AuthServer.Migrations
                         .HasColumnName("created");
 
                     b.Property<DateOnly?>("DateOfBirth")
+                        .ValueGeneratedOnAdd()
                         .HasColumnType("date")
-                        .HasColumnName("date_of_birth");
+                        .HasColumnName("date_of_birth")
+                        .HasDefaultValueSql("NULL");
 
                     b.Property<string>("EmailAddress")
                         .IsRequired()

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230110180844_UserSearchAttributes.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230110180844_UserSearchAttributes.cs
@@ -12,6 +12,26 @@ namespace TeacherIdentity.AuthServer.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.AlterColumn<DateOnly>(
+                name: "date_of_birth",
+                table: "users",
+                type: "date",
+                nullable: true,
+                defaultValueSql: "NULL",
+                oldClrType: typeof(DateOnly),
+                oldType: "date",
+                oldNullable: true);
+
+            var dataFixSql = @"
+UPDATE
+    users
+SET
+    date_of_birth = NULL
+WHERE
+    date_of_birth = '-infinity'
+";
+            migrationBuilder.Sql(dataFixSql);
+
             migrationBuilder.CreateTable(
                 name: "user_search_attributes",
                 columns: table => new
@@ -126,6 +146,16 @@ CREATE TRIGGER trg_update_user_search_attributes
         {
             migrationBuilder.DropTable(
                 name: "user_search_attributes");
+
+            migrationBuilder.AlterColumn<DateOnly>(
+                name: "date_of_birth",
+                table: "users",
+                type: "date",
+                nullable: true,
+                oldClrType: typeof(DateOnly),
+                oldType: "date",
+                oldNullable: true,
+                oldDefaultValueSql: "NULL");
         }
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/TeacherIdentityServerDbContextModelSnapshot.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/TeacherIdentityServerDbContextModelSnapshot.cs
@@ -443,8 +443,10 @@ namespace TeacherIdentity.AuthServer.Migrations
                         .HasColumnName("created");
 
                     b.Property<DateOnly?>("DateOfBirth")
+                        .ValueGeneratedOnAdd()
                         .HasColumnType("date")
-                        .HasColumnName("date_of_birth");
+                        .HasColumnName("date_of_birth")
+                        .HasDefaultValueSql("NULL");
 
                     b.Property<string>("EmailAddress")
                         .IsRequired()

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/Mappings/UserMapping.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/Mappings/UserMapping.cs
@@ -14,7 +14,7 @@ public class UserMapping : IEntityTypeConfiguration<User>
         builder.HasIndex(u => u.Trn).IsUnique().HasFilter("is_deleted = false and trn is not null");
         builder.Property(u => u.FirstName).HasMaxLength(User.FirstNameAddressMaxLength).IsRequired();
         builder.Property(u => u.LastName).HasMaxLength(User.LastNameAddressMaxLength).IsRequired();
-        builder.Property(u => u.DateOfBirth);
+        builder.Property(u => u.DateOfBirth).HasDefaultValueSql("NULL");
         builder.Property(u => u.Created).IsRequired();
         builder.Property(u => u.CompletedTrnLookup);
         builder.Property(u => u.UserType).IsRequired();


### PR DESCRIPTION
### Context

The date of birth field in the identity users table previously defaulted to "-infinity" rather than NULL if no value was entered which has left the odd record in pre-prod with an invalid date of birth essentially and has caused an EF migration to fail.

### Changes proposed in this pull request

- Data fix existing users records so that any date of birth values of "-infinity" become NULL.
- Amend default value of date of birth column to default to NULL. 

### Guidance to review

This is simply an Entity Framework change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [x] Reminder created to manually clean any removed app settings post deployment
