### PR TITLE
Add Support UI for changing a user's email address

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditUserEmail.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditUserEmail.cshtml
@@ -1,0 +1,21 @@
+@page "/admin/users/{userId}/email"
+@model TeacherIdentity.AuthServer.Pages.Admin.EditUserEmailModel
+@{
+    ViewBag.Title = Html.DisplayNameFor(m => m.Email);
+}
+
+@section BeforeContent {
+    <govuk-back-link asp-page="User" asp-route-userId="@Model.UserId" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <form asp-page="EditUserEmail" asp-route-userId="@Model.UserId">
+            <govuk-input asp-for="Email" type="email" autocomplete="off">
+                <govuk-input-label class="govuk-label--xl" />
+            </govuk-input>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditUserEmail.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditUserEmail.cshtml.cs
@@ -1,0 +1,90 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Infrastructure.Security;
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.Pages.Admin;
+
+[Authorize(AuthorizationPolicies.GetAnIdentitySupport)]
+public class EditUserEmailModel : PageModel
+{
+    private readonly TeacherIdentityServerDbContext _dbContext;
+    private readonly IClock _clock;
+
+    public EditUserEmailModel(TeacherIdentityServerDbContext dbContext, IClock clock)
+    {
+        _dbContext = dbContext;
+        _clock = clock;
+    }
+
+    [FromRoute]
+    public Guid UserId { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Change email address")]
+    [Required(ErrorMessage = "Enter an email address")]
+    [EmailAddress(ErrorMessage = "Enter a valid email address")]
+    public string? Email { get; set; }
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        var user = await _dbContext.Users.Where(u => u.UserType == UserType.Default && u.UserId == UserId).SingleAsync();
+
+        var changes = user.EmailAddress != Email ? UserUpdatedEventChanges.EmailAddress : UserUpdatedEventChanges.None;
+
+        user.EmailAddress = Email!;
+
+        if (changes != UserUpdatedEventChanges.None)
+        {
+            _dbContext.AddEvent(new UserUpdatedEvent()
+            {
+                Source = UserUpdatedEventSource.SupportUi,
+                UpdatedByUserId = User.GetUserId()!.Value,
+                CreatedUtc = _clock.UtcNow,
+                User = Events.User.FromModel(user),
+                Changes = changes
+            });
+
+            try
+            {
+                await _dbContext.SaveChangesAsync();
+            }
+            catch (DbUpdateException ex) when (ex.IsUniqueIndexViolation("ix_users_email_address"))
+            {
+                ModelState.AddModelError(nameof(Email), "This email address is already in use - Enter a different email address");
+                return this.PageWithErrors();
+            }
+
+            TempData.SetFlashSuccess("Email changed successfully");
+        }
+
+        return RedirectToPage("User", new { UserId });
+    }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        var user = await _dbContext.Users.Where(u => u.UserType == UserType.Default && u.UserId == UserId).SingleOrDefaultAsync();
+
+        if (user is null)
+        {
+            context.Result = NotFound();
+            return;
+        }
+
+        await next();
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/User.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/User.cshtml
@@ -43,7 +43,7 @@
                 <govuk-summary-list-row-key>Email address</govuk-summary-list-row-key>
                 <govuk-summary-list-row-value>@Model.EmailAddress</govuk-summary-list-row-value>
                 <govuk-summary-list-row-actions>
-                    <govuk-summary-list-row-action href="#" visually-hidden-text="email address">Change</govuk-summary-list-row-action>
+                    <govuk-summary-list-row-action asp-page="EditUserEmail" asp-route-userId="@Model.UserId" visually-hidden-text="email address">Change</govuk-summary-list-row-action>
                 </govuk-summary-list-row-actions>
             </govuk-summary-list-row>
             <govuk-summary-list-row>

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/EditUserEmailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/EditUserEmailTests.cs
@@ -1,0 +1,217 @@
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Events;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Admin;
+
+public class EditUserEmailTests : TestBase
+{
+    public EditUserEmailTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_UnauthenticatedUser_RedirectsToSignIn()
+    {
+        var user = await TestData.CreateUser(userType: Models.UserType.Default);
+
+        await UnauthenticatedUser_RedirectsToSignIn(HttpMethod.Get, $"/admin/users/{user.UserId}/email");
+    }
+
+    [Fact]
+    public async Task Get_AuthenticatedUserDoesNotHavePermission_ReturnsForbidden()
+    {
+        var user = await TestData.CreateUser(userType: Models.UserType.Default);
+
+        await AuthenticatedUserDoesNotHavePermission_ReturnsForbidden(HttpMethod.Get, $"/admin/users/{user.UserId}/email");
+    }
+
+    [Fact]
+    public async Task Get_UserDoesNotExist_ReturnsNotFound()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/users/{userId}/email");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_UserIsNotDefaultType_ReturnsNotFound()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: Models.UserType.Staff);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/users/{user.UserId}/email");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_RendersExpectedContent()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: Models.UserType.Default);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/users/{user.UserId}/email");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_UnauthenticatedUser_RedirectsToSignIn()
+    {
+        var user = await TestData.CreateUser(userType: Models.UserType.Default);
+
+        await UnauthenticatedUser_RedirectsToSignIn(HttpMethod.Post, $"/admin/users/{user.UserId}/email");
+    }
+
+    [Fact]
+    public async Task Post_AuthenticatedUserDoesNotHavePermission_ReturnsForbidden()
+    {
+        var user = await TestData.CreateUser(userType: Models.UserType.Default);
+
+        await AuthenticatedUserDoesNotHavePermission_ReturnsForbidden(HttpMethod.Post, $"/admin/users/{user.UserId}/email");
+    }
+
+    [Fact]
+    public async Task Post_UserDoesNotExist_ReturnsNotFound()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{userId}/email");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_UserIsNotDefaultType_ReturnsNotFound()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: Models.UserType.Staff);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{user.UserId}/email");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidEmailData))]
+    public async Task Post_InvalidEmail_RendersError(string email, string expectedErrorMessage)
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: Models.UserType.Default);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{user.UserId}/email")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Email", email }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Email", expectedErrorMessage);
+    }
+
+    [Fact]
+    public async Task Post_EmailAlreadyInUse_RendersError()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: Models.UserType.Default);
+        var otherUser = await TestData.CreateUser();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{user.UserId}/email")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Email", otherUser.EmailAddress }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Email", "This email address is already in use - Enter a different email address");
+    }
+
+    [Theory]
+    [InlineData(false, false, UserUpdatedEventChanges.None)]
+    [InlineData(true, true, UserUpdatedEventChanges.EmailAddress)]
+    public async Task Post_ValidRequest_SetsUserNameEmitsEventAndRedirects(
+        bool changeEmail,
+        bool expectEvent,
+        UserUpdatedEventChanges expectedChanges)
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: Models.UserType.Default);
+
+        var newEmail = changeEmail ? Faker.Internet.Email() : user.EmailAddress;
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{user.UserId}/email")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Email", newEmail }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/admin/users/{user.UserId}", response.Headers.Location?.OriginalString);
+
+        await TestData.WithDbContext(async dbContext =>
+        {
+            user = await dbContext.Users.SingleAsync(u => u.UserId == user.UserId);
+            Assert.Equal(newEmail, user.EmailAddress);
+        });
+
+        if (expectEvent)
+        {
+            EventObserver.AssertEventsSaved(
+                e =>
+                {
+                    var userUpdatedEvent = Assert.IsType<UserUpdatedEvent>(e);
+                    Assert.Equal(Clock.UtcNow, userUpdatedEvent.CreatedUtc);
+                    Assert.Equal(UserUpdatedEventSource.SupportUi, userUpdatedEvent.Source);
+                    Assert.Equal(expectedChanges, userUpdatedEvent.Changes);
+                    Assert.Equal(user.UserId, userUpdatedEvent.User.UserId);
+                    Assert.Equal(TestUsers.AdminUserWithAllRoles.UserId, userUpdatedEvent.UpdatedByUserId);
+                });
+        }
+        else
+        {
+            EventObserver.AssertEventsSaved();
+        }
+    }
+
+    public static TheoryData<string, string> InvalidEmailData { get; } = new()
+    {
+        { "", "Enter an email address" },
+        { "xxx", "Enter a valid email address" },
+    };
+}


### PR DESCRIPTION
### Context

We're migrating the Support UI from Find into ID. This is the UI for changing a user's email.

### Changes proposed in this pull request

Add `/admin/users/{userId}/email` for changing a user's name.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
