### PR TITLE
Add email confirmation page for GAI light registration journey (#522)

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -221,7 +221,7 @@ public class AuthenticationState
         EmailAddressVerified = false;
     }
 
-    public void OnEmailVerified()
+    public void OnEmailVerified(User? user = null)
     {
         if (EmailAddress is null)
         {
@@ -229,12 +229,6 @@ public class AuthenticationState
         }
 
         EmailAddressVerified = true;
-    }
-
-    public void OnEmailVerified(User? user)
-    {
-        OnEmailVerified();
-
         FirstTimeSignInForEmail = user is null;
 
         if (user is not null)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -221,7 +221,7 @@ public class AuthenticationState
         EmailAddressVerified = false;
     }
 
-    public void OnEmailVerified(User? user)
+    public void OnEmailVerified()
     {
         if (EmailAddress is null)
         {
@@ -229,6 +229,12 @@ public class AuthenticationState
         }
 
         EmailAddressVerified = true;
+    }
+
+    public void OnEmailVerified(User? user)
+    {
+        OnEmailVerified();
+
         FirstTimeSignInForEmail = user is null;
 
         if (user is not null)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -77,6 +77,8 @@ public static class IdentityLinkGeneratorExtensions
 
     public static string RegisterEmailConfirmation(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Register/EmailConfirmation");
 
+    public static string RegisterName(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Register/Name");
+
     public static string UpdateEmail(this IIdentityLinkGenerator linkGenerator, string? returnUrl, string? cancelUrl) =>
         linkGenerator.PageWithAuthenticationJourneyId("/Authenticated/UpdateEmail/Index", authenticationJourneyRequired: false)
             .SetQueryParam("returnUrl", returnUrl)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/BaseEmailConfirmationPageModel.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/BaseEmailConfirmationPageModel.cs
@@ -1,0 +1,80 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeacherIdentity.AuthServer.Services.EmailVerification;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn;
+
+public class BaseEmailConfirmationPageModel : PageModel
+{
+    protected readonly PinValidator PinValidator;
+    protected readonly IEmailVerificationService EmailVerificationService;
+
+    public BaseEmailConfirmationPageModel(
+        IEmailVerificationService emailVerificationService,
+        PinValidator pinValidator)
+    {
+        PinValidator = pinValidator;
+        EmailVerificationService = emailVerificationService;
+    }
+
+    public virtual string? Email => HttpContext.GetAuthenticationState().EmailAddress;
+
+    [BindProperty]
+    [Display(Name = "Enter your code")]
+    public virtual string? Code { get; set; }
+
+    protected async Task<IActionResult> HandlePinVerificationFailed(PinVerificationFailedReasons pinVerificationFailedReasons)
+    {
+        if (pinVerificationFailedReasons == PinVerificationFailedReasons.RateLimitExceeded)
+        {
+            return new ViewResult()
+            {
+                StatusCode = 429,
+                ViewName = "TooManyPinVerificationRequests"
+            };
+        }
+
+        if (pinVerificationFailedReasons.ShouldGenerateAnotherCode())
+        {
+            var pinGenerationResult = await EmailVerificationService.GeneratePin(Email!);
+
+            if (pinGenerationResult.FailedReasons != PinGenerationFailedReasons.None)
+            {
+                HandlePinGenerationFailed(pinGenerationResult.FailedReasons);
+            }
+
+            ModelState.AddModelError(nameof(Code), "The security code has expired. New code sent.");
+        }
+        else
+        {
+            ModelState.AddModelError(nameof(Code), "Enter a correct security code");
+        }
+
+        return this.PageWithErrors();
+    }
+
+    private IActionResult HandlePinGenerationFailed(PinGenerationFailedReasons pinGenerationFailedReasons)
+    {
+        if (pinGenerationFailedReasons == PinGenerationFailedReasons.RateLimitExceeded)
+        {
+            return new ViewResult()
+            {
+                StatusCode = 429,
+                ViewName = "TooManyRequests"
+            };
+        }
+
+        throw new NotImplementedException($"Unknown {nameof(PinGenerationFailedReasons)}: '{pinGenerationFailedReasons}'.");
+    }
+
+    protected void ValidateCode()
+    {
+        var validationError = PinValidator.ValidateCode(Code);
+
+        if (validationError is not null)
+        {
+            ModelState.AddModelError(nameof(Code), validationError);
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/BaseEmailConfirmationPageModel.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/BaseEmailConfirmationPageModel.cs
@@ -5,7 +5,7 @@ using TeacherIdentity.AuthServer.Services.EmailVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn;
 
-public class BaseEmailConfirmationPageModel : PageModel
+public abstract class BaseEmailConfirmationPageModel : PageModel
 {
     protected readonly PinValidator PinValidator;
     protected readonly IEmailVerificationService EmailVerificationService;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/EmailConfirmation.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/EmailConfirmation.cshtml
@@ -1,0 +1,25 @@
+@page "/sign-in/register/email-confirmation"
+@model TeacherIdentity.AuthServer.Pages.SignIn.Register.EmailConfirmationModel
+@{
+    ViewBag.Title = "Confirm your email address";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.RegisterEmail()" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.RegisterEmailConfirmation()" method="post" asp-antiforgery="true">
+            <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
+
+            <p>A confirmation code has been sent to <span data-testid="email">@Model.Email</span></p>
+
+            <govuk-input asp-for="Code" input-class="govuk-!-width-one-quarter" pattern="[0-9]*" inputmode="numeric" autocomplete="one-time-code">
+                <govuk-input-label class="govuk-label--s" />
+            </govuk-input>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/EmailConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/EmailConfirmation.cshtml.cs
@@ -1,0 +1,49 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using TeacherIdentity.AuthServer.Services.EmailVerification;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
+
+public class EmailConfirmationModel : BaseEmailConfirmationPageModel
+{
+    private readonly IIdentityLinkGenerator _linkGenerator;
+
+    public EmailConfirmationModel(
+        IEmailVerificationService emailConfirmationService,
+        PinValidator pinValidator,
+        IIdentityLinkGenerator linkGenerator)
+        : base(emailConfirmationService, pinValidator)
+    {
+        _linkGenerator = linkGenerator;
+    }
+
+    [BindProperty]
+    [Display(Name = "Confirmation code")]
+    public override string? Code { get; set; }
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        Code = Code?.Trim();
+        ValidateCode();
+
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        var pinVerificationFailedReasons = await EmailVerificationService.VerifyPin(Email!, Code!);
+
+        if (pinVerificationFailedReasons != PinVerificationFailedReasons.None)
+        {
+            return await HandlePinVerificationFailed(pinVerificationFailedReasons);
+        }
+
+        HttpContext.GetAuthenticationState().OnEmailVerified();
+
+        return Redirect(_linkGenerator.RegisterName());
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailConfirmationTests.cs
@@ -1,0 +1,286 @@
+using Microsoft.Extensions.Options;
+using TeacherIdentity.AuthServer.Services.EmailVerification;
+using TeacherIdentity.AuthServer.Tests.Infrastructure;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
+
+[Collection(nameof(DisableParallelization))]  // Depends on mocks and changes the clock
+public class EmailConfirmationTests : TestBase
+{
+    public EmailConfirmationTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+        HostFixture.RateLimitStore.Setup(x => x.IsClientIpBlockedForPinVerification(TestRequestClientIpProvider.ClientIpAddress)).ReturnsAsync(false);
+    }
+
+    [Fact]
+    public async Task Get_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register/email-confirmation");
+    }
+
+    [Fact]
+    public async Task Get_NoAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await MissingAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register/email-confirmation");
+    }
+
+    [Fact]
+    public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Get, "/sign-in/register/email-confirmation");
+    }
+
+    [Fact]
+    public async Task Get_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(c => c.EmailSet(), HttpMethod.Get, "/sign-in/register/email-confirmation");
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_RendersExpectedContent()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet());
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/email-confirmation?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Act
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+        Assert.Equal(authStateHelper.AuthenticationState.EmailAddress, doc.GetElementByTestId("email")?.TextContent);
+    }
+
+    [Fact]
+    public async Task Post_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Post, "/sign-in/register/email-confirmation");
+    }
+
+    [Fact]
+    public async Task Post_NoAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await MissingAuthenticationState_ReturnsBadRequest(HttpMethod.Post, "/sign-in/register/email-confirmation");
+    }
+
+    [Fact]
+    public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Post, "/sign-in/register/email-confirmation");
+    }
+
+    [Fact]
+    public async Task Post_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(c => c.EmailSet(), HttpMethod.Post, "/sign-in/register/email-confirmation");
+    }
+
+    [Fact]
+    public async Task Post_UnknownPin_ReturnsError()
+    {
+        // Arrange
+        var email = Faker.Internet.Email();
+
+        // The real PIN generation service never generates pins that start with a '0'
+        var pin = "01234";
+
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email));
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email-confirmation?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pin }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Code", "Enter a correct security code");
+    }
+
+    [Fact]
+    public async Task Post_PinTooShort_ReturnsError()
+    {
+        // Arrange
+        var email = Faker.Internet.Email();
+        var pin = "0";
+
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email));
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email-confirmation?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pin }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Code", "You’ve not entered enough numbers, the code must be 5 numbers");
+    }
+
+    [Fact]
+    public async Task Post_PinTooLong_ReturnsError()
+    {
+        // Arrange
+        var email = Faker.Internet.Email();
+        var pin = "0123345678";
+
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email));
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email-confirmation?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pin }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Code", "You’ve entered too many numbers, the code must be 5 numbers");
+    }
+
+    [Fact]
+    public async Task Post_NonNumericPin_ReturnsError()
+    {
+        // Arrange
+        var email = Faker.Internet.Email();
+        var pin = "abc";
+
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email));
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email-confirmation?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pin }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Code", "The code must be 5 numbers");
+    }
+
+    [Fact]
+    public async Task Post_PinExpiredLessThanTwoHoursAgo_ReturnsErrorAndSendsANewPin()
+    {
+        // Arrange
+        var email = Faker.Internet.Email();
+
+        var emailVerificationService = HostFixture.Services.GetRequiredService<IEmailVerificationService>();
+        var pinResult = await emailVerificationService.GeneratePin(email);
+        Clock.AdvanceBy(TimeSpan.FromHours(1));
+        Spy.Get<IEmailVerificationService>().Reset();
+
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email));
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email-confirmation?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pinResult.Pin! }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Code", "The security code has expired. New code sent.");
+
+        HostFixture.EmailVerificationService.Verify(mock => mock.GeneratePin(email), Times.Once);
+    }
+
+    [Fact]
+    public async Task Post_PinExpiredMoreThanTwoHoursAgo_ReturnsErrorAndDoesNotSendANewPin()
+    {
+        // Arrange
+        var email = Faker.Internet.Email();
+
+        var emailVerificationService = HostFixture.Services.GetRequiredService<IEmailVerificationService>();
+        var emailVerificationOptions = HostFixture.Services.GetRequiredService<IOptions<EmailVerificationOptions>>();
+        var pinResult = await emailVerificationService.GeneratePin(email);
+        Clock.AdvanceBy(TimeSpan.FromHours(2) + TimeSpan.FromSeconds(emailVerificationOptions.Value.PinLifetimeSeconds));
+        Spy.Get<IEmailVerificationService>().Reset();
+
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email));
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email-confirmation?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pinResult.Pin! }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Code", "Enter a correct security code");
+
+        HostFixture.EmailVerificationService.Verify(mock => mock.GeneratePin(email), Times.Never);
+    }
+
+    [Fact]
+    public async Task Post_ValidPin_UpdatesAuthenticationState()
+    {
+        // Arrange
+        var email = Faker.Internet.Email();
+
+        var emailVerificationService = HostFixture.Services.GetRequiredService<IEmailVerificationService>();
+        var pinResult = await emailVerificationService.GeneratePin(email);
+
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email));
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email-confirmation?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pinResult.Pin! }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        Assert.True(authStateHelper.AuthenticationState.EmailAddressVerified);
+    }
+
+    [Fact]
+    public async Task Post_BlockedClient_ReturnsTooManyRequestsStatusCode()
+    {
+        // Arrange
+        HostFixture.RateLimitStore.Setup(x => x.IsClientIpBlockedForPinVerification(TestRequestClientIpProvider.ClientIpAddress)).ReturnsAsync(true);
+
+        var email = Faker.Internet.Email();
+        var emailVerificationService = HostFixture.Services.GetRequiredService<IEmailVerificationService>();
+        var pinResult = await emailVerificationService.GeneratePin(email);
+
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email));
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email-confirmation?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pinResult.Pin! }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status429TooManyRequests, (int)response.StatusCode);
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailTests.cs
@@ -129,7 +129,7 @@ public class EmailTests : TestBase
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public async Task Post_ValidEmail_SetsEmailOnAuthenticationStateGeneratesPin(bool emailIsKnown)
+    public async Task Post_ValidEmail_SetsEmailOnAuthenticationStateGeneratesPinAndRedirectsToRegisterEmailConfirmation(bool emailIsKnown)
     {
         // Arrange
         var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
@@ -153,6 +153,8 @@ public class EmailTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/register/email-confirmation", response.Headers.Location?.OriginalString);
+
         Assert.Equal(email, authStateHelper.AuthenticationState.EmailAddress);
 
         HostFixture.EmailVerificationService.Verify(mock => mock.GeneratePin(email), Times.Once);


### PR DESCRIPTION
### Context

We're creating a 'GAI light' sign in/registration journey that is detached from Find a Lost TRN. This the page is where the user enters their email verification PIN during the registration journey.

[ticket](https://trello.com/c/V59mlP9L/522-gai-light-registration-email-confirmation-page)

### Changes proposed in this pull request

Create a new page at /sign-in/register/email-confirmation following design at https://get-an-identity-prototype.herokuapp.com/auth/email-code

Refactor existing EmailConfirmation and TrnInUse pages to extent BaseEmailConfirmationPageModel

### Guidance to review

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
