### PR TITLE
Add identity check answers page for TRN lookup flow

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -468,6 +468,33 @@ public class AuthenticationState
         HaveResumedCompletedJourney = true;
     }
 
+    public string? GetOfficialName()
+    {
+        return GetFullName(OfficialFirstName, OfficialLastName);
+    }
+
+    public string? GetPreviousOfficialName()
+    {
+        if (string.IsNullOrEmpty(PreviousOfficialFirstName) && string.IsNullOrEmpty(PreviousOfficialLastName))
+        {
+            return null;
+        }
+
+        return GetFullName(PreviousOfficialFirstName ?? OfficialFirstName, PreviousOfficialLastName ?? OfficialLastName);
+    }
+
+    public string? GetPreferredName()
+    {
+        return GetFullName(FirstName, LastName);
+    }
+
+    private string? GetFullName(string? firstName, string? lastName)
+    {
+        return !string.IsNullOrEmpty(firstName) && !string.IsNullOrEmpty(lastName)
+            ? $"@{firstName} @{lastName}"
+            : null;
+    }
+
     public string Serialize() => JsonSerializer.Serialize(this, _jsonSerializerOptions);
 
     public async Task SignIn(HttpContext httpContext)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -491,7 +491,7 @@ public class AuthenticationState
     private string? GetFullName(string? firstName, string? lastName)
     {
         return !string.IsNullOrEmpty(firstName) && !string.IsNullOrEmpty(lastName)
-            ? $"@{firstName} @{lastName}"
+            ? $"{firstName} {lastName}"
             : null;
     }
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -84,10 +84,13 @@ public class AuthenticationState
     public string? TrnOwnerEmailAddress { get; private set; }
     [JsonInclude]
     public TrnLookupStatus? TrnLookupStatus { get; private set; }
-    public bool? HaveNationalInsuranceNumber { get; set; }
+    [JsonInclude]
+    public bool? HaveNationalInsuranceNumber { get; private set; }
     public string? NationalInsuranceNumber { get; set; }
-    public bool? AwardedQts { get; set; }
-    public bool? HaveIttProvider { get; set; }
+    [JsonInclude]
+    public bool? AwardedQts { get; private set; }
+    [JsonInclude]
+    public bool? HaveIttProvider { get; private set; }
     public string? IttProviderName { get; set; }
 
     /// <summary>
@@ -422,6 +425,37 @@ public class AuthenticationState
     public void OnDateOfBirthSet(DateOnly dateOfBirth)
     {
         DateOfBirth = dateOfBirth;
+    }
+
+    public void OnHaveNationalInsuranceNumberSet(bool haveNationalInsuranceNumber)
+    {
+        if (!haveNationalInsuranceNumber)
+        {
+            NationalInsuranceNumber = null;
+        }
+
+        HaveNationalInsuranceNumber = haveNationalInsuranceNumber;
+    }
+
+    public void OnHaveIttProviderSet(bool haveIttProvider)
+    {
+        if (!haveIttProvider)
+        {
+            IttProviderName = null;
+        }
+
+        HaveIttProvider = haveIttProvider;
+    }
+
+    public void OnAwardedQtsSet(bool awardedQts)
+    {
+        if (!awardedQts)
+        {
+            HaveIttProvider = null;
+            IttProviderName = null;
+        }
+
+        AwardedQts = awardedQts;
     }
 
     public void OnHaveResumedCompletedJourney()

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/AwardedQtsPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/AwardedQtsPage.cshtml.cs
@@ -25,6 +25,7 @@ public class AwardedQtsPage : PageModel
 
     public void OnGet()
     {
+        SetDefaultInputValues();
     }
 
     public IActionResult OnPost()
@@ -34,7 +35,7 @@ public class AwardedQtsPage : PageModel
             return this.PageWithErrors();
         }
 
-        HttpContext.GetAuthenticationState().AwardedQts = (bool)AwardedQts!;
+        HttpContext.GetAuthenticationState().OnAwardedQtsSet((bool)AwardedQts!);
 
         return (bool)AwardedQts!
             ? Redirect(_linkGenerator.TrnIttProvider())
