### PR TITLE
Add official name page for new TRN lookup flow (#525)

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -61,6 +61,14 @@ public class AuthenticationState
     [JsonInclude]
     public string? LastName { get; private set; }
     [JsonInclude]
+    public string? OfficialFirstName { get; private set; }
+    [JsonInclude]
+    public string? OfficialLastName { get; private set; }
+    [JsonInclude]
+    public string? PreviousOfficialFirstName { get; private set; }
+    [JsonInclude]
+    public string? PreviousOfficialLastName { get; private set; }
+    [JsonInclude]
     public DateOnly? DateOfBirth { get; private set; }
     [JsonInclude]
     public string? Trn { get; private set; }
@@ -387,6 +395,18 @@ public class AuthenticationState
     {
         FirstName = firstName;
         LastName = lastName;
+    }
+
+    public void OnOfficialNameSet(
+        string officialFirstName,
+        string officialLastName,
+        string? previousOfficialFirstName,
+        string? previousOfficiaLastName)
+    {
+        OfficialFirstName = officialFirstName;
+        OfficialLastName = officialLastName;
+        PreviousOfficialFirstName = previousOfficialFirstName;
+        PreviousOfficialLastName = previousOfficiaLastName;
     }
 
     public void OnHaveResumedCompletedJourney()

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -69,6 +69,10 @@ public static class IdentityLinkGeneratorExtensions
 
     public static string TrnCallback(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/TrnCallback");
 
+    public static string TrnOfficialName(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Trn/OfficialName");
+
+    public static string TrnPreferredName(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Trn/PreferredName");
+
     public static string Landing(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Landing");
 
     public static string Register(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Register/Index");

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn.cshtml.cs
@@ -32,6 +32,12 @@ public class TrnModel : PageModel
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
+        if (_findALostTrnIntegrationHelper.Options.UseNewTrnLookupJourney)
+        {
+            context.Result = new RedirectResult(_linkGenerator.TrnOfficialName());
+            return;
+        }
+
         var authenticationState = context.HttpContext.GetAuthenticationState();
 
         // We expect to have a verified email at this point but we shouldn't have completed the TRN lookup

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/OfficialName.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/OfficialName.cshtml
@@ -1,0 +1,56 @@
+@page "/sign-in/trn/official-name"
+@model TeacherIdentity.AuthServer.Pages.SignIn.Trn.OfficialName
+@{
+    ViewBag.Title = "What’s your name?";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.Trn()" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.TrnOfficialName()" method="post" asp-antiforgery="true">
+            <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
+
+            <p>Use the name on your official documents, such as your passport.</p>
+
+            <govuk-input asp-for="OfficialFirstName" spellcheck="false" autocomplete="given-name">
+                <govuk-input-label class="govuk-label--s" />
+            </govuk-input>
+
+            <govuk-input asp-for="OfficialLastName" spellcheck="false" autocomplete="family-name">
+                <govuk-input-label class="govuk-label--s"/>
+            </govuk-input>
+
+            <govuk-radios asp-for="HasPreviousName">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m">
+                        Have you ever changed your name?
+                    </govuk-radios-fieldset-legend>
+
+                    <govuk-radios-item value="false">No</govuk-radios-item>
+                    <govuk-radios-item value="true">
+                        Yes
+                        <govuk-radios-item-conditional>
+                            <h2 class="govuk-heading-m">What was your previous name?</h2>
+                            <p>You do not have to tell us your previous name, but it will help us identify you.</p>
+                            <p>If we cannot match your current name against our records, we’ll try to match your previous name.</p>
+                            <p>If you changed your name more than once, please tell us your most recent previous name.</p>
+                            <govuk-input asp-for="PreviousOfficialFirstName" spellcheck="false" autocomplete="given-name">
+                                <govuk-input-label class="govuk-label--s"/>
+                            </govuk-input>
+                            <govuk-input asp-for="PreviousOfficialLastName" spellcheck="false" autocomplete="family-name">
+                                <govuk-input-label class="govuk-label--s"/>
+                            </govuk-input>
+                        </govuk-radios-item-conditional>
+                    </govuk-radios-item>
+                    <govuk-radios-item value="false">Prefer not to say</govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>
+

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/OfficialName.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/OfficialName.cshtml.cs
@@ -1,0 +1,67 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn.Trn;
+
+[BindProperties]
+
+public class OfficialName : PageModel
+{
+    private IIdentityLinkGenerator _linkGenerator;
+
+    public OfficialName(IIdentityLinkGenerator linkGenerator)
+    {
+        _linkGenerator = linkGenerator;
+    }
+
+    [Display(Name = "First name")]
+    [Required(ErrorMessage = "Enter your first name")]
+    public string? OfficialFirstName { get; set; }
+
+    [Display(Name = "Last name")]
+    [Required(ErrorMessage = "Enter your last name")]
+    public string? OfficialLastName { get; set; }
+
+    [Display(Name = "Previous first name (optional)")]
+    public string? PreviousOfficialFirstName { get; set; }
+
+    [Display(Name = "Previous last name (optional)")]
+    public string? PreviousOfficialLastName { get; set; }
+
+    public bool HasPreviousName { get; set; }
+
+    public void OnGet()
+    {
+    }
+
+    public IActionResult OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        HttpContext.GetAuthenticationState().OnOfficialNameSet(
+            OfficialFirstName!,
+            OfficialLastName!,
+            HasPreviousName ? PreviousOfficialFirstName : null,
+            HasPreviousName ? PreviousOfficialLastName : null);
+
+        return Redirect(_linkGenerator.TrnPreferredName());
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var authenticationState = context.HttpContext.GetAuthenticationState();
+
+        // We expect to have a verified email at this point but we shouldn't have completed the TRN lookup
+        if (string.IsNullOrEmpty(authenticationState.EmailAddress) ||
+            !authenticationState.EmailAddressVerified ||
+            authenticationState.HaveCompletedTrnLookup)
+        {
+            context.Result = new RedirectResult(authenticationState.GetNextHopUrl(_linkGenerator));
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/TrnLookup/FindALostTrnIntegrationOptions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/TrnLookup/FindALostTrnIntegrationOptions.cs
@@ -12,4 +12,7 @@ public class FindALostTrnIntegrationOptions
 
     [Required]
     public required bool EnableStubEndpoints { get; set; }
+
+    [Required]
+    public bool UseNewTrnLookupJourney { get; set; }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Development.json
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Development.json
@@ -33,7 +33,8 @@
   "FindALostTrnIntegration": {
     "HandoverEndpoint": "/FindALostTrn/Identity",
     "SharedKey": "OKqdp0+u8QSzwk5unfZrTRZzqwYJSOuo0pOsOIVhkog=",
-    "EnableStubEndpoints": true
+    "EnableStubEndpoints": true,
+    "UseNewTrnLookupJourney": true
   },
   "AdminCredentials": {
     "Username": "developer",

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TestBase.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TestBase.cs
@@ -15,6 +15,7 @@ public abstract partial class TestBase
         });
 
         HostFixture.ResetMocks();
+        HostFixture.ResetUseNewTrnLookupJourney();
         HostFixture.InitEventObserver();
     }
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/OfficialNameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/OfficialNameTests.cs
@@ -1,0 +1,134 @@
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Trn;
+
+public class OfficialNameTests : TestBase
+{
+    public OfficialNameTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, $"/sign-in/trn/official-name");
+    }
+
+    [Fact]
+    public async Task Get_NoAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await MissingAuthenticationState_ReturnsBadRequest(HttpMethod.Get, $"/sign-in/trn/official-name");
+    }
+
+    [Fact]
+    public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Get, "/sign-in/trn/official-name");
+    }
+
+    [Fact]
+    public async Task Get_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(c => c.EmailVerified(), HttpMethod.Get, "/sign-in/trn/official-name");
+    }
+
+    [Fact]
+    public async Task Post_EmptyOfficialFirstName_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified());
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/official-name?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "OfficialFirstName", "Enter your first name");
+    }
+
+    [Fact]
+    public async Task Post_EmptyOfficialLastName_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified());
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/official-name?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "OfficialLastName", "Enter your last name");
+    }
+
+    [Fact]
+    public async Task Post_ValidOfficialName_SetsOfficialNameOnAuthenticationState()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified());
+        var firstName = "first";
+        var lastName = "last";
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/official-name?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "OfficialFirstName", firstName },
+                { "OfficialLastName", lastName }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        Assert.Equal(firstName, authStateHelper.AuthenticationState.OfficialFirstName);
+        Assert.Equal(lastName, authStateHelper.AuthenticationState.OfficialLastName);
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Post_HasPreviousOfficialNames_SetsPreviousOfficialNameOnAuthenticationState(bool hasPreviousName)
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified());
+        var previousFirstName = "previous first";
+        var previousLastName = "previous last";
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/official-name?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "OfficialFirstName", "first" },
+                { "OfficialLastName", "last" },
+                { "PreviousOfficialFirstName", previousFirstName },
+                { "PreviousOfficialLastName", previousLastName },
+                { "HasPreviousName", hasPreviousName}
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        if (hasPreviousName)
+        {
+            Assert.Equal(previousFirstName, authStateHelper.AuthenticationState.PreviousOfficialFirstName);
+            Assert.Equal(previousLastName, authStateHelper.AuthenticationState.PreviousOfficialLastName);
+        }
+        else
+        {
+            Assert.Null(authStateHelper.AuthenticationState.PreviousOfficialFirstName);
+            Assert.Null(authStateHelper.AuthenticationState.PreviousOfficialLastName);
+        }
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/HostFixture.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/HostFixture.cs
@@ -92,7 +92,7 @@ public class HostFixture : WebApplicationFactory<TeacherIdentity.AuthServer.Prog
         var trnConfig = Configuration.GetSection("FindALostTrnIntegration:UseNewTrnLookupJourney");
         if (bool.TryParse(trnConfig.Value, out var useNewTrnLookupJourney))
         {
-            var trnOptions =Services.GetRequiredService<IOptions<FindALostTrnIntegrationOptions>>().Value;
+            var trnOptions = Services.GetRequiredService<IOptions<FindALostTrnIntegrationOptions>>().Value;
             trnOptions.UseNewTrnLookupJourney = useNewTrnLookupJourney;
         }
     }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/HostFixture.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/HostFixture.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Options;
 using OpenIddict.Abstractions;
 using OpenIddict.Server.AspNetCore;
 using TeacherIdentity.AuthServer.EventProcessing;
