### PR TITLE
Add index page for GAI light registration journey (#512)

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -71,7 +71,9 @@ public static class IdentityLinkGeneratorExtensions
 
     public static string Landing(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Landing");
 
-    public static string Register(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Register");
+    public static string Register(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Register/Index");
+
+    public static string RegisterEmail(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Register/Email");
 
     public static string UpdateEmail(this IIdentityLinkGenerator linkGenerator, string? returnUrl, string? cancelUrl) =>
         linkGenerator.PageWithAuthenticationJourneyId("/Authenticated/UpdateEmail/Index", authenticationJourneyRequired: false)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Landing.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Landing.cshtml
@@ -5,7 +5,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <h1 class="govuk-heading-xl">You need a Teaching Services account to continue</h1>
+        <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
 
         <p>A teaching services account lets you:</p>
         <ul class="govuk-list govuk-list--bullet">

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Index.cshtml
@@ -1,0 +1,21 @@
+@page "/sign-in/register"
+@{
+    ViewBag.Title = "Create a Teaching Services account";
+}
+
+<govuk-panel class="app-panel--interruption">
+    <govuk-panel-title>@ViewBag.Title</govuk-panel-title>
+
+    <govuk-panel-body>
+        <p>To create a Teaching Services account you’ll need to provide your:</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li>personal email address</li>
+            <li>name</li>
+            <li>date of birth</li>
+        </ul>
+
+        <p>Once you’ve created your account you can Apply for a QTS</p>
+
+        <govuk-button-link class="app-button--inverse" href="@LinkGenerator.RegisterEmail()">Continue</govuk-button-link>
+    </govuk-panel-body>
+</govuk-panel>

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/LandingTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/LandingTests.cs
@@ -1,0 +1,48 @@
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn;
+
+[Collection(nameof(DisableParallelization))]  // Relies on mocks
+public class LandingTests : TestBase
+{
+    public LandingTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/landing");
+    }
+
+    [Fact]
+    public async Task Get_MissingAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/landing");
+    }
+
+    [Fact]
+    public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Get, "/sign-in/landing");
+    }
+
+    [Fact]
+    public async Task Get_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(c => c.Start(), HttpMethod.Get, "/sign-in/landing");
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_ReturnsOk()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/landing?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/LandingTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/LandingTests.cs
@@ -1,6 +1,5 @@
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn;
 
-[Collection(nameof(DisableParallelization))]  // Relies on mocks
 public class LandingTests : TestBase
 {
     public LandingTests(HostFixture hostFixture)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/IndexTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/IndexTests.cs
@@ -1,0 +1,48 @@
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
+
+[Collection(nameof(DisableParallelization))]  // Relies on mocks
+public class IndexTests : TestBase
+{
+    public IndexTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register");
+    }
+
+    [Fact]
+    public async Task Get_MissingAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register");
+    }
+
+    [Fact]
+    public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Get, "/sign-in/register");
+    }
+
+    [Fact]
+    public async Task Get_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(c => c.Start(), HttpMethod.Get, "/sign-in/register");
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_ReturnsOk()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/IndexTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/IndexTests.cs
@@ -1,6 +1,5 @@
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
 
-[Collection(nameof(DisableParallelization))]  // Relies on mocks
 public class IndexTests : TestBase
 {
     public IndexTests(HostFixture hostFixture)


### PR DESCRIPTION
### Context

We're creating a 'GAI light' sign in/registration journey that is detached from Find a Lost TRN. This is the page a user hits after they choose to 'Create an account' from the landing page. [Trello ticket](https://trello.com/c/UQRtRvqa/512-gai-light-initial-bookend-page)

### Changes proposed in this pull request

Create a new page at /sign-in/register 
The 'Continue' link should point to /sign-in/register/email (a new endpoint).

### Guidance to review

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