@@ -53,5 +54,10 @@ public class AwardedQtsPage : PageModel
         {
             context.Result = new RedirectResult(authenticationState.GetNextHopUrl(_linkGenerator));
         }
+    }
+
+    private void SetDefaultInputValues()
+    {
+        AwardedQts ??= HttpContext.GetAuthenticationState().AwardedQts;
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/CheckAnswers.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/CheckAnswers.cshtml
@@ -1,0 +1,84 @@
+@page "/sign-in/trn/check-answers"
+@model TeacherIdentity.AuthServer.Pages.SignIn.Trn.CheckAnswers
+@{
+    ViewBag.Title = "Check your answers";
+}
+
+@section BeforeContent
+{
+    <govuk-back-link href="@Model.BackLink" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.TrnCheckAnswers()" method="post" asp-antiforgery="true">
+            <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
+
+            <govuk-summary-list>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Email address</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.EmailAddress</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.OfficialName</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.TrnOfficialName()">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                @if (!string.IsNullOrEmpty(Model.PreviousOfficialName))
+                {
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Previous name</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value>@Model.PreviousOfficialName</govuk-summary-list-row-value>
+                        <govuk-summary-list-row-actions>
+                            <govuk-summary-list-row-action href="@LinkGenerator.TrnOfficialName()">Change</govuk-summary-list-row-action>
+                        </govuk-summary-list-row-actions>
+                    </govuk-summary-list-row>
+                }
+                @if (!string.IsNullOrEmpty(Model.PreferredName))
+                {
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Preferred name</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value>@Model.PreferredName</govuk-summary-list-row-value>
+                        <govuk-summary-list-row-actions>
+                            <govuk-summary-list-row-action href="@LinkGenerator.TrnPreferredName()">Change</govuk-summary-list-row-action>
+                        </govuk-summary-list-row-actions>
+                    </govuk-summary-list-row>
+                }
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.DateOfBirth?.ToString("dd MMMM yyyy")</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.TrnDateOfBirth()">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>National Insurance number</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@(Model.NationalInsuranceNumber ?? "Not given")</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.TrnHaveNiNumber()">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Have you been awarded QTS?</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@(Model.AwardedQts == true ? "Yes" : "No")</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.TrnAwardedQts()">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                @if (Model.AwardedQts == true)
+                {
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Did a university, SCITT or school award your QTS?</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value>@(Model.IttProviderName ?? "No, I was awarded QTS another way")</govuk-summary-list-row-value>
+                        <govuk-summary-list-row-actions>
+                            <govuk-summary-list-row-action href="@LinkGenerator.TrnIttProvider()">Change</govuk-summary-list-row-action>
+                        </govuk-summary-list-row-actions>
+                    </govuk-summary-list-row>
+                }
+            </govuk-summary-list>
+        </form>
+    </div>
+</div>
+

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/CheckAnswers.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/CheckAnswers.cshtml.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/CheckAnswers.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/CheckAnswers.cshtml.cs
@@ -1,0 +1,61 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn.Trn;
+
+[BindProperties]
+public class CheckAnswers : PageModel
+{
+    private IIdentityLinkGenerator _linkGenerator;
+
+    public CheckAnswers(IIdentityLinkGenerator linkGenerator)
+    {
+        _linkGenerator = linkGenerator;
+    }
+
+    public string? BackLink => (HttpContext.GetAuthenticationState().HaveIttProvider == true)
+        ? _linkGenerator.TrnIttProvider()
+        : _linkGenerator.TrnAwardedQts();
+    public string? EmailAddress => HttpContext.GetAuthenticationState().EmailAddress;
+    public string? OfficialName => GetFullName(HttpContext.GetAuthenticationState().OfficialFirstName, HttpContext.GetAuthenticationState().OfficialLastName);
+    public string? PreviousOfficialName => GetFullName(HttpContext.GetAuthenticationState().PreviousOfficialFirstName, HttpContext.GetAuthenticationState().PreviousOfficialLastName);
+    public string? PreferredName => GetFullName(HttpContext.GetAuthenticationState().FirstName, HttpContext.GetAuthenticationState().LastName);
+    public DateOnly? DateOfBirth => HttpContext.GetAuthenticationState().DateOfBirth;
+    public string? NationalInsuranceNumber => HttpContext.GetAuthenticationState().NationalInsuranceNumber;
+    public bool? AwardedQts => HttpContext.GetAuthenticationState().AwardedQts;
+    public string? IttProviderName => HttpContext.GetAuthenticationState().IttProviderName;
+
+
+    public void OnGet()
+    {
+    }
+
+    public void OnPost()
+    {
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var authenticationState = context.HttpContext.GetAuthenticationState();
+
+        // We expect to have a verified email and official names at this point but we shouldn't have completed the TRN lookup
+        if (string.IsNullOrEmpty(authenticationState.EmailAddress) ||
+            !authenticationState.EmailAddressVerified ||
+            !authenticationState.HasOfficialName() ||
+            authenticationState.HaveCompletedTrnLookup)
+        {
+            context.Result = new RedirectResult(authenticationState.GetNextHopUrl(_linkGenerator));
+        }
+    }
+
+    private string? GetFullName(string? firstName, string? lastName)
+    {
+        if (!string.IsNullOrEmpty(firstName) && !string.IsNullOrEmpty(lastName))
+        {
+            return $"{firstName} {lastName}";
+        }
+        return firstName ?? (lastName ?? null);
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/CheckAnswers.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/CheckAnswers.cshtml.cs
@@ -18,9 +18,9 @@ public class CheckAnswers : PageModel
         ? _linkGenerator.TrnIttProvider()
         : _linkGenerator.TrnAwardedQts();
     public string? EmailAddress => HttpContext.GetAuthenticationState().EmailAddress;
-    public string? OfficialName => GetFullName(HttpContext.GetAuthenticationState().OfficialFirstName, HttpContext.GetAuthenticationState().OfficialLastName);
-    public string? PreviousOfficialName => GetFullName(HttpContext.GetAuthenticationState().PreviousOfficialFirstName, HttpContext.GetAuthenticationState().PreviousOfficialLastName);
-    public string? PreferredName => GetFullName(HttpContext.GetAuthenticationState().FirstName, HttpContext.GetAuthenticationState().LastName);
+    public string? OfficialName => HttpContext.GetAuthenticationState().GetOfficialName();
+    public string? PreviousOfficialName => HttpContext.GetAuthenticationState().GetPreviousOfficialName();
+    public string? PreferredName => HttpContext.GetAuthenticationState().GetPreferredName();
     public DateOnly? DateOfBirth => HttpContext.GetAuthenticationState().DateOfBirth;
     public string? NationalInsuranceNumber => HttpContext.GetAuthenticationState().NationalInsuranceNumber;
     public bool? AwardedQts => HttpContext.GetAuthenticationState().AwardedQts;
@@ -47,14 +47,5 @@ public class CheckAnswers : PageModel
         {
             context.Result = new RedirectResult(authenticationState.GetNextHopUrl(_linkGenerator));
         }
-    }
-
-    private string? GetFullName(string? firstName, string? lastName)
-    {
-        if (!string.IsNullOrEmpty(firstName) && !string.IsNullOrEmpty(lastName))
-        {
-            return $"{firstName} {lastName}";
-        }
-        return firstName ?? (lastName ?? null);
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/DateOfBirthPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/DateOfBirthPage.cshtml.cs
@@ -22,6 +22,7 @@ public class DateOfBirthPage : PageModel
 
     public void OnGet()
     {
+        SetDefaultInputValues();
     }
 
     public IActionResult OnPost()
@@ -48,5 +49,10 @@ public class DateOfBirthPage : PageModel
         {
             context.Result = new RedirectResult(authenticationState.GetNextHopUrl(_linkGenerator));
         }
+    }
+
+    private void SetDefaultInputValues()
+    {
+        DateOfBirth ??= HttpContext.GetAuthenticationState().DateOfBirth;
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/HaveNiNumber.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/HaveNiNumber.cshtml.cs
@@ -21,6 +21,7 @@ public class HaveNiNumber : PageModel
 
     public void OnGet()
     {
+        SetDefaultInputValues();
     }
 
     public IActionResult OnPost()
@@ -30,7 +31,7 @@ public class HaveNiNumber : PageModel
             return this.PageWithErrors();
         }
 
-        HttpContext.GetAuthenticationState().HaveNationalInsuranceNumber = (bool)HasNiNumber!;
+        HttpContext.GetAuthenticationState().OnHaveNationalInsuranceNumberSet((bool)HasNiNumber!);
 
         return (bool)HasNiNumber!
             ? Redirect(_linkGenerator.TrnNiNumber())
@@ -49,5 +50,10 @@ public class HaveNiNumber : PageModel
         {
             context.Result = new RedirectResult(authenticationState.GetNextHopUrl(_linkGenerator));
         }
+    }
+
+    private void SetDefaultInputValues()
+    {
+        HasNiNumber ??= HttpContext.GetAuthenticationState().HaveNationalInsuranceNumber;
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/IttProvider.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/IttProvider.cshtml
@@ -17,12 +17,14 @@
         window.onload = function () {
             const inputName = '@nameof(Model.IttProviderName)';
             const select = document.querySelector(`select[name=${inputName}`);
+            const value = select.value;
             const container = select.parentElement;
 
             accessibleAutocomplete({
                 element: container,
                 id: inputName,
-                source: @Html.Raw(Json.Serialize(Model.IttProviderNames))
+                source: @Html.Raw(Json.Serialize(Model.IttProviderNames)),
+                defaultValue: value
             })
 
             container.removeChild(select);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/IttProvider.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/IttProvider.cshtml.cs
@@ -38,6 +38,7 @@ public class IttProvider : PageModel
 
     public void OnGet()
     {
+        SetDefaultInputValues();
     }
 
     public IActionResult OnPost()
@@ -47,7 +48,7 @@ public class IttProvider : PageModel
             return this.PageWithErrors();
         }
 
-        HttpContext.GetAuthenticationState().HaveIttProvider = HasIttProvider;
+        HttpContext.GetAuthenticationState().OnHaveIttProviderSet((bool)HasIttProvider!);
 
         if (HasIttProvider == true)
         {
@@ -79,5 +80,11 @@ public class IttProvider : PageModel
         }
 
         await next();
+    }
+
+    private void SetDefaultInputValues()
+    {
+        HasIttProvider ??= HttpContext.GetAuthenticationState().HaveIttProvider;
+        IttProviderName ??= HttpContext.GetAuthenticationState().IttProviderName;
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/NiNumberPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/NiNumberPage.cshtml.cs
@@ -22,13 +22,14 @@ public class NiNumberPage : PageModel
 
     public void OnGet()
     {
+        SetDefaultInputValues();
     }
 
     public IActionResult OnPost(string submit)
     {
         if (submit == "ni_number_not_known")
         {
-            HttpContext.GetAuthenticationState().HaveNationalInsuranceNumber = false;
+            HttpContext.GetAuthenticationState().OnHaveNationalInsuranceNumberSet(false);
         }
         else
         {
@@ -55,5 +56,10 @@ public class NiNumberPage : PageModel
         {
             context.Result = new RedirectResult(authenticationState.GetNextHopUrl(_linkGenerator));
         }
+    }
+
+    private void SetDefaultInputValues()
+    {
+        NiNumber ??= HttpContext.GetAuthenticationState().NationalInsuranceNumber;
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/OfficialName.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/OfficialName.cshtml.cs
@@ -33,6 +33,7 @@ public class OfficialName : PageModel
 
     public void OnGet()
     {
+        SetDefaultInputValues();
     }
 
     public IActionResult OnPost()
@@ -69,5 +70,16 @@ public class OfficialName : PageModel
         True,
         False,
         PreferNotToSay
+    }
+
+    private void SetDefaultInputValues()
+    {
+        OfficialFirstName ??= HttpContext.GetAuthenticationState().OfficialFirstName;
+        OfficialLastName ??= HttpContext.GetAuthenticationState().OfficialLastName;
+        PreviousOfficialFirstName ??= HttpContext.GetAuthenticationState().PreviousOfficialFirstName;
+        PreviousOfficialLastName ??= HttpContext.GetAuthenticationState().PreviousOfficialLastName;
+
+        HasPreviousName ??= !string.IsNullOrEmpty(PreviousOfficialFirstName) ||
+                          !string.IsNullOrEmpty(PreviousOfficialLastName) ? PreviousName.True : null;
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/PreferredName.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/PreferredName.cshtml
@@ -1,7 +1,7 @@
 @page "/sign-in/trn/preferred-name"
 @model TeacherIdentity.AuthServer.Pages.SignIn.Trn.PreferredName
 @{
-    ViewBag.Title = $"Is {Model.FirstName} {Model.LastName} your preferred name?";
+    ViewBag.Title = $"Is {Model.OfficialFirstName} {Model.OfficialLastName} your preferred name?";
 }
 
 @section BeforeContent {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/PreferredName.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/PreferredName.cshtml.cs
@@ -15,8 +15,8 @@ public class PreferredName : PageModel
         _linkGenerator = linkGenerator;
     }
 
-    public string? FirstName => HttpContext.GetAuthenticationState().FirstName;
-    public string? LastName => HttpContext.GetAuthenticationState().LastName;
+    public string? OfficialFirstName => HttpContext.GetAuthenticationState().OfficialFirstName;
+    public string? OfficialLastName => HttpContext.GetAuthenticationState().OfficialLastName;
 
     // Properties are set in the order that they are declared. Because the value of HasPreferredName
     // is used in the conditional RequiredIfTrue attribute, it should be set first.
@@ -34,6 +34,7 @@ public class PreferredName : PageModel
 
     public void OnGet()
     {
+        SetDefaultInputValues();
     }
 
     public IActionResult OnPost()
@@ -63,5 +64,13 @@ public class PreferredName : PageModel
         {
             context.Result = new RedirectResult(authenticationState.GetNextHopUrl(_linkGenerator));
         }
+    }
+
+    private void SetDefaultInputValues()
+    {
+        PreferredFirstName ??= HttpContext.GetAuthenticationState().FirstName;
+        PreferredLastName ??= HttpContext.GetAuthenticationState().LastName;
+
+        HasPreferredName ??= !string.IsNullOrEmpty(PreferredFirstName) && !string.IsNullOrEmpty(PreferredLastName) ? true : null;
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
@@ -120,7 +120,27 @@ public sealed class AuthenticationStateHelper
 
                 await EmailSet(email ?? user?.EmailAddress)(s);
                 s.OnEmailVerified(user);
-                s.OnOfficialNameSet("first", "last", null, null);
+                s.OnOfficialNameSet(Faker.Name.First(), Faker.Name.Last(), null, null);
+            };
+
+        public Func<AuthenticationState, Task> TrnIdentityJourneyComplete(string? email = null, User? user = null) =>
+            async s =>
+            {
+                if (email is not null && user is not null && email != user?.EmailAddress)
+                {
+                    throw new ArgumentException("Email does not match user's email.", nameof(email));
+                }
+
+                await EmailSet(email ?? user?.EmailAddress)(s);
+                s.OnEmailVerified(user);
+                s.OnOfficialNameSet(Faker.Name.First(), Faker.Name.Last(), Faker.Name.First(), Faker.Name.Last());
+                s.OnNameChanged(Faker.Name.First(), Faker.Name.Last());
+                s.OnDateOfBirthSet(DateOnly.Parse("1/1/2000"));
+                s.OnHaveNationalInsuranceNumberSet(true);
+                s.NationalInsuranceNumber = "QQ 12 34 56 C";
+                s.OnAwardedQtsSet(true);
+                s.OnHaveIttProviderSet(true);
+                s.IttProviderName = "provider";
             };
 
         public Func<AuthenticationState, Task> TrnLookupCallbackCompleted(

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/AwardedQtsPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/AwardedQtsPageTests.cs
@@ -129,5 +129,9 @@ public class AwardedQtsPageTests : TestBase
         {
             Assert.StartsWith("/sign-in/trn/itt-provider", response.Headers.Location?.OriginalString);
         }
+        else
+        {
+            Assert.StartsWith("/sign-in/trn/check-answers", response.Headers.Location?.OriginalString);
+        }
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/CheckAnswersTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/CheckAnswersTests.cs
@@ -1,0 +1,87 @@
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Trn;
+
+public class CheckAnswersTests : TestBase
+{
+    public CheckAnswersTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/trn/check-answers");
+    }
+
+    [Fact]
+    public async Task Get_MissingAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/trn/check-answers");
+    }
+
+    [Fact]
+    public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Get, "/sign-in/trn/check-answers");
+    }
+
+    [Fact]
+    public async Task Get_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(c => c.OfficialNameSet(), HttpMethod.Get, "/sign-in/trn/check-answers");
+    }
+
+    [Theory]
+    [MemberData(nameof(TrnIdentityData))]
+    public async Task Get_ValidRequest_RendersExpectedContent(
+        bool haveNiNumber = false,
+        bool awardedQts = false,
+        bool haveIttProvider = false)
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.TrnIdentityJourneyComplete());
+        var authState = authStateHelper.AuthenticationState;
+
+        authState.OnHaveNationalInsuranceNumberSet(haveNiNumber);
+        authState.OnAwardedQtsSet(awardedQts);
+        authState.OnHaveIttProviderSet(haveIttProvider);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/check-answers?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+        Assert.Equal(authState.EmailAddress, doc.GetSummaryListValueForKey("Email address"));
+        Assert.Equal($"{authState.OfficialFirstName} {authState.OfficialLastName}", doc.GetSummaryListValueForKey("Name"));
+        Assert.Equal($"{authState.PreviousOfficialFirstName} {authState.PreviousOfficialLastName}", doc.GetSummaryListValueForKey("Previous name"));
+        Assert.Equal($"{authState.FirstName} {authState.LastName}", doc.GetSummaryListValueForKey("Preferred name"));
+        Assert.Equal(authState.DateOfBirth?.ToString("dd MMMM yyyy"), doc.GetSummaryListValueForKey("Date of birth"));
+        Assert.Equal(haveNiNumber ? authState.NationalInsuranceNumber : "Not given", doc.GetSummaryListValueForKey("National Insurance number"));
+        Assert.Equal(awardedQts ? "Yes" : "No", doc.GetSummaryListValueForKey("Have you been awarded QTS?"));
+
+        if (awardedQts)
+        {
+            Assert.Equal(haveIttProvider ? authState.IttProviderName : "No, I was awarded QTS another way", doc.GetSummaryListValueForKey("Did a university, SCITT or school award your QTS?"));
+        }
+        else
+        {
+            Assert.Null(doc.GetSummaryListRowForKey("Did a university, SCITT or school award your QTS?"));
+        }
+    }
+
+    public static TheoryData<bool, bool, bool> TrnIdentityData { get; } = new()
+    {
+        { true, true, true },
+        { true, true, false },
+        { true, false, true },
+        { true, false, false },
+        { false, true, true },
+        { false, true, false },
+        { false, false, true },
+        { false, false, false },
+    };
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/IttProviderTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/IttProviderTests.cs
@@ -150,7 +150,7 @@ public class IitProviderTests : TestBase
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public async Task Post_ValidForm_UpdatesAuthenticationState(bool hasIttProvider)
+    public async Task Post_ValidForm_UpdatesAuthenticationStateRedirectsToCheckAnswers(bool hasIttProvider)
     {
         // Arrange
         var ittProviderName = "provider";
@@ -171,6 +171,7 @@ public class IitProviderTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/trn/check-answers", response.Headers.Location?.OriginalString);
 
         Assert.Equal(hasIttProvider, authStateHelper.AuthenticationState.HaveIttProvider);
         Assert.Equal(hasIttProvider ? ittProviderName : null, authStateHelper.AuthenticationState.IttProviderName);


### PR DESCRIPTION
### Context

We're removing the dependency on Find from ID. This is the next page in the UI ported from Find.

### Changes proposed in this pull request

Add a new page at /sign-in/trn/check-answers following the design at [This is a prototype used for research - Find a lost teacher reference number (TRN) - GOV.UK](https://find-a-lost-trn.herokuapp.com/get-an-identity/check-answers)

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
