### PR TITLE
Add gai light email page

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -75,6 +75,8 @@ public static class IdentityLinkGeneratorExtensions
 
     public static string RegisterEmail(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Register/Email");
 
+    public static string RegisterEmailConfirmation(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Register/EmailConfirmation");
+
     public static string UpdateEmail(this IIdentityLinkGenerator linkGenerator, string? returnUrl, string? cancelUrl) =>
         linkGenerator.PageWithAuthenticationJourneyId("/Authenticated/UpdateEmail/Index", authenticationJourneyRequired: false)
             .SetQueryParam("returnUrl", returnUrl)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Email.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Email.cshtml
@@ -1,0 +1,23 @@
+@page "/sign-in/register/email"
+@model TeacherIdentity.AuthServer.Pages.SignIn.Register.EmailModel
+@{
+    ViewBag.Title = "Your email address";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.Register()" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.RegisterEmail()" method="post" asp-antiforgery="true">
+            <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
+
+            <govuk-input asp-for="Email" type="email" autocomplete="email">
+                <govuk-input-label class="govuk-label--s" />
+            </govuk-input>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Email.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Email.cshtml.cs
@@ -1,0 +1,58 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeacherIdentity.AuthServer.Services.EmailVerification;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
+
+[BindProperties]
+public class EmailModel : PageModel
+{
+    private readonly IEmailVerificationService _emailVerificationService;
+    private readonly IIdentityLinkGenerator _linkGenerator;
+
+    public EmailModel(
+        IEmailVerificationService emailVerificationService,
+        IIdentityLinkGenerator linkGenerator)
+    {
+        _emailVerificationService = emailVerificationService;
+        _linkGenerator = linkGenerator;
+    }
+
+    [Display(Name = "Email address", Description = "We’ll use this to send you a code to confirm your email address. Do not use a work or university email that you might lose access to.")]
+    [Required(ErrorMessage = "Enter your email address")]
+    [EmailAddress(ErrorMessage = "Enter a valid email address")]
+    public string? Email { get; set; }
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        HttpContext.GetAuthenticationState().OnEmailSet(Email!);
+
+        var pinGenerationResult = await _emailVerificationService.GeneratePin(Email!);
+
+        if (pinGenerationResult.FailedReasons != PinGenerationFailedReasons.None)
+        {
+            if (pinGenerationResult.FailedReasons == PinGenerationFailedReasons.RateLimitExceeded)
+            {
+                return new ViewResult()
+                {
+                    StatusCode = 429,
+                    ViewName = "TooManyRequests"
+                };
+            }
+
+            throw new NotImplementedException($"Unknown {nameof(PinGenerationFailedReasons)}: '{pinGenerationResult.FailedReasons}'.");
+        }
+
+        return Redirect(_linkGenerator.RegisterEmailConfirmation());
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailTests.cs
@@ -35,17 +35,9 @@ public class EmailTests : TestBase
     }
 
     [Fact]
-    public async Task Get_ValidRequest_ReturnsOk()
+    public async Task Get_ValidRequest_RendersContent()
     {
-        // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/email?{authStateHelper.ToQueryParam()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        response.EnsureSuccessStatusCode();
+        await ValidRequest_RendersContent("/sign-in/email");
     }
 
     [Fact]

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/LandingTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/LandingTests.cs
@@ -32,16 +32,8 @@ public class LandingTests : TestBase
     }
 
     [Fact]
-    public async Task Get_ValidRequest_ReturnsOk()
+    public async Task Get_ValidRequest_RendersContent()
     {
-        // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/landing?{authStateHelper.ToQueryParam()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        response.EnsureSuccessStatusCode();
+        await ValidRequest_RendersContent("/sign-in/landing");
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailTests.cs
@@ -35,17 +35,9 @@ public class EmailTests : TestBase
     }
 
     [Fact]
-    public async Task Get_ValidRequest_ReturnsOk()
+    public async Task Get_ValidRequest_RendersContent()
     {
-        // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/email?{authStateHelper.ToQueryParam()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        response.EnsureSuccessStatusCode();
+        await ValidRequest_RendersContent("/sign-in/register/email");
     }
 
     [Fact]

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailTests.cs
@@ -1,0 +1,168 @@
+using TeacherIdentity.AuthServer.Tests.Infrastructure;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
+
+[Collection(nameof(DisableParallelization))]  // Depends on mocks
+public class EmailTests : TestBase
+{
+    public EmailTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register/email");
+    }
+
+    [Fact]
+    public async Task Get_MissingAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register/email");
+    }
+
+    [Fact]
+    public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Get, "/sign-in/register/email");
+    }
+
+    [Fact]
+    public async Task Get_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(c => c.Start(), HttpMethod.Get, "/sign-in/register/email");
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_ReturnsOk()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/email?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+    }
+
+    [Fact]
+    public async Task Post_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Post, "/sign-in/register/email");
+    }
+
+    [Fact]
+    public async Task Post_NoAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await MissingAuthenticationState_ReturnsBadRequest(HttpMethod.Post, "/sign-in/register/email");
+    }
+
+    [Fact]
+    public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Post, "/sign-in/register/email");
+    }
+
+    [Fact]
+    public async Task Post_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(c => c.Start(), HttpMethod.Post, "/sign-in/register/email");
+    }
+
+    [Fact]
+    public async Task Post_ValidEmailWithBlockedClient_ReturnsTooManyRequestsStatusCode()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
+        var email = Faker.Internet.Email();
+
+        HostFixture.RateLimitStore.Setup(x => x.IsClientIpBlockedForPinGeneration(TestRequestClientIpProvider.ClientIpAddress)).ReturnsAsync(true);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Email", email }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status429TooManyRequests, (int)response.StatusCode);
+    }
+
+
+    [Fact]
+    public async Task Post_EmptyEmail_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Email", "Enter your email address");
+    }
+
+    [Fact]
+    public async Task Post_InvalidEmail_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Email", "xxx" }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Email", "Enter a valid email address");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Post_ValidEmail_SetsEmailOnAuthenticationStateGeneratesPin(bool emailIsKnown)
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
+        var email = Faker.Internet.Email();
+
+        if (emailIsKnown)
+        {
+            await TestData.CreateUser(email);
+        }
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Email", email }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal(email, authStateHelper.AuthenticationState.EmailAddress);
+
+        HostFixture.EmailVerificationService.Verify(mock => mock.GeneratePin(email), Times.Once);
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/IndexTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/IndexTests.cs
@@ -32,16 +32,8 @@ public class IndexTests : TestBase
     }
 
     [Fact]
