### PR TITLE
Fix sign in for users who have TRNs assigned via API

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -163,7 +163,7 @@ public class AuthenticationState
         if (UserRequirements.HasFlag(UserRequirements.TrnHolder))
         {
             // If it's not been done before, launch the journey to find the TRN
-            if (!HaveCompletedTrnLookup)
+            if (Trn is null && !HaveCompletedTrnLookup)
             {
                 return linkGenerator.Trn();
             }
@@ -251,7 +251,7 @@ public class AuthenticationState
             StaffRoles = user.StaffRoles;
             TrnLookupStatus = user.TrnLookupStatus;
 
-            if (HaveCompletedTrnLookup)
+            if (HaveCompletedTrnLookup || Trn is not null)
             {
                 TrnLookup = TrnLookupState.Complete;
             }


### PR DESCRIPTION
Currently we check `CompletedTrnLookup` in a few places to know whether to redirect users to Find. In cases where a TRN has been assigned via the API (and the user has never gone to Find), this property remains `null`. We don't yet support attaching a TRN to an existing user so we're getting runtime errors at sign in.

This change modifies the checks to consider `Trn` as well.