### PR TITLE
Add User list to support UI

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Trn.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Trn.cshtml
@@ -5,7 +5,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link asp-page="User" asp-route-userId="@Model.UserId" />
+    <govuk-back-link asp-page="/Admin/User" asp-route-userId="@Model.UserId" />
 }
 
 <div class="govuk-grid-row">

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Users.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Users.cshtml
@@ -1,0 +1,110 @@
+@page "/admin/users"
+@model TeacherIdentity.AuthServer.Pages.Admin.UsersModel
+@{
+    ViewBag.Title = "Users";
+}
+
+<h1 class="govuk-heading-xl">@ViewBag.Title</h1>
+
+<govuk-tabs>
+    <govuk-tabs-item label="Open" id="open-tab">
+        <p class="govuk-heading-s ">These records need to be checked against the DQT.</p>
+
+        <p>Showing @Model.OpenTotal of @Model.OpenTotal total</p>
+
+        @if (Model.Open!.Length > 0)
+        {
+            <table class="govuk-table">
+                <thead class="govuk-table__head">
+                    <tr class="govuk-table__row">
+                        <th scope="col" class="govuk-table__header">Name</th>
+                        <th scope="col" class="govuk-table__header">Email</th>
+                        <th scope="col" class="govuk-table__header"></th>
+                    </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                    @foreach (var user in Model.Open!)
+                    {
+                        <tr class="govuk-table__row" data-testid="user-@user.UserId">
+                            <td class="govuk-table__cell"><a asp-page="EditUser" asp-route-userId="@user.UserId">@user.Name</a></td>
+                            <td class="govuk-table__cell">@user.EmailAddress</td>
+                            <td class="govuk-table__cell"><a asp-page="AssignTrn/Trn" asp-route-userId="@user.UserId">Add a DQT record</a></td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        }
+    </govuk-tabs-item>
+    <govuk-tabs-item label="Closed" id="closed-tab" is-open="@true">
+        <p class="govuk-heading-s ">These records have been checked against the DQT.</p>
+
+        <p>Showing @Model.Closed!.Length of @Model.ClosedTotal total</p>
+
+        @if (Model.TotalPages > 1)
+        {
+            <govuk-pagination>
+                @if (Model.PreviousPage.HasValue)
+                {
+                    <govuk-pagination-previous asp-page="Users" asp-route-pageNumber="@Model.PreviousPage" asp-fragment="closed-tab" />
+                }
+
+                @for (int i = 0; i < Model.PaginationPages!.Length; i++)
+                {
+                    var item = Model.PaginationPages[i];
+
+                    if (i > 0 && Model.PaginationPages[i - 1] != item - 1)
+                    {
+                        <govuk-pagination-ellipsis />
+                    }
+
+                    <govuk-pagination-item asp-page="Users" asp-route-pageNumber="@item" is-current="@(item == Model.PageNumber)" asp-fragment="closed-tab">@item</govuk-pagination-item>
+                }
+
+                @if (Model.NextPage.HasValue)
+                {
+                    <govuk-pagination-next asp-page="Users" asp-route-pageNumber="@Model.NextPage" asp-fragment="closed-tab" />
+                }
+            </govuk-pagination>
+        }
+
+        @if (Model.Closed.Length > 0)
+        {
+            <table class="govuk-table">
+                <thead class="govuk-table__head">
+                    <tr class="govuk-table__row">
+                        <th scope="col" class="govuk-table__header">Name</th>
+                        <th scope="col" class="govuk-table__header">Email</th>
+                        <th scope="col" class="govuk-table__header">Status</th>
+                        <th scope="col" class="govuk-table__header">TRN</th>
+                    </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                    @foreach (var user in Model.Closed!)
+                    {
+                        <tr class="govuk-table__row" data-testid="user-@user.UserId">
+                            <td class="govuk-table__cell"><a asp-page="User" asp-route-userId="@user.UserId">@user.Name</a></td>
+                            <td class="govuk-table__cell">@user.EmailAddress</td>
+                            <td class="govuk-table__cell">@user.TrnLookupStatus</td>
+                            <td class="govuk-table__cell">@(user.Trn ?? "N/A")</td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        }
+
+        @if (Model.PreviousPage.HasValue || Model.NextPage.HasValue)
+        {
+            <govuk-pagination>
+                @if (Model.PreviousPage.HasValue)
+                {
+                    <govuk-pagination-previous asp-page="Users" asp-route-pageNumber="@Model.PreviousPage" asp-fragment="closed-tab" />
+                }
+
+                @if (Model.NextPage.HasValue)
+                {
+                    <govuk-pagination-next asp-page="Users" asp-route-pageNumber="@Model.NextPage" asp-fragment="closed-tab" />
+                }
+            </govuk-pagination>
+        }
+    </govuk-tabs-item>
+</govuk-tabs>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Users.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Users.cshtml.cs
@@ -1,0 +1,106 @@
+using System.Linq.Expressions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Infrastructure.Security;
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.Pages.Admin;
+
+[Authorize(AuthorizationPolicies.GetAnIdentitySupport)]
+public class UsersModel : PageModel
+{
+    private readonly TeacherIdentityServerDbContext _dbContext;
+
+    public UsersModel(TeacherIdentityServerDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public UserInfo[]? Open { get; set; }
+
+    public UserInfo[]? Closed { get; set; }
+
+    public int ClosedTotal { get; set; }
+
+    public int OpenTotal { get; set; }
+
+    [FromQuery(Name = "pageNumber")]
+    public int? PageNumber { get; set; }
+
+    public int[]? PaginationPages { get; set; }
+
+    public int TotalPages { get; set; }
+
+    public int? PreviousPage { get; set; }
+
+    public int? NextPage { get; set; }
+
+    public async Task<IActionResult> OnGet()
+    {
+        if (PageNumber < 1)
+        {
+            return BadRequest();
+        }
+
+        PageNumber ??= 1;
+        var pageSize = 100;
+
+        Expression<Func<User, bool>> openPredicate = user => user.UserType == UserType.Default && user.TrnLookupStatus == TrnLookupStatus.Pending;
+        Expression<Func<User, bool>> closedPredicate = user => user.UserType == UserType.Default && user.TrnLookupStatus != TrnLookupStatus.Pending;
+
+        Expression<Func<User, UserInfo>> mapUserInfo = user => new UserInfo()
+        {
+            UserId = user.UserId,
+            EmailAddress = user.EmailAddress,
+            Name = user.FirstName + " " + user.LastName,
+            Trn = user.Trn,
+            TrnLookupStatus = user.TrnLookupStatus
+        };
+
+        var sortedUsers = _dbContext.Users.OrderBy(u => u.LastName).ThenBy(u => u.FirstName);
+
+        Open = await sortedUsers.Where(openPredicate).Select(mapUserInfo).ToArrayAsync();
+        OpenTotal = Open.Length;
+
+        Closed = await sortedUsers.Where(closedPredicate)
+            .Skip((PageNumber.Value - 1) * pageSize)
+            .Take(pageSize)
+            .Select(mapUserInfo)
+            .ToArrayAsync();
+
+        if (PageNumber > 1 && Closed.Length == 0)
+        {
+            // Page is out of range
+            return BadRequest();
+        }
+
+        ClosedTotal = await sortedUsers.Where(closedPredicate).CountAsync();
+
+        TotalPages = (int)Math.Ceiling((decimal)ClosedTotal / pageSize);
+
+        // In the pagination control, show the first page, last page, current page and two pages either side of the current page
+        PaginationPages = Enumerable.Range(-2, 5).Select(offset => PageNumber.Value + offset)
+            .Append(1)
+            .Append(TotalPages)
+            .Where(page => page <= TotalPages && page >= 1)
+            .Distinct()
+            .Order()
+            .ToArray();
+
+        PreviousPage = PageNumber > 1 ? PageNumber - 1 : null;
+        NextPage = PageNumber < TotalPages ? PageNumber + 1 : null;
+
+        return Page();
+    }
+
+    public record UserInfo
+    {
+        public required Guid UserId { get; init; }
+        public required string EmailAddress { get; init; }
+        public required string Name { get; init; }
+        public required string? Trn { get; init; }
+        public required TrnLookupStatus? TrnLookupStatus { get; init; }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/_Layout.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/_Layout.cshtml
@@ -9,6 +9,9 @@
     <nav aria-label="Menu" class="govuk-header__navigation ">
         <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide menu" hidden>Menu</button>
         <ul id="navigation" class="govuk-header__navigation-list">
+            <li class="govuk-header__navigation-item @(Context.Request.Path.StartsWithSegments("/admin/users") ? "govuk-header__navigation-item--active" : "")">
+                <a class="govuk-header__link" asp-page="Users">Users</a>
+            </li>
             @if (User.IsInRole(StaffRoles.GetAnIdentityAdmin))
             {
                 <li class="govuk-header__navigation-item @(Context.Request.Path.StartsWithSegments("/admin/clients") ? "govuk-header__navigation-item--active" : "")">

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/libman.json
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/libman.json
@@ -3,7 +3,7 @@
   "defaultProvider": "jsdelivr",
   "libraries": [
     {
-      "library": "govuk-frontend@4.1.0",
+      "library": "govuk-frontend@4.3.0",
       "destination": "wwwroot/lib/govuk-frontend/"
     }
   ]

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/UsersTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/UsersTests.cs
@@ -1,0 +1,64 @@
+using AngleSharp.Dom;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Admin;
+
+public class UsersTests : TestBase
+{
+    public UsersTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_UnauthenticatedUser_RedirectsToSignIn()
+    {
+        await UnauthenticatedUser_RedirectsToSignIn(HttpMethod.Get, "/admin/users/");
+    }
+
+    [Fact]
+    public async Task Get_AuthenticatedUserDoesNotHavePermission_ReturnsForbidden()
+    {
+        await AuthenticatedUserDoesNotHavePermission_ReturnsForbidden(HttpMethod.Get, "/admin/users");
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_ReturnsExpectedContent()
+    {
+        // Arrange
+        var userWithPendingTrnStatus = await TestData.CreateUser(trnLookupStatus: TrnLookupStatus.Pending);
+        var userWithNoneTrnStatus = await TestData.CreateUser(trnLookupStatus: TrnLookupStatus.None);
+        var userWithFoundTrnStatus = await TestData.CreateUser(trnLookupStatus: TrnLookupStatus.Found);
+        var userWithFailedTrnStatus = await TestData.CreateUser(trnLookupStatus: TrnLookupStatus.Failed);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/admin/users");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+
+        var openUsers = GetUserIdsFromTab(doc.GetElementById("open-tab")!);
+        var closedUsers = GetUserIdsFromTab(doc.GetElementById("closed-tab")!);
+
+        Assert.Contains(userWithPendingTrnStatus.UserId, openUsers);
+        Assert.DoesNotContain(userWithPendingTrnStatus.UserId, closedUsers);
+
+        Assert.Contains(userWithNoneTrnStatus.UserId, closedUsers);
+        Assert.DoesNotContain(userWithNoneTrnStatus.UserId, openUsers);
+
+        Assert.Contains(userWithFoundTrnStatus.UserId, closedUsers);
+        Assert.DoesNotContain(userWithFoundTrnStatus.UserId, openUsers);
+
+        Assert.Contains(userWithFailedTrnStatus.UserId, closedUsers);
+        Assert.DoesNotContain(userWithFailedTrnStatus.UserId, openUsers);
+
+        static Guid[] GetUserIdsFromTab(IElement tab) =>
+            tab.QuerySelectorAll("[data-testid^='user-']")
+                .Select(e => e.GetAttribute("data-testid")!["user-".Length..])
+                .Select(Guid.Parse)
+                .ToArray();
+    }
+}


### PR DESCRIPTION
### Context

We're porting the Identity Support function from Find into ID itself. This page is the User list, modified to better show which users need TRN resolving manually.

### Changes proposed in this pull request

Adds a `/admin/users` page with a list of users grouped by whether they need a manual TRN lookup or not.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
