### PR TITLE
Add identity awarded QTS page for TRN lookup flow

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -84,9 +84,9 @@ public class AuthenticationState
     public string? TrnOwnerEmailAddress { get; private set; }
     [JsonInclude]
     public TrnLookupStatus? TrnLookupStatus { get; private set; }
-    public bool HaveNationalInsuranceNumber { get; set; }
+    public bool? HaveNationalInsuranceNumber { get; set; }
     public string? NationalInsuranceNumber { get; set; }
-    public bool AwardedQts { get; set; }
+    public bool? AwardedQts { get; set; }
 
     /// <summary>
     /// Whether the user has gone back to an earlier page after this journey has been completed.

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -86,6 +86,7 @@ public class AuthenticationState
     public TrnLookupStatus? TrnLookupStatus { get; private set; }
     public bool HaveNationalInsuranceNumber { get; set; }
     public string? NationalInsuranceNumber { get; set; }
+    public bool AwardedQts { get; set; }
 
     /// <summary>
     /// Whether the user has gone back to an earlier page after this journey has been completed.

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -79,7 +79,11 @@ public static class IdentityLinkGeneratorExtensions
 
     public static string TrnNiNumber(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Trn/NiNumberPage");
 
-    public static string TrnAwardedQts(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Trn/AwardedQts");
+    public static string TrnAwardedQts(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Trn/AwardedQtsPage");
+
+    public static string TrnIttProvider(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Trn/IttProvider");
+
+    public static string TrnCheckAnswers(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Trn/CheckAnswers");
 
     public static string Landing(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Landing");
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/AwardedQtsPage.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/AwardedQtsPage.cshtml
@@ -1,0 +1,27 @@
+@page "/sign-in/trn/awarded-qts"
+@model TeacherIdentity.AuthServer.Pages.SignIn.Trn.AwardedQtsPage
+@{
+    ViewBag.Title = Html.DisplayNameFor(m => m.AwardedQts);
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@Model.BackLink" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.TrnAwardedQts()" method="post" asp-antiforgery="true">
+            <govuk-radios asp-for="AwardedQts">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--xl"/>
+
+                    <govuk-radios-item value="True">Yes</govuk-radios-item>
+                    <govuk-radios-item value="False">No</govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>
+

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/AwardedQtsPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/AwardedQtsPage.cshtml.cs
@@ -1,0 +1,57 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn.Trn;
+
+[BindProperties]
+public class AwardedQtsPage : PageModel
+{
+    private IIdentityLinkGenerator _linkGenerator;
+
+    public AwardedQtsPage(IIdentityLinkGenerator linkGenerator)
+    {
+        _linkGenerator = linkGenerator;
+    }
+
+    public string? BackLink => HttpContext.GetAuthenticationState().HaveNationalInsuranceNumber
+        ? _linkGenerator.TrnNiNumber()
+        : _linkGenerator.TrnHaveNiNumber();
+
+    [Display(Name = "Have you been awarded qualified teacher status (QTS)?")]
+    [Required(ErrorMessage = "Tell us if you have been awarded qualified teacher status (QTS)")]
+    public bool? AwardedQts { get; set; }
+
+    public void OnGet()
+    {
+    }
+
+    public IActionResult OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        HttpContext.GetAuthenticationState().AwardedQts = (bool)AwardedQts!;
+
+        return (bool)AwardedQts!
+            ? Redirect(_linkGenerator.TrnIttProvider())
+            : Redirect(_linkGenerator.TrnCheckAnswers());
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var authenticationState = context.HttpContext.GetAuthenticationState();
+
+        // We expect to have a verified email and official names at this point but we shouldn't have completed the TRN lookup
+        if (string.IsNullOrEmpty(authenticationState.EmailAddress) ||
+            !authenticationState.EmailAddressVerified ||
+            !authenticationState.HasOfficialName() ||
+            authenticationState.HaveCompletedTrnLookup)
+        {
+            context.Result = new RedirectResult(authenticationState.GetNextHopUrl(_linkGenerator));
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/AwardedQtsPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/AwardedQtsPage.cshtml.cs
@@ -15,7 +15,7 @@ public class AwardedQtsPage : PageModel
         _linkGenerator = linkGenerator;
     }
 
-    public string? BackLink => HttpContext.GetAuthenticationState().HaveNationalInsuranceNumber
+    public string? BackLink => (HttpContext.GetAuthenticationState().HaveNationalInsuranceNumber == true)
         ? _linkGenerator.TrnNiNumber()
         : _linkGenerator.TrnHaveNiNumber();
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/AwardedQtsPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/AwardedQtsPageTests.cs
@@ -1,0 +1,128 @@
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Trn;
+
+public class AwardedQtsPageTests : TestBase
+{
+    public AwardedQtsPageTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, $"/sign-in/trn/awarded-qts");
+    }
+
+    [Fact]
+    public async Task Get_NoAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await MissingAuthenticationState_ReturnsBadRequest(HttpMethod.Get, $"/sign-in/trn/awarded-qts");
+    }
+
+    [Fact]
+    public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Get, "/sign-in/trn/awarded-qts");
+    }
+
+    [Fact]
+    public async Task Get_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(c => c.OfficialNameSet(), HttpMethod.Get, "/sign-in/trn/awarded-qts");
+    }
+
+    [Fact]
+    public async Task Get_NoEmail_RedirectsToEmailPage()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/awarded-qts?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/email", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_EmailNotVerified_RedirectsToEmailConfirmationPage()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet());
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/awarded-qts?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/email-confirmation", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_OfficialNameNotSet_RedirectsToNextHopUrl()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified());
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/awarded-qts?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal(authStateHelper.GetNextHopUrl(), response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_RendersContent()
+    {
+        await ValidRequest_RendersContent("/sign-in/trn/awarded-qts", c => c.OfficialNameSet());
+    }
+
+    [Fact]
+    public async Task Post_NullAwardedQts_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.OfficialNameSet());
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/awarded-qts?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "AwardedQts", "Tell us if you have been awarded qualified teacher status (QTS)");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Post_ValidForm_SetsAwardedQtsOnAuthenticationState(bool awardedQts)
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.OfficialNameSet());
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/awarded-qts?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "AwardedQts", awardedQts },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal(awardedQts, authStateHelper.AuthenticationState.AwardedQts);
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/HaveNiNumberTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/HaveNiNumberTests.cs
@@ -147,4 +147,26 @@ public class HaveNiNumberTests : TestBase
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.StartsWith("/sign-in/trn/ni-number", response.Headers.Location?.OriginalString);
     }