-    public async Task Get_ValidRequest_ReturnsOk()
+    public async Task Get_ValidRequest_RendersContent()
     {
-        // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register?{authStateHelper.ToQueryParam()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        response.EnsureSuccessStatusCode();
+        await ValidRequest_RendersContent("/sign-in/register");
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TestBase.CommonTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TestBase.CommonTests.cs
@@ -149,4 +149,20 @@ public partial class TestBase
             Assert.Null(doc.GetElementByTestId("JourneyExpiredError"));
         }
     }
+
+    public async Task ValidRequest_RendersContent(string url)
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
+
+        var fullUrl = new Url(url).SetQueryParam(AuthenticationStateMiddleware.IdQueryParameterName, authStateHelper.AuthenticationState.JourneyId);
+        var request = new HttpRequestMessage(HttpMethod.Get, fullUrl);
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        response.EnsureSuccessStatusCode();
+        await response.GetDocument();
+    }
 }


### PR DESCRIPTION
### Context

We're creating a 'GAI light' sign in/registration journey that is detached from Find a Lost TRN. This is the page where the user enters their account email address in the registration process.

[ticket](https://trello.com/c/kPMEKUTw/513-gai-light-email-page)

### Changes proposed in this pull request

Create a new page at /sign-in/register/email following design at https://get-an-identity-prototype.herokuapp.com/auth/email

### Guidance to review

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
