### PR TITLE
Port the Assign TRN UI from Find's Support

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Events/UserUpdatedEvent.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Events/UserUpdatedEvent.cs
@@ -23,5 +23,6 @@ public enum UserUpdatedEventSource
 {
     Api = 0,
     TrnMatchedToExistingUser = 1,
-    ChangedByUser = 2
+    ChangedByUser = 2,
+    SupportUi = 3
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/TrnAssociationSource.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/TrnAssociationSource.cs
@@ -3,5 +3,6 @@ namespace TeacherIdentity.AuthServer.Models;
 public enum TrnAssociationSource
 {
     Lookup = 0,
-    Api = 1
+    Api = 1,
+    SupportUi = 2
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Confirm.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Confirm.cshtml
@@ -1,0 +1,80 @@
+@page "/admin/users/{userId}/assign-trn/{trn}"
+@model TeacherIdentity.AuthServer.Pages.Admin.AssignTrn.ConfirmModel
+@{
+    ViewBag.Title = "We found a DQT record, is it the right one?";
+}
+
+@section BeforeContent {
+    <govuk-back-link asp-page="Trn" asp-route-userId="@Model.UserId" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+
+        <form asp-page="Confirm" asp-route-userId="@Model.UserId" asp-route-trn="@Model.Trn">
+            <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
+
+            <section class="x-govuk-summary-card govuk-!-margin-bottom-6 ">
+                <header class="x-govuk-summary-card__header">
+                    <h2 class="x-govuk-summary-card__title">
+                        Get an identity
+                    </h2>
+                </header>
+
+                <div class="x-govuk-summary-card__body">
+                    <govuk-summary-list>
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>Preferred name</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value>@Model.Name</govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>Email address</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value>@Model.EmailAddress</govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                    </govuk-summary-list>
+                </div>
+            </section>
+
+            <section class="x-govuk-summary-card govuk-!-margin-bottom-6 ">
+                <header class="x-govuk-summary-card__header">
+                    <h2 class="x-govuk-summary-card__title">
+                        DQT record
+                    </h2>
+                </header>
+
+                <div class="x-govuk-summary-card__body">
+                    <dl class="govuk-summary-list">
+                        <govuk-summary-list>
+                            <govuk-summary-list-row>
+                                <govuk-summary-list-row-key>DQT name</govuk-summary-list-row-key>
+                                <govuk-summary-list-row-value>@Model.DqtName</govuk-summary-list-row-value>
+                            </govuk-summary-list-row>
+                            <govuk-summary-list-row>
+                                <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
+                                <govuk-summary-list-row-value>@Model.DqtDateOfBirth!.Value.ToString("d MMMM yyyy")</govuk-summary-list-row-value>
+                            </govuk-summary-list-row>
+                            <govuk-summary-list-row>
+                                <govuk-summary-list-row-key>National insurance number</govuk-summary-list-row-key>
+                                <govuk-summary-list-row-value>@(!string.IsNullOrEmpty(Model.DqtNationalInsuranceNumber) ? "Given" : "Not given")</govuk-summary-list-row-value>
+                            </govuk-summary-list-row>
+                            <govuk-summary-list-row>
+                                <govuk-summary-list-row-key>TRN</govuk-summary-list-row-key>
+                                <govuk-summary-list-row-value>@Model.Trn</govuk-summary-list-row-value>
+                            </govuk-summary-list-row>
+                        </govuk-summary-list>
+                    </dl>
+                </div>
+            </section>
+
+            <govuk-radios asp-for="AddRecord">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m"/>
+                    <govuk-radios-item value="@true">Yes, add this record</govuk-radios-item>
+                    <govuk-radios-item value="@false">No, this is the wrong record</govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Confirm.cshtml.cs
@@ -1,0 +1,120 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Infrastructure.Security;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Services.DqtApi;
+
+namespace TeacherIdentity.AuthServer.Pages.Admin.AssignTrn;
+
+[Authorize(AuthorizationPolicies.GetAnIdentitySupport)]
+public class ConfirmModel : PageModel
+{
+    private readonly TeacherIdentityServerDbContext _dbContext;
+    private readonly IDqtApiClient _dqtApiClient;
+    private readonly IClock _clock;
+
+    public ConfirmModel(TeacherIdentityServerDbContext dbContext, IDqtApiClient dqtApiClient, IClock clock)
+    {
+        _dbContext = dbContext;
+        _dqtApiClient = dqtApiClient;
+        _clock = clock;
+    }
+
+    [FromRoute]
+    public Guid UserId { get; set; }
+
+    [FromRoute]
+    public string Trn { get; set; } = default!;
+
+    public string? EmailAddress { get; set; }
+
+    public string? Name { get; set; }
+
+    public string? DqtName { get; set; }
+
+    public DateOnly? DqtDateOfBirth { get; set; }
+
+    public string? DqtNationalInsuranceNumber { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Do you want to add this DQT record?")]
+    [Required(ErrorMessage = "Tell us if this is the right DQT record")]
+    public bool? AddRecord { get; set; }
+
+    public IActionResult OnGet()
+    {
+        return Page();
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        if (AddRecord == false)
+        {
+            return RedirectToPage("/Admin/EditUser", new { UserId });
+        }
+
+        var user = await _dbContext.Users.SingleAsync(u => u.UserId == UserId);
+
+        user.Trn = Trn;
+        user.TrnLookupStatus = TrnLookupStatus.Found;
+        user.TrnAssociationSource = TrnAssociationSource.SupportUi;
+        user.Updated = _clock.UtcNow;
+
+        var changes = Events.UserUpdatedEventChanges.Trn | Events.UserUpdatedEventChanges.TrnLookupStatus;
+
+        _dbContext.AddEvent(new Events.UserUpdatedEvent()
+        {
+            Source = Events.UserUpdatedEventSource.SupportUi,
+            CreatedUtc = _clock.UtcNow,
+            Changes = changes,
+            User = Events.User.FromModel(user)
+        });
+
+        await _dbContext.SaveChangesAsync();
+
+        TempData[TempDataKeys.FlashSuccess] = "DQT record added";
+        return RedirectToPage("/Admin/EditUser", new { UserId });
+    }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        var user = await _dbContext.Users.SingleOrDefaultAsync(u => u.UserId == UserId);
+
+        if (user is null || user.UserType != UserType.Default)
+        {
+            context.Result = NotFound();
+            return;
+        }
+
+        if (user.Trn is not null)
+        {
+            context.Result = BadRequest();
+            return;
+        }
+
+        var dqtTeacher = await _dqtApiClient.GetTeacherByTrn(Trn);
+
+        if (dqtTeacher is null)
+        {
+            context.Result = NotFound();
+            return;
+        }
+
+        EmailAddress = user.EmailAddress;
+        Name = $"{user.FirstName} {user.LastName}";
+        DqtName = $"{dqtTeacher.FirstName} {dqtTeacher.LastName}";
+        DqtDateOfBirth = dqtTeacher.DateOfBirth;
+        DqtNationalInsuranceNumber = dqtTeacher.NationalInsuranceNumber;
+
+        await next();
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Trn.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Trn.cshtml
@@ -1,0 +1,21 @@
+@page "/admin/users/{userId}/assign-trn"
+@model TeacherIdentity.AuthServer.Pages.Admin.AssignTrn.TrnModel
+@{
+    ViewBag.Title = "What is their TRN?";
+}
+
+@section BeforeContent {
+    <govuk-back-link asp-page="EditUser" asp-route-userId="@Model.UserId" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <form asp-page="Trn" asp-route-userId="@Model.UserId">
+            <govuk-input asp-for="Trn">
+                <govuk-input-label class="govuk-label--xl" />
+            </govuk-input>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Trn.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Trn.cshtml.cs
@@ -1,0 +1,82 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Infrastructure.Security;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Services.DqtApi;
+
+namespace TeacherIdentity.AuthServer.Pages.Admin.AssignTrn;
+
+[Authorize(AuthorizationPolicies.GetAnIdentitySupport)]
+public class TrnModel : PageModel
+{
+    private readonly TeacherIdentityServerDbContext _dbContext;
+    private readonly IDqtApiClient _dqtApiClient;
+
+    public TrnModel(TeacherIdentityServerDbContext dbContext, IDqtApiClient dqtApiClient)
+    {
+        _dbContext = dbContext;
+        _dqtApiClient = dqtApiClient;
+    }
+
+    [BindProperty]
+    [Display(Name = "What is their teacher reference number (TRN)?")]
+    [Required(ErrorMessage = "Enter a TRN")]
+    [RegularExpression(@"^\d{7}$", ErrorMessage = "TRN must be 7 digits")]
+    public string? Trn { get; set; }
+
+    [FromRoute]
+    public Guid UserId { get; set; }
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        var dqtTeacher = await _dqtApiClient.GetTeacherByTrn(Trn!);
+
+        if (dqtTeacher is null)
+        {
+            ModelState.AddModelError(nameof(Trn), "TRN does not exist");
+            return this.PageWithErrors();
+        }
+
+        var otherOtherWithTrn = await _dbContext.Users.SingleOrDefaultAsync(u => u.Trn == Trn);
+
+        if (otherOtherWithTrn is not null)
+        {
+            ModelState.AddModelError(nameof(Trn), "TRN is assigned to another user");
+            return this.PageWithErrors();
+        }
+
+        return RedirectToPage("Confirm", new { UserId, Trn });
+    }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        var user = await _dbContext.Users.SingleOrDefaultAsync(u => u.UserId == UserId);
+
+        if (user is null || user.UserType != UserType.Default)
+        {
+            context.Result = NotFound();
+            return;
+        }
+
+        if (user.Trn is not null)
+        {
+            context.Result = BadRequest();
+            return;
+        }
+
+        await next();
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditUser.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditUser.cshtml
@@ -52,7 +52,7 @@
                 @if (Model.CanChangeDqtRecord)
                 {
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="#">Change record</govuk-summary-list-row-action>
+                        <govuk-summary-list-row-action asp-page="AssignTrn/Trn" asp-route-userId="@Model.UserId">Change record</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 }
             </govuk-summary-list-row>

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AssignTrn/ConfirmTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AssignTrn/ConfirmTests.cs
@@ -1,0 +1,440 @@
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Services.DqtApi;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Admin.AssignTrn;
+
+[Collection(nameof(DisableParallelization))]  // Relies on mocks
+public class ConfirmTests : TestBase
+{
+    public ConfirmTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_UnauthenticatedUser_RedirectsToSignIn()
+    {
+        var user = await TestData.CreateUser(userType: UserType.Default, hasTrn: false);
+        var trn = TestData.GenerateTrn();
+
+        HostFixture.DqtApiClient.Setup(mock => mock.GetTeacherByTrn(trn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TeacherInfo()
+            {
+                Trn = trn,
+                DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
+                FirstName = Faker.Name.First(),
+                LastName = Faker.Name.Last(),
+                NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber()
+            });
+
+        await UnauthenticatedUser_RedirectsToSignIn(HttpMethod.Get, $"/admin/users/{user.UserId}/assign-trn/{trn}");
+    }
+
+    [Fact]
+    public async Task Get_AuthenticatedUserDoesNotHavePermission_ReturnsForbidden()
+    {
+        var user = await TestData.CreateUser(userType: UserType.Default, hasTrn: false);
+        var trn = TestData.GenerateTrn();
+
+        HostFixture.DqtApiClient.Setup(mock => mock.GetTeacherByTrn(trn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TeacherInfo()
+            {
+                Trn = trn,
+                DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
+                FirstName = Faker.Name.First(),
+                LastName = Faker.Name.Last(),
+                NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber()
+            });
+
+        await AuthenticatedUserDoesNotHavePermission_ReturnsForbidden(HttpMethod.Get, $"/admin/users/{user.UserId}/assign-trn/{trn}");
+    }
+
+    [Fact]
+    public async Task Get_UserDoesNotExist_ReturnsNotFound()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var trn = TestData.GenerateTrn();
+
+        HostFixture.DqtApiClient.Setup(mock => mock.GetTeacherByTrn(trn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TeacherInfo()
+            {
+                Trn = trn,
+                DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
+                FirstName = Faker.Name.First(),
+                LastName = Faker.Name.Last(),
+                NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber()
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/users/{userId}/assign-trn/{trn}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_UserAlreadyHasTrnAssigned_ReturnsBadRequest()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default, hasTrn: true);
+        var trn = TestData.GenerateTrn();
+
+        HostFixture.DqtApiClient.Setup(mock => mock.GetTeacherByTrn(trn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TeacherInfo()
+            {
+                Trn = trn,
+                DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
+                FirstName = Faker.Name.First(),
+                LastName = Faker.Name.Last(),
+                NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber()
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/users/{user.UserId}/assign-trn/{trn}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_TrnDoesNotExist_ReturnsNotFound()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var trn = TestData.GenerateTrn();
+
+        HostFixture.DqtApiClient.Setup(mock => mock.GetTeacherByTrn(trn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TeacherInfo?)null);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/users/{userId}/assign-trn/{trn}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_RendersExpectedContent()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default, hasTrn: false);
+        var trn = TestData.GenerateTrn();
+
+        var dqtFirstName = Faker.Name.First();
+        var dqtLastName = Faker.Name.Last();
+        var dqtDateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
+        var dqtNino = Faker.Identification.UkNationalInsuranceNumber();
+
+        HostFixture.DqtApiClient.Setup(mock => mock.GetTeacherByTrn(trn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TeacherInfo()
+            {
+                DateOfBirth = dqtDateOfBirth,
+                FirstName = dqtFirstName,
+                LastName = dqtLastName,
+                NationalInsuranceNumber = dqtNino,
+                Trn = trn
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/users/{user.UserId}/assign-trn/{trn}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+        Assert.Equal($"{user.FirstName} {user.LastName}", doc.GetSummaryListValueForKey("Preferred name"));
+        Assert.Equal(user.EmailAddress, doc.GetSummaryListValueForKey("Email address"));
+        Assert.Equal($"{dqtFirstName} {dqtLastName}", doc.GetSummaryListValueForKey("DQT name"));
+        Assert.Equal(dqtDateOfBirth.ToString("d MMMM yyyy"), doc.GetSummaryListValueForKey("Date of birth"));
+        Assert.Equal("Given", doc.GetSummaryListValueForKey("National insurance number"));
+        Assert.Equal(trn, doc.GetSummaryListValueForKey("TRN"));
+    }
+
+    [Fact]
+    public async Task Post_UnauthenticatedUser_RedirectsToSignIn()
+    {
+        var user = await TestData.CreateUser(userType: UserType.Default, hasTrn: false);
+        var trn = TestData.GenerateTrn();
+
+        HostFixture.DqtApiClient.Setup(mock => mock.GetTeacherByTrn(trn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TeacherInfo()
+            {
+                Trn = trn,
+                DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
+                FirstName = Faker.Name.First(),
+                LastName = Faker.Name.Last(),
+                NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber()
+            });
+
+        await UnauthenticatedUser_RedirectsToSignIn(
+            HttpMethod.Post,
+            $"/admin/users/{user.UserId}/assign-trn/{trn}",
+            new FormUrlEncodedContentBuilder()
+            {
+                { "AddRecord", bool.TrueString }
+            });
+    }
+
+    [Fact]
+    public async Task Post_AuthenticatedUserDoesNotHavePermission_ReturnsForbidden()
+    {
+        var user = await TestData.CreateUser(userType: UserType.Default, hasTrn: false);
+        var trn = TestData.GenerateTrn();
+
+        HostFixture.DqtApiClient.Setup(mock => mock.GetTeacherByTrn(trn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TeacherInfo()
+            {
+                Trn = trn,
+                DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
+                FirstName = Faker.Name.First(),
+                LastName = Faker.Name.Last(),
+                NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber()
+            });
+
+        await AuthenticatedUserDoesNotHavePermission_ReturnsForbidden(
+            HttpMethod.Post,
+            $"/admin/users/{user.UserId}/assign-trn/{trn}",
+            new FormUrlEncodedContentBuilder()
+            {
+                { "AddRecord", bool.TrueString }
+            });
+    }
+
+    [Fact]
+    public async Task Post_UserDoesNotExist_ReturnsNotFound()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var trn = TestData.GenerateTrn();
+
+        HostFixture.DqtApiClient.Setup(mock => mock.GetTeacherByTrn(trn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TeacherInfo()
+            {
+                Trn = trn,
+                DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
+                FirstName = Faker.Name.First(),
+                LastName = Faker.Name.Last(),
+                NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber()
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{userId}/assign-trn/{trn}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "AddRecord", bool.TrueString }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_UserAlreadyHasTrnAssigned_ReturnsBadRequest()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default, hasTrn: true);
+        var trn = TestData.GenerateTrn();
+
+        HostFixture.DqtApiClient.Setup(mock => mock.GetTeacherByTrn(trn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TeacherInfo()
+            {
+                Trn = trn,
+                DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
+                FirstName = Faker.Name.First(),
+                LastName = Faker.Name.Last(),
+                NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber()
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{user.UserId}/assign-trn/{trn}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "AddRecord", bool.TrueString }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_TrnDoesNotExist_ReturnsNotFound()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var trn = TestData.GenerateTrn();
+
+        HostFixture.DqtApiClient.Setup(mock => mock.GetTeacherByTrn(trn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TeacherInfo?)null);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{userId}/assign-trn/{trn}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "AddRecord", bool.TrueString }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_NoOptionSelected_ReturnsError()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default, hasTrn: false);
+        var trn = TestData.GenerateTrn();
+
+        var dqtFirstName = Faker.Name.First();
+        var dqtLastName = Faker.Name.Last();
+        var dqtDateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
+        var dqtNino = Faker.Identification.UkNationalInsuranceNumber();
+
+        HostFixture.DqtApiClient.Setup(mock => mock.GetTeacherByTrn(trn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TeacherInfo()
+            {
+                DateOfBirth = dqtDateOfBirth,
+                FirstName = dqtFirstName,
+                LastName = dqtLastName,
+                NationalInsuranceNumber = dqtNino,
+                Trn = trn
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{user.UserId}/assign-trn/{trn}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "AddRecord", "Tell us if this is the right DQT record");
+    }
+
+    [Fact]
+    public async Task Post_WithAddRecordNotConfirmed_RedirectsAndDoesNotAssignTrn()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default, hasTrn: false);
+        var trn = TestData.GenerateTrn();
+
+        var dqtFirstName = Faker.Name.First();
+        var dqtLastName = Faker.Name.Last();
+        var dqtDateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
+        var dqtNino = Faker.Identification.UkNationalInsuranceNumber();
+
+        HostFixture.DqtApiClient.Setup(mock => mock.GetTeacherByTrn(trn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TeacherInfo()
+            {
+                DateOfBirth = dqtDateOfBirth,
+                FirstName = dqtFirstName,
+                LastName = dqtLastName,
+                NationalInsuranceNumber = dqtNino,
+                Trn = trn
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{user.UserId}/assign-trn/{trn}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "AddRecord", bool.FalseString }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/admin/users/{user.UserId}", response.Headers.Location?.OriginalString);
+
+        await TestData.WithDbContext(async dbContext =>
+        {
+            user = await dbContext.Users.SingleAsync(u => u.UserId == user.UserId);
+            Assert.Null(user.Trn);
+            Assert.Null(user.TrnAssociationSource);
+            Assert.NotEqual(TrnLookupStatus.Found, user.TrnLookupStatus);
+            Assert.Equal(user.Created, user.Updated);
+        });
+    }
+
+    [Fact]
+    public async Task Post_WithAddRecordConfirmed_AssignsTrnToUserEmitsEventAndRedirects()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default, hasTrn: false);
+        var trn = TestData.GenerateTrn();
+
+        var dqtFirstName = Faker.Name.First();
+        var dqtLastName = Faker.Name.Last();
+        var dqtDateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
+        var dqtNino = Faker.Identification.UkNationalInsuranceNumber();
+
+        HostFixture.DqtApiClient.Setup(mock => mock.GetTeacherByTrn(trn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TeacherInfo()
+            {
+                DateOfBirth = dqtDateOfBirth,
+                FirstName = dqtFirstName,
+                LastName = dqtLastName,
+                NationalInsuranceNumber = dqtNino,
+                Trn = trn
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{user.UserId}/assign-trn/{trn}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "AddRecord", bool.TrueString }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/admin/users/{user.UserId}", response.Headers.Location?.OriginalString);
+
+        await TestData.WithDbContext(async dbContext =>
+        {
+            user = await dbContext.Users.SingleAsync(u => u.UserId == user.UserId);
+            Assert.Equal(trn, user.Trn);
+            Assert.Equal(TrnAssociationSource.SupportUi, user.TrnAssociationSource);
+            Assert.Equal(TrnLookupStatus.Found, user.TrnLookupStatus);
+            Assert.Equal(Clock.UtcNow, user.Updated);
+        });
+
+        EventObserver.AssertEventsSaved(
+            e =>
+            {
+                var userUpdatedEvent = Assert.IsType<UserUpdatedEvent>(e);
+                Assert.Equal(Clock.UtcNow, userUpdatedEvent.CreatedUtc);
+                Assert.Equal(UserUpdatedEventSource.SupportUi, userUpdatedEvent.Source);
+                Assert.Equal(UserUpdatedEventChanges.Trn | UserUpdatedEventChanges.TrnLookupStatus, userUpdatedEvent.Changes);
+                Assert.Equal(user.UserId, userUpdatedEvent.User.UserId);
+            });
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AssignTrn/TrnTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AssignTrn/TrnTests.cs
@@ -1,0 +1,268 @@
+using TeacherIdentity.AuthServer.Services.DqtApi;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Admin.AssignTrn;
+
+[Collection(nameof(DisableParallelization))]  // Relies on mocks
+public class TrnTests : TestBase
+{
+    public TrnTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_UnauthenticatedUser_RedirectsToSignIn()
+    {
+        var user = await TestData.CreateUser(userType: Models.UserType.Default, hasTrn: false);
+
+        await UnauthenticatedUser_RedirectsToSignIn(HttpMethod.Get, $"/admin/users/{user.UserId}/assign-trn");
+    }
+
+    [Fact]
+    public async Task Get_AuthenticatedUserDoesNotHavePermission_ReturnsForbidden()
+    {
+        var user = await TestData.CreateUser(userType: Models.UserType.Default, hasTrn: false);
+
+        await AuthenticatedUserDoesNotHavePermission_ReturnsForbidden(HttpMethod.Get, $"/admin/users/{user.UserId}/assign-trn");
+    }
+
+    [Fact]
+    public async Task Get_UserDoesNotExist_ReturnsNotFound()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/users/{userId}/assign-trn");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_UserAlreadyHasTrnAssigned_ReturnsBadRequest()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: Models.UserType.Default, hasTrn: true);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/users/{user.UserId}/assign-trn");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_ReturnsOk()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: Models.UserType.Default, hasTrn: false);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/users/{user.UserId}/assign-trn");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_UnauthenticatedUser_RedirectsToSignIn()
+    {
+        var user = await TestData.CreateUser(userType: Models.UserType.Default, hasTrn: false);
+
+        await UnauthenticatedUser_RedirectsToSignIn(HttpMethod.Post, $"/admin/users/{user.UserId}/assign-trn");
+    }
+
+    [Fact]
+    public async Task Post_AuthenticatedUserDoesNotHavePermission_ReturnsForbidden()
+    {
+        var user = await TestData.CreateUser(userType: Models.UserType.Default, hasTrn: false);
+
+        await AuthenticatedUserDoesNotHavePermission_ReturnsForbidden(HttpMethod.Post, $"/admin/users/{user.UserId}/assign-trn");
+    }
+
+    [Fact]
+    public async Task Post_UserDoesNotExist_ReturnsNotFound()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{userId}/assign-trn");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_UserAlreadyHasTrnAssigned_ReturnsBadRequest()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: Models.UserType.Default, hasTrn: true);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{user.UserId}/assign-trn");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_TrnNotEntered_ReturnsError()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: Models.UserType.Default, hasTrn: false);
+        var trn = TestData.GenerateTrn();
+
+        HostFixture.DqtApiClient.Setup(mock => mock.GetTeacherByTrn(trn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TeacherInfo()
+            {
+                Trn = trn,
+                DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
+                FirstName = Faker.Name.First(),
+                LastName = Faker.Name.Last(),
+                NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber()
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{user.UserId}/assign-trn")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Trn", "Enter a TRN");
+    }
+
+    [Theory]
+    [InlineData("xxx")]
+    [InlineData("1")]
+    [InlineData("12345678")]
+    public async Task Post_TrnNotValid_ReturnsError(string trn)
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: Models.UserType.Default, hasTrn: false);
+
+        HostFixture.DqtApiClient.Setup(mock => mock.GetTeacherByTrn(trn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TeacherInfo()
+            {
+                Trn = trn,
+                DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
+                FirstName = Faker.Name.First(),
+                LastName = Faker.Name.Last(),
+                NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber()
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{user.UserId}/assign-trn")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Trn", trn }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Trn", "TRN must be 7 digits");
+    }
+
+    [Fact]
+    public async Task Post_TrnDoesNotExist_ReturnsError()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: Models.UserType.Default, hasTrn: false);
+        var trn = TestData.GenerateTrn();
+
+        HostFixture.DqtApiClient.Setup(mock => mock.GetTeacherByTrn(trn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((TeacherInfo?)null);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{user.UserId}/assign-trn")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Trn", trn }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Trn", "TRN does not exist");
+    }
+
+    [Fact]
+    public async Task Post_TrnAlreadyAllocated_ReturnsError()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: Models.UserType.Default, hasTrn: false);
+        var anotherUser = await TestData.CreateUser(hasTrn: true);
+        var trn = anotherUser.Trn!;
+
+        HostFixture.DqtApiClient.Setup(mock => mock.GetTeacherByTrn(trn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TeacherInfo()
+            {
+                Trn = trn,
+                DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
+                FirstName = Faker.Name.First(),
+                LastName = Faker.Name.Last(),
+                NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber()
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{user.UserId}/assign-trn")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Trn", trn }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Trn", "TRN is assigned to another user");
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_RedirectsToConfirmPage()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: Models.UserType.Default, hasTrn: false);
+        var trn = TestData.GenerateTrn();
+
+        HostFixture.DqtApiClient.Setup(mock => mock.GetTeacherByTrn(trn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TeacherInfo()
+            {
+                Trn = trn,
+                DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
+                FirstName = Faker.Name.First(),
+                LastName = Faker.Name.Last(),
+                NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber()
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{user.UserId}/assign-trn")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Trn", trn }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/admin/users/{user.UserId}/assign-trn/{trn}", response.Headers.Location?.OriginalString);
+    }
+}


### PR DESCRIPTION
### Context

We're porting ID support from Find into ID itself. This PR is largely a clone of what Find has today for assigning a TRN to a user.

### Changes proposed in this pull request

Add UI for assigning a TRN to a user. There a few behaviour improvements over the existing version to better handle where a TRN is already assigned to another user. We also prevent a TRN being assigned where one is already in place, at least for now.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
