### PR TITLE
Show the initial TRN bookend with new journey

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn.cshtml
@@ -12,7 +12,7 @@
     <govuk-panel-body>
         <vc:client-scoped-partial view-name="_TrnLookup.StartBookend.{0}.Content" />
 
-        <form action="@Model.HandoverUrl" method="post" asp-antiforgery="false">
+        <form action="@Model.HandoverUrl" method="@Model.HandoverMethod" asp-antiforgery="false">
             @foreach (var p in Model.HandoverParameters!)
             {
                 <input type="hidden" name="@(p.Key)" value="@(p.Value)" />

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnTests.cs
@@ -83,7 +83,7 @@ public class TrnTests : TestBase
     }
 
     [Fact]
-    public async Task Get_WhenUseNewTrnLookupJourneyTrue_RedirectsToTrnOfficialName()
+    public async Task Get_WhenUseNewTrnLookupJourneyTrue_SubmitsToTrnOfficialName()
     {
         // Arrange
         var trnConfig = HostFixture.Services.GetRequiredService<IOptions<FindALostTrnIntegrationOptions>>().Value;
@@ -97,7 +97,11 @@ public class TrnTests : TestBase
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith("/sign-in/trn/official-name", response.Headers.Location?.OriginalString);
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+        var form = doc.GetElementsByTagName("form").Single();
+        Assert.StartsWith("/sign-in/trn/official-name", form.GetAttribute("action"));
+        Assert.Equal("GET", form.GetAttribute("method"));
     }
 }


### PR DESCRIPTION
### Context

We added a config-based redirect to the initial TRN bookend page to develop the 'in house' TRN registration journey but we redirected a little too early.

### Changes proposed in this pull request

This changes the point of redirection to be the button press rather than page load on `/sign-in/trn`. For now it's done by switching the form from a GET to a POST. Once we've rolled this whole journey out and decoupled Find it can be replaced with a simple link.

### Checklist

~~-   [ ] Attach to Trello card~~
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
![localhost_7236_sign-in_trn_asid=733836d0-d559-450e-9536-6029c7fcd178](https://user-images.githubusercontent.com/2041280/214113193-73c8e8bd-c628-4103-95ce-f66a214fe4a9.png)
