### PR TITLE
Amend the base authz policy for /admin to Staff users

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/ClientScopedViewHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/ClientScopedViewHelper.cs
@@ -23,7 +23,12 @@ public class ClientScopedViewHelper
     public async Task<IView?> FindClientScopedView(string viewName)
     {
         var client = await _currentClientProvider.GetCurrentClient();
-        var actionContext = _actionContextAccessor.ActionContext ?? throw new InvalidOperationException("No current ActionContext.");
+        var actionContext = _actionContextAccessor.ActionContext;
+
+        if (actionContext is null)
+        {
+            return null;
+        }
 
         // By convention, pascal case the client ID to get the view suffix
         // e.g. register-for-npq -> RegisterForNpq

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/Security/AuthorizationPolicies.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/Security/AuthorizationPolicies.cs
@@ -6,5 +6,6 @@ public static class AuthorizationPolicies
     public const string ApiUserWrite = "API:UserWrite";
     public const string Authenticated = "Authenticated";
     public const string GetAnIdentityAdmin = "GetAnIdentityAdmin";
+    public const string Staff = "Staff";
     public const string TrnLookupApi = "API:TrnLookup";
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AddClient.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AddClient.cshtml.cs
@@ -1,12 +1,15 @@
 using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeacherIdentity.AuthServer.Events;
 using TeacherIdentity.AuthServer.Infrastructure.ModelBinding;
+using TeacherIdentity.AuthServer.Infrastructure.Security;
 using TeacherIdentity.AuthServer.Oidc;
 
 namespace TeacherIdentity.AuthServer.Pages.Admin;
 
+[Authorize(AuthorizationPolicies.GetAnIdentityAdmin)]
 public class AddClientModel : PageModel
 {
     private readonly TeacherIdentityApplicationManager _applicationManager;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AddStaffUser.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AddStaffUser.cshtml.cs
@@ -1,12 +1,15 @@
 using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Infrastructure.Security;
 using TeacherIdentity.AuthServer.Models;
 
 namespace TeacherIdentity.AuthServer.Pages.Admin;
 
+[Authorize(AuthorizationPolicies.GetAnIdentityAdmin)]
 [BindProperties]
 public class AddStaffUserModel : PageModel
 {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AddWebHook.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AddWebHook.cshtml.cs
@@ -1,11 +1,14 @@
 using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Infrastructure.Security;
 using TeacherIdentity.AuthServer.Models;
 
 namespace TeacherIdentity.AuthServer.Pages.Admin;
 
+[Authorize(AuthorizationPolicies.GetAnIdentityAdmin)]
 public class AddWebHookModel : PageModel
 {
     private readonly TeacherIdentityServerDbContext _dbContext;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Clients.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Clients.cshtml.cs
@@ -1,9 +1,12 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using OpenIddict.Abstractions;
+using TeacherIdentity.AuthServer.Infrastructure.Security;
 using TeacherIdentity.AuthServer.Models;
 
 namespace TeacherIdentity.AuthServer.Pages.Admin;
 
+[Authorize(AuthorizationPolicies.GetAnIdentityAdmin)]
 public class ClientsModel : PageModel
 {
     private readonly IOpenIddictApplicationManager _applicationManager;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditClient.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditClient.cshtml.cs
@@ -1,14 +1,17 @@
 using System.Collections.Immutable;
 using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using OpenIddict.Abstractions;
 using TeacherIdentity.AuthServer.Events;
 using TeacherIdentity.AuthServer.Infrastructure.ModelBinding;
+using TeacherIdentity.AuthServer.Infrastructure.Security;
 using TeacherIdentity.AuthServer.Oidc;
 
 namespace TeacherIdentity.AuthServer.Pages.Admin;
 
+[Authorize(AuthorizationPolicies.GetAnIdentityAdmin)]
 public class EditClientModel : PageModel
 {
     private readonly TeacherIdentityApplicationStore _applicationStore;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditStaffUser.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditStaffUser.cshtml.cs
@@ -1,13 +1,16 @@
 using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Infrastructure.Security;
 using TeacherIdentity.AuthServer.Models;
 
 namespace TeacherIdentity.AuthServer.Pages.Admin;
 
+[Authorize(AuthorizationPolicies.GetAnIdentityAdmin)]
 [BindProperties]
 public class EditStaffUserModel : PageModel
 {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditWebHook.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditWebHook.cshtml.cs
@@ -1,12 +1,15 @@
 using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Infrastructure.Security;
 using TeacherIdentity.AuthServer.Models;
 
 namespace TeacherIdentity.AuthServer.Pages.Admin;
 
+[Authorize(AuthorizationPolicies.GetAnIdentityAdmin)]
 public class EditWebHookModel : PageModel
 {
     private readonly TeacherIdentityServerDbContext _dbContext;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Staff.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Staff.cshtml.cs
@@ -1,9 +1,12 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Infrastructure.Security;
 using TeacherIdentity.AuthServer.Models;
 
 namespace TeacherIdentity.AuthServer.Pages.Admin;
 
+[Authorize(AuthorizationPolicies.GetAnIdentityAdmin)]
 public class StaffModel : PageModel
 {
     private readonly TeacherIdentityServerDbContext _dbContext;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/WebHooks.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/WebHooks.cshtml.cs
@@ -1,9 +1,12 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Infrastructure.Security;
 using TeacherIdentity.AuthServer.Models;
 
 namespace TeacherIdentity.AuthServer.Pages.Admin;
 
+[Authorize(AuthorizationPolicies.GetAnIdentityAdmin)]
 public class WebHooksModel : PageModel
 {
     private readonly TeacherIdentityServerDbContext _dbContext;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/_Layout.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/_Layout.cshtml
@@ -9,15 +9,18 @@
     <nav aria-label="Menu" class="govuk-header__navigation ">
         <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide menu" hidden>Menu</button>
         <ul id="navigation" class="govuk-header__navigation-list">
-            <li class="govuk-header__navigation-item @(Context.Request.Path.StartsWithSegments("/admin/clients") ? "govuk-header__navigation-item--active" : "")">
-                <a class="govuk-header__link" asp-page="Clients">Clients</a>
-            </li>
-            <li class="govuk-header__navigation-item @(Context.Request.Path.StartsWithSegments("/admin/staff") ? "govuk-header__navigation-item--active" : "")">
-                <a class="govuk-header__link" asp-page="Staff">Staff</a>
-            </li>
-            <li class="govuk-header__navigation-item @(Context.Request.Path.StartsWithSegments("/admin/webhooks") ? "govuk-header__navigation-item--active" : "")">
-                <a class="govuk-header__link" asp-page="WebHooks">Web hooks</a>
-            </li>
+            @if (User.IsInRole(StaffRoles.GetAnIdentityAdmin))
+            {
+                <li class="govuk-header__navigation-item @(Context.Request.Path.StartsWithSegments("/admin/clients") ? "govuk-header__navigation-item--active" : "")">
+                    <a class="govuk-header__link" asp-page="Clients">Clients</a>
+                </li>
+                <li class="govuk-header__navigation-item @(Context.Request.Path.StartsWithSegments("/admin/staff") ? "govuk-header__navigation-item--active" : "")">
+                    <a class="govuk-header__link" asp-page="Staff">Staff</a>
+                </li>
+                <li class="govuk-header__navigation-item @(Context.Request.Path.StartsWithSegments("/admin/webhooks") ? "govuk-header__navigation-item--active" : "")">
+                    <a class="govuk-header__link" asp-page="WebHooks">Web hooks</a>
+                </li>
+            }
         </ul>
     </nav>
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
@@ -221,6 +221,13 @@ public class Program
                     .RequireRole(StaffRoles.GetAnIdentityAdmin));
 
             options.AddPolicy(
+                AuthorizationPolicies.Staff,
+                policy => policy
+                    .AddAuthenticationSchemes("Delegated")
+                    .RequireAuthenticatedUser()
+                    .RequireClaim(CustomClaims.UserType, UserClaimHelper.MapUserTypeToClaimValue(UserType.Staff)));
+
+            options.AddPolicy(
                 AuthorizationPolicies.TrnLookupApi,
                 policy => policy
                     .AddAuthenticationSchemes(ApiKeyAuthenticationHandler.AuthenticationScheme)
@@ -264,7 +271,7 @@ public class Program
                 "/Admin",
                 model =>
                 {
-                    model.Filters.Add(new AuthorizeFilter(AuthorizationPolicies.GetAnIdentityAdmin));
+                    model.Filters.Add(new AuthorizeFilter(AuthorizationPolicies.Staff));
                 });
 
             options.Conventions.AddFolderApplicationModelConvention(

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/UserClaimHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/UserClaimHelper.cs
@@ -107,6 +107,8 @@ public static class UserClaimHelper
             authenticationState.TrnLookupStatus);
     }
 
+    public static string MapUserTypeToClaimValue(UserType userType) => userType.ToString();
+
     private static string? GetClaim(ClaimsPrincipal principal, string claimType, bool throwIfMissing)
     {
         var value = principal.FindFirstValue(claimType);
@@ -165,7 +167,7 @@ public static class UserClaimHelper
         yield return new Claim(Claims.GivenName, firstName);
         yield return new Claim(Claims.FamilyName, lastName);
         yield return new Claim(CustomClaims.HaveCompletedTrnLookup, haveCompletedTrnLookup.ToString());
-        yield return new Claim(CustomClaims.UserType, userType.ToString());
+        yield return new Claim(CustomClaims.UserType, MapUserTypeToClaimValue(userType));
 
         if (dateOfBirth.HasValue)
         {


### PR DESCRIPTION
In preparation for ID Support moving into ID itself, this PR changes the base authorization policy for all pages under /admin to check for Staff users only. Individual pages have an additional `AuthorizeAttribute` that checks for the `GetAnIdentityAdmin` role.