### PR TITLE
Simplify testing with different scopes

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.TestClient/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.TestClient/Program.cs
@@ -56,12 +56,10 @@ public class Program
                 options.Events.OnRedirectToIdentityProvider = ctx =>
                 {
                     var customScope = ctx.HttpContext.Request.Query["scope"].ToString();
-                    if (string.IsNullOrEmpty(customScope))
+                    if (!string.IsNullOrEmpty(customScope))
                     {
-                        customScope = "trn";
+                        ctx.ProtocolMessage.Scope = customScope;
                     }
-
-                    ctx.ProtocolMessage.Scope += " " + customScope;
 
                     return Task.CompletedTask;
                 };

--- a/dotnet-authserver/src/TeacherIdentity.TestClient/Views/Home/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.TestClient/Views/Home/Index.cshtml
@@ -1,1 +1,7 @@
-﻿<govuk-button-link asp-action="Profile">My profile</govuk-button-link>
+<form asp-action="Profile" method="get">
+    <govuk-input name="scope" value="email openid profile trn" input-class="govuk-input--width-20">
+        <govuk-input-label>Scope</govuk-input-label>
+    </govuk-input>
+
+    <govuk-button type="submit">My profile</govuk-button>
+</form>

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignIn.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignIn.cs
@@ -50,8 +50,7 @@ public class SignIn : IClassFixture<HostFixture>
 
         // Start on the client app and try to access a protected area
 
-        await page.GotoAsync("/");
-        await page.ClickAsync("text=Profile");
+        await page.GotoAsync("/profile?scope=email+openid+profile+trn");
 
         // Fill in the sign in form (email + PIN)
 
@@ -180,8 +179,7 @@ public class SignIn : IClassFixture<HostFixture>
 
         // Start on the client app and try to access a protected area
 
-        await page.GotoAsync("/");
-        await page.ClickAsync("text=Profile");
+        await page.GotoAsync("/profile?scope=email+openid+profile+trn");
 
         // Should have jumped straight to confirmation page as the auth server knows who we are
 
@@ -261,8 +259,7 @@ public class SignIn : IClassFixture<HostFixture>
 
         // Start on the client app and try to access a protected area
 
-        await page.GotoAsync("/");
-        await page.ClickAsync("text=Profile");
+        await page.GotoAsync("/profile?scope=email+openid+profile+trn");
 
         // Fill in the sign in form (email + PIN)
 
@@ -500,7 +497,7 @@ public class SignIn : IClassFixture<HostFixture>
 
         // Start on the client app and try to access a protected area with admin scope
 
-        await page.GotoAsync($"/profile?scope={CustomScopes.UserRead}");
+        await page.GotoAsync($"/profile?scope=email+openid+profile+{CustomScopes.UserRead}");
 
         // Fill in the sign in form (email + PIN)
 


### PR DESCRIPTION
### Context

We're building more and more UI variations for sign in and registration that are dependent on the OAuth scopes passed in to the `authorize` endpoint. The TestClient has a hard-coded set of scopes baked in but has allowed appending to these scopes via a query parameter. We've not had any UI for setting this query parameter however so it's not very discoverable. 

### Changes proposed in this pull request

Add a text box to the root page in TestClient for specifying scopes. 

### Checklist

~~-   [ ] Attach to Trello card~~
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
- 
![localhost_7261_](https://user-images.githubusercontent.com/2041280/211897988-9a5e7d8b-f6e3-4fff-8c40-e5625dd88c2a.png)
