### PR TITLE
Update GovUk.Frontend.AspNetCore version

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/TeacherIdentity.AuthServer.csproj
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/TeacherIdentity.AuthServer.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="EFCore.NamingConventions" Version="7.0.0" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.4.0" />
     <PackageReference Include="Flurl" Version="3.0.6" />
-    <PackageReference Include="GovUk.Frontend.AspNetCore" Version="1.0.0-beta3" />
+    <PackageReference Include="GovUk.Frontend.AspNetCore" Version="1.0.0-beta4" />
     <PackageReference Include="GovukNotify" Version="6.1.0" />
     <PackageReference Include="Hangfire.AspNetCore" Version="1.7.32" />
     <PackageReference Include="Hangfire.Core" Version="1.7.32" />


### PR DESCRIPTION
Gives us support for binding `DateOnly` properties in the Date input component.