### PR TITLE
Add Support UI for changing a user's name

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Validators/UpdateUserRequestValidator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Validators/UpdateUserRequestValidator.cs
@@ -18,14 +18,14 @@ public class UpdateUserRequestValidator : AbstractValidator<UpdateUserRequest>
 
         RuleFor(r => r.Body.FirstName)
             .Cascade(CascadeMode.Stop)
-            .MaximumLength(User.FirstNameAddressMaxLength)
-                .WithMessage($"First name must be {User.FirstNameAddressMaxLength} characters or less.")
+            .MaximumLength(User.FirstNameMaxLength)
+                .WithMessage($"First name must be {User.FirstNameMaxLength} characters or less.")
             .When(r => r.Body.FirstNameSet);
 
         RuleFor(r => r.Body.LastName)
             .Cascade(CascadeMode.Stop)
-            .MaximumLength(User.LastNameAddressMaxLength)
-                .WithMessage($"Last name must be {User.LastNameAddressMaxLength} characters or less.")
+            .MaximumLength(User.LastNameMaxLength)
+                .WithMessage($"Last name must be {User.LastNameMaxLength} characters or less.")
             .When(r => r.Body.LastNameSet);
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/Mappings/UserMapping.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/Mappings/UserMapping.cs
@@ -12,8 +12,8 @@ public class UserMapping : IEntityTypeConfiguration<User>
         builder.Property(u => u.EmailAddress).HasMaxLength(User.EmailAddressMaxLength).IsRequired().UseCollation("case_insensitive");
         builder.HasIndex(u => u.EmailAddress).IsUnique().HasDatabaseName(User.EmailAddressUniqueIndexName).HasFilter("is_deleted = false");
         builder.HasIndex(u => u.Trn).IsUnique().HasFilter("is_deleted = false and trn is not null");
-        builder.Property(u => u.FirstName).HasMaxLength(User.FirstNameAddressMaxLength).IsRequired();
-        builder.Property(u => u.LastName).HasMaxLength(User.LastNameAddressMaxLength).IsRequired();
+        builder.Property(u => u.FirstName).HasMaxLength(User.FirstNameMaxLength).IsRequired();
+        builder.Property(u => u.LastName).HasMaxLength(User.LastNameMaxLength).IsRequired();
         builder.Property(u => u.DateOfBirth).HasDefaultValueSql("NULL");
         builder.Property(u => u.Created).IsRequired();
         builder.Property(u => u.CompletedTrnLookup);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/User.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/User.cs
@@ -3,8 +3,8 @@ namespace TeacherIdentity.AuthServer.Models;
 public class User
 {
     public const int EmailAddressMaxLength = 200;
-    public const int FirstNameAddressMaxLength = 200;
-    public const int LastNameAddressMaxLength = 200;
+    public const int FirstNameMaxLength = 200;
+    public const int LastNameMaxLength = 200;
 
     public const string EmailAddressUniqueIndexName = "ix_users_email_address";
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Confirm.cshtml.cs
@@ -59,7 +59,7 @@ public class ConfirmModel : PageModel
 
         if (AddRecord == false)
         {
-            return RedirectToPage("/Admin/EditUser", new { UserId });
+            return RedirectToPage("/Admin/User", new { UserId });
         }
 
         var user = await _dbContext.Users.SingleAsync(u => u.UserId == UserId);
@@ -83,7 +83,7 @@ public class ConfirmModel : PageModel
         await _dbContext.SaveChangesAsync();
 
         TempData[TempDataKeys.FlashSuccess] = "DQT record added";
-        return RedirectToPage("/Admin/EditUser", new { UserId });
+        return RedirectToPage("/Admin/User", new { UserId });
     }
 
     public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Trn.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Trn.cshtml
@@ -5,7 +5,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link asp-page="EditUser" asp-route-userId="@Model.UserId" />
+    <govuk-back-link asp-page="User" asp-route-userId="@Model.UserId" />
 }
 
 <div class="govuk-grid-row">

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditStaffUser.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditStaffUser.cshtml.cs
@@ -29,17 +29,17 @@ public class EditStaffUserModel : PageModel
     [Display(Name = "Email address")]
     [Required(ErrorMessage = "Enter the user’s email address")]
     [EmailAddress(ErrorMessage = "Enter a valid email address")]