+
+    [Fact]
+    public async Task Post_HasNiNumberFalse_RedirectsToAwardedQtsPage()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.OfficialNameSet());
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/have-nino?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "HasNiNumber", false },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/trn/awarded-qts", response.Headers.Location?.OriginalString);
+    }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/NiNumberPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/NiNumberPageTests.cs
@@ -2,9 +2,9 @@ using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Trn;
 
-public class NiNumberTests : TestBase
+public class NiNumberPageTests : TestBase
 {
-    public NiNumberTests(HostFixture hostFixture)
+    public NiNumberPageTests(HostFixture hostFixture)
         : base(hostFixture)
     {
     }
@@ -138,7 +138,7 @@ public class NiNumberTests : TestBase
     [InlineData("QQ 12 34 56 C")]
     [InlineData("QQ123456C")]
     [InlineData("qQ123456c")]
-    public async Task Post_ValidNiNumber_SetsNiNumberOnAuthenticationState(string niNumber)
+    public async Task Post_ValidNiNumber_SetsNiNumberOnAuthenticationStateRedirectsToAwardedQtsPage(string niNumber)
     {
         // Arrange
         var authStateHelper = await CreateAuthenticationStateHelper(c => c.OfficialNameSet());
@@ -156,6 +156,8 @@ public class NiNumberTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/trn/awarded-qts", response.Headers.Location?.OriginalString);
+
         Assert.Equal(niNumber, authStateHelper.AuthenticationState.NationalInsuranceNumber);
     }
 


### PR DESCRIPTION
### Context

We're removing the dependency on Find from ID. This is the next page in the UI ported from Find.

### Changes proposed in this pull request

Add new Award QTS page

### Guidance to review

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