@@ -13,6 +14,7 @@ using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Services.DqtApi;
 using TeacherIdentity.AuthServer.Services.Email;
 using TeacherIdentity.AuthServer.Services.EmailVerification;
+using TeacherIdentity.AuthServer.Services.TrnLookup;
 using TeacherIdentity.AuthServer.State;
 using TeacherIdentity.AuthServer.TestCommon;
 using TeacherIdentity.AuthServer.Tests.Infrastructure;
@@ -85,6 +87,15 @@ public class HostFixture : WebApplicationFactory<TeacherIdentity.AuthServer.Prog
     // N.B. Don't call this from InitializeAsync - it won't work
     public void SetUserId(Guid? userId) => Services.GetRequiredService<CurrentUserIdContainer>().CurrentUserId.Value = userId;
 
+    public void ResetUseNewTrnLookupJourney()
+    {
+        var trnConfig = Configuration.GetSection("FindALostTrnIntegration:UseNewTrnLookupJourney");
+        if (bool.TryParse(trnConfig.Value, out var useNewTrnLookupJourney))
+        {
+            var trnOptions =Services.GetRequiredService<IOptions<FindALostTrnIntegrationOptions>>().Value;
+            trnOptions.UseNewTrnLookupJourney = useNewTrnLookupJourney;
+        }
+    }
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("UnitTests");

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/appsettings.json
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/appsettings.json
@@ -8,6 +8,7 @@
   "BaseAddress": "http://localhost",
   "FindALostTrnIntegration": {
     "HandoverEndpoint": "/FindALostTrn",
-    "SharedKey": "OKqdp0+u8QSzwk5unfZrTRZzqwYJSOuo0pOsOIVhkog="
+    "SharedKey": "OKqdp0+u8QSzwk5unfZrTRZzqwYJSOuo0pOsOIVhkog=",
+    "UseNewTrnLookupJourney": false
   }
 }


### PR DESCRIPTION
### Context

We're removing the dependency on Find from ID. This is the first page in the UI ported from Find.

### Changes proposed in this pull request

Add Official Name page
Redirect to new TRN flow if UseNewTrnLookupJourney is true

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [x] Reminder created to manually clean any removed app settings post deployment