-    [MaxLength(200, ErrorMessage = "Email address must be 200 characters or less")]
+    [MaxLength(Models.User.EmailAddressMaxLength, ErrorMessage = "Email address must be 200 characters or less")]
     public string? Email { get; set; }
 
     [Display(Name = "First name")]
     [Required(ErrorMessage = "Enter the user’s first name")]
-    [MaxLength(200, ErrorMessage = "First name must be 200 characters or less")]
+    [MaxLength(Models.User.FirstNameMaxLength, ErrorMessage = "First name must be 200 characters or less")]
     public string? FirstName { get; set; }
 
     [Display(Name = "Last name")]
     [Required(ErrorMessage = "Enter the user’s last name")]
-    [MaxLength(200, ErrorMessage = "Last name must be 200 characters or less")]
+    [MaxLength(Models.User.LastNameMaxLength, ErrorMessage = "Last name must be 200 characters or less")]
     public string? LastName { get; set; }
 
     [Display(Name = "Roles")]

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditUserName.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditUserName.cshtml
@@ -1,0 +1,45 @@
+@page "/admin/users/{userId}/name"
+@model TeacherIdentity.AuthServer.Pages.Admin.EditUserNameModel
+@{
+    ViewBag.Title = "Change their preferred name";
+}
+
+@section BeforeContent {
+    <govuk-back-link asp-page="User" asp-route-userId="@Model.UserId" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <form asp-page="EditUserName" asp-route-userId="@Model.UserId">
+            <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
+
+            <p>Changes to a preferred name will not update DQT.</p>
+
+            <h2 class="govuk-heading-m">Current names</h2>
+
+            <section class="x-govuk-summary-card govuk-!-margin-bottom-6 ">
+                <div class="x-govuk-summary-card__body">
+                    <govuk-summary-list>
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>Preferred name</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value>@Model.CurrentName</govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                    </govuk-summary-list>
+                </div>
+            </section>
+
+
+            <h2 class="govuk-heading-m">New preferred name</h2>
+
+            <govuk-input asp-for="NewFirstName">
+                <govuk-input-label class="govuk-label--s" />
+            </govuk-input>
+
+            <govuk-input asp-for="NewLastName">
+                <govuk-input-label class="govuk-label--s" />
+            </govuk-input>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditUserName.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditUserName.cshtml.cs
@@ -1,0 +1,95 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Infrastructure.Security;
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.Pages.Admin;
+
+[Authorize(AuthorizationPolicies.GetAnIdentitySupport)]
+public class EditUserNameModel : PageModel
+{
+    private readonly TeacherIdentityServerDbContext _dbContext;
+    private readonly IClock _clock;
+
+    public EditUserNameModel(TeacherIdentityServerDbContext dbContext, IClock clock)
+    {
+        _dbContext = dbContext;
+        _clock = clock;
+    }
+
+    [FromRoute]
+    public Guid UserId { get; set; }
+
+    public string? CurrentName { get; set; }
+
+    [BindProperty]
+    [Display(Name = "First name")]
+    [Required(ErrorMessage = "Enter a first name")]
+    [MaxLength(Models.User.FirstNameMaxLength, ErrorMessage = "First name must be 200 characters or less")]
+    public string? NewFirstName { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Last name")]
+    [Required(ErrorMessage = "Enter a last name")]
+    [MaxLength(Models.User.LastNameMaxLength, ErrorMessage = "Last name must be 200 characters or less")]
+    public string? NewLastName { get; set; }
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        var user = await _dbContext.Users.Where(u => u.UserType == UserType.Default && u.UserId == UserId).SingleAsync();
+
+        var changes = UserUpdatedEventChanges.None |
+            (user.FirstName != NewFirstName ? UserUpdatedEventChanges.FirstName : UserUpdatedEventChanges.None) |
+            (user.LastName != NewLastName ? UserUpdatedEventChanges.LastName : UserUpdatedEventChanges.None);
+
+        user.FirstName = NewFirstName!;
+        user.LastName = NewLastName!;
+
+        if (changes != UserUpdatedEventChanges.None)
+        {
+            _dbContext.AddEvent(new UserUpdatedEvent()
+            {
+                Source = UserUpdatedEventSource.SupportUi,
+                UpdatedByUserId = User.GetUserId()!.Value,
+                CreatedUtc = _clock.UtcNow,
+                User = Events.User.FromModel(user),
+                Changes = changes
+            });
+
+            await _dbContext.SaveChangesAsync();
+
+            TempData.SetFlashSuccess("Name changed successfully");
+        }
+
+        return RedirectToPage("User", new { UserId });
+    }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        var user = await _dbContext.Users.Where(u => u.UserType == UserType.Default && u.UserId == UserId).SingleOrDefaultAsync();
+
+        if (user is null)
+        {
+            context.Result = NotFound();
+            return;
+        }
+
+        CurrentName = $"{user.FirstName} {user.LastName}";
+
+        await next();
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/User.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/User.cshtml
@@ -36,7 +36,7 @@
                     </span>
                 </govuk-summary-list-row-value>
                 <govuk-summary-list-row-actions>
-                    <govuk-summary-list-row-action href="#" visually-hidden-text="name">Change</govuk-summary-list-row-action>
+                    <govuk-summary-list-row-action asp-page="EditUserName" asp-route-userId="@Model.UserId" visually-hidden-text="name">Change</govuk-summary-list-row-action>
                 </govuk-summary-list-row-actions>
             </govuk-summary-list-row>
             <govuk-summary-list-row>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/User.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/User.cshtml
@@ -1,5 +1,5 @@
 @page "/admin/users/{userId}"
-@model TeacherIdentity.AuthServer.Pages.Admin.EditUserModel
+@model TeacherIdentity.AuthServer.Pages.Admin.UserModel
 @{
     ViewBag.Title = Model.Name;
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/User.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/User.cshtml.cs
@@ -9,12 +9,12 @@ using TeacherIdentity.AuthServer.Services.DqtApi;
 namespace TeacherIdentity.AuthServer.Pages.Admin;
 
 [Authorize(AuthorizationPolicies.GetAnIdentitySupport)]
-public class EditUserModel : PageModel
+public class UserModel : PageModel
 {
     private readonly TeacherIdentityServerDbContext _dbContext;
     private readonly IDqtApiClient _dqtApiClient;
 
-    public EditUserModel(TeacherIdentityServerDbContext dbContext, IDqtApiClient dqtApiClient)
+    public UserModel(TeacherIdentityServerDbContext dbContext, IDqtApiClient dqtApiClient)
     {
         _dbContext = dbContext;
         _dqtApiClient = dqtApiClient;

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/EditUserNameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/EditUserNameTests.cs
@@ -1,0 +1,211 @@
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Events;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Admin;
+
+public class EditUserNameTests : TestBase
+{
+    public EditUserNameTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_UnauthenticatedUser_RedirectsToSignIn()
+    {
+        var user = await TestData.CreateUser(userType: Models.UserType.Default);
+
+        await UnauthenticatedUser_RedirectsToSignIn(HttpMethod.Get, $"/admin/users/{user.UserId}/name");
+    }
+
+    [Fact]
+    public async Task Get_AuthenticatedUserDoesNotHavePermission_ReturnsForbidden()
+    {
+        var user = await TestData.CreateUser(userType: Models.UserType.Default);
+
+        await AuthenticatedUserDoesNotHavePermission_ReturnsForbidden(HttpMethod.Get, $"/admin/users/{user.UserId}/name");
+    }
+
+    [Fact]
+    public async Task Get_UserDoesNotExist_ReturnsNotFound()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/users/{userId}/name");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_UserIsNotDefaultType_ReturnsNotFound()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: Models.UserType.Staff);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/users/{user.UserId}/name");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_RendersExpectedContent()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: Models.UserType.Default);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/users/{user.UserId}/name");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+        Assert.Equal($"{user.FirstName} {user.LastName}", doc.GetSummaryListValueForKey("Preferred name"));
+    }
+
+    [Fact]
+    public async Task Post_UnauthenticatedUser_RedirectsToSignIn()
+    {
+        var user = await TestData.CreateUser(userType: Models.UserType.Default);
+
+        await UnauthenticatedUser_RedirectsToSignIn(HttpMethod.Post, $"/admin/users/{user.UserId}/name");
+    }
+
+    [Fact]
+    public async Task Post_AuthenticatedUserDoesNotHavePermission_ReturnsForbidden()
+    {
+        var user = await TestData.CreateUser(userType: Models.UserType.Default);
+
+        await AuthenticatedUserDoesNotHavePermission_ReturnsForbidden(HttpMethod.Post, $"/admin/users/{user.UserId}/name");
+    }
+
+    [Fact]
+    public async Task Post_UserDoesNotExist_ReturnsNotFound()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{userId}/name");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_UserIsNotDefaultType_ReturnsNotFound()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: Models.UserType.Staff);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{user.UserId}/name");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidNamesData))]
+    public async Task Post_InvalidName_RendersError(
+        string newFirstName,
+        string newLastName,
+        string expectedErrorField,
+        string expectedErrorMessage)
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: Models.UserType.Default);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{user.UserId}/name")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "NewFirstName", newFirstName },
+                { "NewLastName", newLastName },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, expectedErrorField, expectedErrorMessage);
+    }
+
+    [Theory]
+    [InlineData(false, false, false, UserUpdatedEventChanges.None)]
+    [InlineData(true, false, true, UserUpdatedEventChanges.FirstName)]
+    [InlineData(false, true, true, UserUpdatedEventChanges.LastName)]
+    [InlineData(true, true, true, UserUpdatedEventChanges.FirstName | UserUpdatedEventChanges.LastName)]
+    public async Task Post_ValidRequest_SetsUserNameEmitsEventAndRedirects(
+        bool changeFirstName,
+        bool changeLastName,
+        bool expectEvent,
+        UserUpdatedEventChanges expectedChanges)
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: Models.UserType.Default);
+
+        var newFirstName = changeFirstName ? Faker.Name.First() : user.FirstName;
+        var newLastName = changeLastName ? Faker.Name.Last() : user.LastName;
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{user.UserId}/name")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "NewFirstName", newFirstName },
+                { "NewLastName", newLastName },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/admin/users/{user.UserId}", response.Headers.Location?.OriginalString);
+
+        await TestData.WithDbContext(async dbContext =>
+        {
+            user = await dbContext.Users.SingleAsync(u => u.UserId == user.UserId);
+            Assert.Equal(newFirstName, user.FirstName);
+            Assert.Equal(newLastName, user.LastName);
+        });
+
+        if (expectEvent)
+        {
+            EventObserver.AssertEventsSaved(
+                e =>
+                {
+                    var userUpdatedEvent = Assert.IsType<UserUpdatedEvent>(e);
+                    Assert.Equal(Clock.UtcNow, userUpdatedEvent.CreatedUtc);
+                    Assert.Equal(UserUpdatedEventSource.SupportUi, userUpdatedEvent.Source);
+                    Assert.Equal(expectedChanges, userUpdatedEvent.Changes);
+                    Assert.Equal(user.UserId, userUpdatedEvent.User.UserId);
+                    Assert.Equal(TestUsers.AdminUserWithAllRoles.UserId, userUpdatedEvent.UpdatedByUserId);
+                });
+        }
+        else
+        {
+            EventObserver.AssertEventsSaved();
+        }
+    }
+
+    public static TheoryData<string, string, string, string> InvalidNamesData { get; } = new()
+    {
+        { "", "Bloggs", "NewFirstName", "Enter a first name" },
+        { "Joe", "", "NewLastName", "Enter a last name" },
+        { new string('x', 201), "Bloggs", "NewFirstName", "First name must be 200 characters or less" },
+        { "Joe", new string('x', 201), "NewLastName", "Last name must be 200 characters or less" },
+    };
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/UserTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/UserTests.cs
@@ -1,9 +1,9 @@
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Admin;
 
 [Collection(nameof(DisableParallelization))]  // Relies on mocks
-public class EditUserTests : TestBase
+public class UserTests : TestBase
 {
-    public EditUserTests(HostFixture hostFixture)
+    public UserTests(HostFixture hostFixture)
         : base(hostFixture)
     {
     }


### PR DESCRIPTION
### Context

We're migrating the Support UI from Find into ID. This is the UI for changing a user's name.

### Changes proposed in this pull request

Add `/admin/users/{userId}/name` for changing a user's name.
### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
