### PR TITLE
Port Support User Detail page

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/Security/AuthorizationPolicies.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/Security/AuthorizationPolicies.cs
@@ -6,6 +6,7 @@ public static class AuthorizationPolicies
     public const string ApiUserWrite = "API:UserWrite";
     public const string Authenticated = "Authenticated";
     public const string GetAnIdentityAdmin = "GetAnIdentityAdmin";
+    public const string GetAnIdentitySupport = "GetAnIdentitySupport";
     public const string Staff = "Staff";
     public const string TrnLookupApi = "API:TrnLookup";
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditUser.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditUser.cshtml
@@ -1,0 +1,93 @@
+@page "/admin/users/{userId}"
+@model TeacherIdentity.AuthServer.Pages.Admin.EditUserModel
+@{
+    ViewBag.Title = Model.Name;
+}
+
+@section BeforeContent {
+    <govuk-back-link asp-page="Users" />
+}
+
+<h1 class="govuk-heading-xl">
+    @Model.Name
+</h1>
+
+<section class="x-govuk-summary-card govuk-!-margin-bottom-6">
+    <header class="x-govuk-summary-card__header">
+        <h2 class="x-govuk-summary-card__title">
+            Get an identity details
+        </h2>
+    </header>
+
+    <div class="x-govuk-summary-card__body">
+        <govuk-summary-list>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Preferred name</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value>
+                    <p data-testid="Name">@Model.Name</p>
+
+                    <span class="govuk-!-font-size-16 govuk-hint">
+                        Name used in Get an identity<br>
+                        @if (!string.IsNullOrEmpty(Model.RegistrationClientDisplayName))
+                        {
+                            <text>From: @Model.RegistrationClientDisplayName<br></text>
+                        }
+                        Created: @Model.Created.ToString("dd MMMM yyyy") at @Model.Created.ToString("hh:mmtt")
+                    </span>
+                </govuk-summary-list-row-value>
+                <govuk-summary-list-row-actions>
+                    <govuk-summary-list-row-action href="#" visually-hidden-text="name">Change</govuk-summary-list-row-action>
+                </govuk-summary-list-row-actions>
+            </govuk-summary-list-row>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Email address</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value>@Model.EmailAddress</govuk-summary-list-row-value>
+                <govuk-summary-list-row-actions>
+                    <govuk-summary-list-row-action href="#" visually-hidden-text="email address">Change</govuk-summary-list-row-action>
+                </govuk-summary-list-row-actions>
+            </govuk-summary-list-row>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>DQT record</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value>@(Model.HaveDqtRecord ? "Yes": "No")</govuk-summary-list-row-value>
+                @if (Model.CanChangeDqtRecord)
+                {
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="#">Change record</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                }
+            </govuk-summary-list-row>
+        </govuk-summary-list>
+    </div>
+</section>
+
+@if (Model.HaveDqtRecord)
+{
+    <section class="x-govuk-summary-card govuk-!-margin-bottom-6" data-testid="DqtSection">
+        <header class="x-govuk-summary-card__header">
+            <h2 class="x-govuk-summary-card__title">
+                DQT record
+            </h2>
+        </header>
+
+        <div class="x-govuk-summary-card__body">
+            <govuk-summary-list>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>DQT name</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.DqtName</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.DqtDateOfBirth!.Value.ToString("d MMMM yyyy")</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>National insurance number</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@(!string.IsNullOrEmpty(Model.DqtNationalInsuranceNumber) ? "Given" : "Not given")</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>TRN</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.Trn</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+            </govuk-summary-list>
+        </div>
+    </section>
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditUser.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditUser.cshtml.cs
@@ -1,0 +1,98 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Infrastructure.Security;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Services.DqtApi;
+
+namespace TeacherIdentity.AuthServer.Pages.Admin;
+
+[Authorize(AuthorizationPolicies.GetAnIdentitySupport)]
+public class EditUserModel : PageModel
+{
+    private readonly TeacherIdentityServerDbContext _dbContext;
+    private readonly IDqtApiClient _dqtApiClient;
+
+    public EditUserModel(TeacherIdentityServerDbContext dbContext, IDqtApiClient dqtApiClient)
+    {
+        _dbContext = dbContext;
+        _dqtApiClient = dqtApiClient;
+    }
+
+    public DateTime Created { get; set; }
+
+    public string? EmailAddress { get; set; }
+
+    public string? Name { get; set; }
+
+    public string? RegistrationClientDisplayName { get; set; }
+
+    public bool HaveDqtRecord { get; set; }
+
+    public bool CanChangeDqtRecord { get; set; }
+
+    public string? DqtName { get; set; }
+
+    public DateOnly? DqtDateOfBirth { get; set; }
+
+    public string? DqtNationalInsuranceNumber { get; set; }
+
+    public string? Trn { get; set; }
+
+    [FromRoute]
+    public Guid UserId { get; set; }
+
+    public async Task<IActionResult> OnGet()
+    {
+        var user = await _dbContext.Users
+            .Where(u => u.UserId == UserId)
+            .Select(u => new
+            {
+                u.UserId,
+                u.EmailAddress,
+                u.FirstName,
+                u.LastName,
+                u.DateOfBirth,
+                u.Trn,
+                u.Created,
+                u.UserType,
+                RegisteredWithClientDisplayName = u.RegisteredWithClient != null ? u.RegisteredWithClient.DisplayName : null
+            })
+            .SingleOrDefaultAsync();
+
+        if (user is null)
+        {
+            return NotFound();
+        }
+
+        if (user.UserType == UserType.Staff)
+        {
+            return RedirectToPage("EditStaffUser", new { UserId });
+        }
+
+        Created = user.Created;
+        EmailAddress = user.EmailAddress;
+        Name = $"{user.FirstName} {user.LastName}";
+        RegistrationClientDisplayName = user.RegisteredWithClientDisplayName;
+        Trn = user.Trn;
+        HaveDqtRecord = user.Trn is not null;
+        CanChangeDqtRecord = !HaveDqtRecord;
+
+        if (user.Trn is not null)
+        {
+            var dqtUser = await _dqtApiClient.GetTeacherByTrn(user.Trn);
+
+            if (dqtUser is null)
+            {
+                throw new InvalidOperationException($"Could not find DQT user with TRN: '{user.Trn}'.");
+            }
+
+            DqtName = $"{dqtUser.FirstName} {dqtUser.LastName}";
+            DqtDateOfBirth = dqtUser.DateOfBirth;
+            DqtNationalInsuranceNumber = dqtUser.NationalInsuranceNumber;
+        }
+
+        return Page();
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
@@ -221,6 +221,13 @@ public class Program
                     .RequireRole(StaffRoles.GetAnIdentityAdmin));
 
             options.AddPolicy(
+                AuthorizationPolicies.GetAnIdentitySupport,
+                policy => policy
+                    .AddAuthenticationSchemes("Delegated")
+                    .RequireAuthenticatedUser()
+                    .RequireRole(StaffRoles.GetAnIdentityAdmin, StaffRoles.GetAnIdentitySupport));
+
+            options.AddPolicy(
                 AuthorizationPolicies.Staff,
                 policy => policy
                     .AddAuthenticationSchemes("Delegated")

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/TeacherInfo.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/TeacherInfo.cs
@@ -5,4 +5,6 @@ public record TeacherInfo
     public required string Trn { get; init; }
     public required string FirstName { get; init; }
     public required string LastName { get; init; }
+    public required DateOnly DateOfBirth { get; init; }
+    public required string? NationalInsuranceNumber { get; init; }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/wwwroot/Styles/_summary-card.scss
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/wwwroot/Styles/_summary-card.scss
@@ -1,0 +1,81 @@
+.x-govuk-summary-card {
+  border: 1px solid $govuk-border-colour;
+
+  // Card header
+  .x-govuk-summary-card__header {
+    align-items: center;
+    background-color: govuk-colour("light-grey");
+    padding: govuk-spacing(3);
+
+    @include govuk-media-query($from: desktop) {
+      display: flex;
+      justify-content: space-between;
+      align-items: start;
+    }
+  }
+
+  .x-govuk-summary-card__title {
+    @include govuk-font($size: 19);
+    margin: 0;
+  }
+
+  .x-govuk-summary-card__meta {
+    @include govuk-font($size: 16);
+    display: block;
+    margin: 0;
+  }
+
+  .x-govuk-summary-card__actions {
+    @include govuk-font($size: 19);
+  }
+
+  .x-govuk-summary-card__actions-list {
+    width: 100%;
+    margin: 0;
+    padding: 0;
+  }
+
+  .x-govuk-summary-card__actions-list-item {
+    display: block;
+    white-space: nowrap;
+
+    @include govuk-media-query($from: desktop) {
+      display: inline-block;
+      margin-left: govuk-spacing(2);
+      text-align: right;
+    }
+  }
+
+  .x-govuk-summary-card__actions-list-item:first-child {
+    margin-left: 0;
+  }
+
+  // Card body
+  .x-govuk-summary-card__body {
+    @include govuk-font($size: 19);
+    padding: govuk-spacing(3);
+  }
+
+  .govuk-summary-list {
+    margin-bottom: 0;
+  }
+
+  .govuk-summary-list__row:last-child,
+  .govuk-summary-list__row:last-child > * {
+    border-bottom: 0;
+  }
+}
+
+.x-govuk-summary-card--large-title .x-govuk-summary-card__title {
+  @include govuk-font($size: 24, $weight: bold);
+}
+
+@media print {
+  .x-govuk-summary-card__header {
+    break-inside: avoid;
+  }
+
+  .x-govuk-summary-card__actions {
+    display: none;
+  }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/wwwroot/Styles/site.scss
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/wwwroot/Styles/site.scss
@@ -1,6 +1,7 @@
 @use '../lib/govuk-frontend/govuk/all.scss';
 @import '../lib/govuk-frontend/govuk/_base.scss';
 @import '../lib/govuk-frontend/govuk/settings/measurements.scss';
+@import './_summary-card.scss';
 
 a {
   @extend %govuk-link;

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AngleSharpExtensions.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AngleSharpExtensions.cs
@@ -39,7 +39,13 @@ public static class AngleSharpExtensions
     public static IElement? GetElementByTestId(this IHtmlDocument doc, string testId) =>
         doc.Body!.GetElementByTestId(testId);
 
-    public static string? GetSummaryListValueForKey(this IHtmlDocument doc, string key)
+    public static IReadOnlyList<IElement> GetSummaryListActionsForKey(this IHtmlDocument doc, string key)
+    {
+        var row = GetSummaryListRowForKey(doc, key);
+        return row?.QuerySelectorAll(".govuk-summary-list__actions>*").ToArray() ?? Array.Empty<IElement>();
+    }
+
+    public static IElement? GetSummaryListRowForKey(this IHtmlDocument doc, string key)
     {
         var allRows = doc.QuerySelectorAll(".govuk-summary-list__row");
 
@@ -49,11 +55,17 @@ public static class AngleSharpExtensions
 
             if (rowKey?.TextContent.Trim() == key)
             {
-                var rowValue = row.QuerySelector(".govuk-summary-list__value");
-                return rowValue?.TextContent.Trim();
+                return row;
             }
         }
 
         return null;
+    }
+
+    public static string? GetSummaryListValueForKey(this IHtmlDocument doc, string key)
+    {
+        var row = GetSummaryListRowForKey(doc, key);
+        var rowValue = row?.QuerySelector(".govuk-summary-list__value");
+        return rowValue?.TextContent.Trim();
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/EditUserTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/EditUserTests.cs
@@ -1,0 +1,114 @@
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Admin;
+
+[Collection(nameof(DisableParallelization))]  // Relies on mocks
+public class EditUserTests : TestBase
+{
+    public EditUserTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_UnauthenticatedUser_RedirectsToSignIn()
+    {
+        var user = await TestData.CreateUser(userType: Models.UserType.Default);
+
+        await UnauthenticatedUser_RedirectsToSignIn(HttpMethod.Get, $"/admin/users/{user.UserId}");
+    }
+
+    [Fact]
+    public async Task Get_AuthenticatedUserDoesNotHavePermission_ReturnsForbidden()
+    {
+        var user = await TestData.CreateUser(userType: Models.UserType.Default);
+
+        await AuthenticatedUserDoesNotHavePermission_ReturnsForbidden(HttpMethod.Get, $"/admin/users/{user.UserId}");
+    }
+
+    [Fact]
+    public async Task Get_UserDoesNotExist_ReturnsNotFound()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/users/{userId}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_UserIsStaffUsers_RedirectsToEditStaffUserPage()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: Models.UserType.Staff);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/users/{user.UserId}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/admin/staff/{user.UserId}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestForUserWithoutTrn_RendersExpectedContent()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(hasTrn: false, userType: Models.UserType.Default);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/users/{user.UserId}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+        Assert.Equal($"{user.FirstName} {user.LastName}", doc.GetElementByTestId("Name")?.TextContent);
+        Assert.Equal(user.EmailAddress, doc.GetSummaryListValueForKey("Email address"));
+        Assert.Equal("No", doc.GetSummaryListValueForKey("DQT record"));
+        Assert.NotEmpty(doc.GetSummaryListActionsForKey("DQT record"));
+        Assert.Null(doc.GetElementByTestId("DqtSection"));
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestForUserWithTrn_RendersExpectedContent()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(hasTrn: true, userType: Models.UserType.Default);
+
+        var dqtFirstName = Faker.Name.First();
+        var dqtLastName = Faker.Name.Last();
+        var dqtDateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
+        var dqtNino = Faker.Identification.UkNationalInsuranceNumber();
+
+        HostFixture.DqtApiClient.Setup(mock => mock.GetTeacherByTrn(user.Trn!, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AuthServer.Services.DqtApi.TeacherInfo()
+            {
+                DateOfBirth = dqtDateOfBirth,
+                FirstName = dqtFirstName,
+                LastName = dqtLastName,
+                NationalInsuranceNumber = dqtNino,
+                Trn = user.Trn!
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/users/{user.UserId}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+        Assert.Empty(doc.GetSummaryListActionsForKey("DQT record"));
+        Assert.NotNull(doc.GetElementByTestId("DqtSection"));
+        Assert.Equal($"{dqtFirstName} {dqtLastName}", doc.GetSummaryListValueForKey("DQT name"));
+        Assert.Equal(dqtDateOfBirth.ToString("d MMMM yyyy"), doc.GetSummaryListValueForKey("Date of birth"));
+        Assert.Equal("Given", doc.GetSummaryListValueForKey("National insurance number"));
+        Assert.Equal(user.Trn, doc.GetSummaryListValueForKey("TRN"));
+    }
+}


### PR DESCRIPTION
### Context

Ports the User detail page from Find's support area into ID. Change links are stubbed out for now.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
