### PR TITLE
Add identity has TRN page for TRN lookup flow

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -92,6 +92,10 @@ public class AuthenticationState
     [JsonInclude]
     public bool? HaveIttProvider { get; private set; }
     public string? IttProviderName { get; set; }
+    [JsonInclude]
+    public bool? HasTrn { get; private set; }
+    public string? StatedTrn { get; set; }
+
 
     /// <summary>
     /// Whether the user has gone back to an earlier page after this journey has been completed.
@@ -456,6 +460,16 @@ public class AuthenticationState
         }
 
         AwardedQts = awardedQts;
+    }
+
+    public void OnHasTrnSet(bool hasTrn)
+    {
+        if (!hasTrn)
+        {
+            StatedTrn = null;
+        }
+
+        HasTrn = hasTrn;
     }
 
     public void OnHaveResumedCompletedJourney()

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/DataAnnotationsExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/DataAnnotationsExtensions.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 
 namespace TeacherIdentity.AuthServer;
 
@@ -8,6 +9,27 @@ public class RequiredIfTrueAttribute : RequiredAttribute
     private string PropertyName { get; }
 
     public RequiredIfTrueAttribute(string propertyName)
+    {
+        PropertyName = propertyName;
+    }
+
+    protected override ValidationResult IsValid(object? value, ValidationContext context)
+    {
+        object instance = context.ObjectInstance;
+        Type type = instance.GetType();
+
+        bool.TryParse(type.GetProperty(PropertyName)?.GetValue(instance)?.ToString(), out bool isRequired);
+        return isRequired && !base.IsValid(value) ? new ValidationResult(ErrorMessage) : ValidationResult.Success!;
+    }
+}
+
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
+public class RegexIfTrueAttribute : RegularExpressionAttribute
+{
+    private string PropertyName { get; }
+
+    public RegexIfTrueAttribute(string propertyName, [StringSyntax(StringSyntaxAttribute.Regex)] string pattern)
+        : base(pattern)
     {
         PropertyName = propertyName;
     }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -69,6 +69,8 @@ public static class IdentityLinkGeneratorExtensions
 
     public static string TrnCallback(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/TrnCallback");
 
+    public static string TrnHasTrn(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Trn/HasTrnPage");
+
     public static string TrnOfficialName(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Trn/OfficialName");
 
     public static string TrnPreferredName(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Trn/PreferredName");

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn.cshtml.cs
@@ -32,7 +32,7 @@ public class TrnModel : PageModel
 
         if (_findALostTrnIntegrationHelper.Options.UseNewTrnLookupJourney)
         {
-            var nextPage = _linkGenerator.TrnOfficialName();
+            var nextPage = _linkGenerator.TrnHasTrn();
             HandoverUrl = new Url(nextPage).RemoveQuery();
             HandoverParameters = new Url(nextPage).QueryParams.ToKeyValuePairs().ToDictionary(q => q.Key, q => q.Value.ToString()!);
             HandoverMethod = HttpMethods.Get;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/HasTrnPage.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/HasTrnPage.cshtml
@@ -1,0 +1,38 @@
+@page "/sign-in/trn/has-trn"
+@model TeacherIdentity.AuthServer.Pages.SignIn.Trn.HasTrnPage
+@{
+    ViewBag.Title = "Do you know your teacher reference number (TRN)?";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.TrnDateOfBirth()" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.TrnHasTrn()" method="post" asp-antiforgery="true">
+            <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
+
+            <p>Your TRN is 7 digits long, for example 4567814.</p>
+            <p>It might include the letters RP and a slash, for example RP99/12345</p>
+            <p>It’s previously been known as a QTS, GTC, DfE, DfES and DCSF number.</p>
+
+            <govuk-radios asp-for="HasTrn">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m"/>
+                    <govuk-radios-item value="True">Yes, I know my TRN
+                        <govuk-radios-item-conditional>
+                            <govuk-input asp-for="StatedTrn" spellcheck="false">
+                                <govuk-input-label class="govuk-label--s"/>
+                            </govuk-input>
+                        </govuk-radios-item-conditional>
+                    </govuk-radios-item>
+                    <govuk-radios-item value="False">No, I need to continue without my TRN</govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>
+

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/HasTrnPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/HasTrnPage.cshtml.cs
@@ -1,0 +1,69 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn.Trn;
+
+[BindProperties]
+public class HasTrnPage : PageModel
+{
+    private IIdentityLinkGenerator _linkGenerator;
+
+    public HasTrnPage(IIdentityLinkGenerator linkGenerator)
+    {
+        _linkGenerator = linkGenerator;
+    }
+
+    // Properties are set in the order that they are declared. Because the value of HasTrn
+    // is used in the conditional RequiredIfTrue attribute, it should be set first.
+    [Display(Name = "Do you know your TRN?")]
+    [Required(ErrorMessage = "Tell us if you know your TRN")]
+    public bool? HasTrn { get; set; }
+
+    [Display(Name = "What is your TRN?")]
+    [RequiredIfTrue(nameof(HasTrn), ErrorMessage = "Enter your TRN")]
+    [RegexIfTrue(nameof(HasTrn), @"\A\D*(\d{1}\D*){7}\D*\Z", ErrorMessage = "Your TRN number should contain 7 digits")]
+    public string? StatedTrn { get; set; }
+
+    public void OnGet()
+    {
+        SetDefaultInputValues();
+    }
+
+    public IActionResult OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        HttpContext.GetAuthenticationState().OnHasTrnSet((bool)HasTrn!);
+
+        if (HasTrn == true)
+        {
+            HttpContext.GetAuthenticationState().StatedTrn = StatedTrn;
+        }
+
+        return Redirect(_linkGenerator.TrnOfficialName());
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var authenticationState = context.HttpContext.GetAuthenticationState();
+
+        // We expect to have a verified email at this point but we shouldn't have completed the TRN lookup
+        if (string.IsNullOrEmpty(authenticationState.EmailAddress) ||
+            !authenticationState.EmailAddressVerified ||
+            authenticationState.HaveCompletedTrnLookup)
+        {
+            context.Result = new RedirectResult(authenticationState.GetNextHopUrl(_linkGenerator));
+        }
+    }
+
+    private void SetDefaultInputValues()
+    {
+        HasTrn ??= HttpContext.GetAuthenticationState().HasTrn;
+        StatedTrn ??= HttpContext.GetAuthenticationState().StatedTrn;
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/HasTrnPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/HasTrnPageTests.cs
@@ -1,0 +1,179 @@
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Trn;
+
+public class HasTrnPageTests : TestBase
+{
+    public HasTrnPageTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, $"/sign-in/trn/has-trn");
+    }
+
+    [Fact]
+    public async Task Get_NoAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await MissingAuthenticationState_ReturnsBadRequest(HttpMethod.Get, $"/sign-in/trn/has-trn");
+    }
+
+    [Fact]
+    public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Get, "/sign-in/trn/has-trn");
+    }
+
+    [Fact]
+    public async Task Get_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(c => c.EmailVerified(), HttpMethod.Get, "/sign-in/trn/has-trn");
+    }
+
+    [Fact]
+    public async Task Get_NoEmail_RedirectsToEmailPage()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/has-trn?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/email", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_EmailNotVerified_RedirectsToEmailConfirmationPage()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet());
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/has-trn?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/email-confirmation", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_NullHasTrn_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified());
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/has-trn?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "HasTrn", "Tell us if you know your TRN");
+    }
+
+    [Fact]
+    public async Task Post_EmptyStatedTrn_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified());
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/has-trn?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "HasTrn", true },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "StatedTrn", "Enter your TRN");
+    }
+
+    [Theory]
+    [InlineData("abc")]
+    [InlineData("123456")]
+    [InlineData("1234567 8")]
+    public async Task Post_InvalidStatedTrn_ReturnsError(string statedTrn)
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified());
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/has-trn?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "HasTrn", true },
+                { "StatedTrn", statedTrn },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "StatedTrn", "Your TRN number should contain 7 digits");
+    }
+
+    [Fact]
+    public async Task Post_FalseHasTrn_UpdatesAuthenticationStateRedirectsToTrnOfficialName()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified());
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/has-trn?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "HasTrn", false },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/trn/official-name", response.Headers.Location?.OriginalString);
+
+        Assert.False(authStateHelper.AuthenticationState.HasTrn);
+    }
+
+    [Theory]
+    [InlineData("4567814")]
+    [InlineData("RP99/12345")]
+    public async Task Post_ValidStatedTrn_UpdatesAuthenticationStateRedirectsToTrnOfficialName(string statedTrn)
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified());
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/has-trn?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "HasTrn", true },
+                { "StatedTrn", statedTrn },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/trn/official-name", response.Headers.Location?.OriginalString);
+
+        Assert.True(authStateHelper.AuthenticationState.HasTrn);
+        Assert.Equal(statedTrn, authStateHelper.AuthenticationState.StatedTrn);
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnTests.cs
@@ -83,7 +83,7 @@ public class TrnTests : TestBase
     }
 
     [Fact]
-    public async Task Get_WhenUseNewTrnLookupJourneyTrue_SubmitsToTrnOfficialName()
+    public async Task Get_WhenUseNewTrnLookupJourneyTrue_SubmitsToTrnHasTrn()
     {
         // Arrange
         var trnConfig = HostFixture.Services.GetRequiredService<IOptions<FindALostTrnIntegrationOptions>>().Value;
@@ -101,7 +101,7 @@ public class TrnTests : TestBase
 
         var doc = await response.GetDocument();
         var form = doc.GetElementsByTagName("form").Single();
-        Assert.StartsWith("/sign-in/trn/official-name", form.GetAttribute("action"));
+        Assert.StartsWith("/sign-in/trn/has-trn", form.GetAttribute("action"));
         Assert.Equal("GET", form.GetAttribute("method"));
     }
 }


### PR DESCRIPTION
### Context

The 'TRN Optional' journey for NPQ requires handling users that do not have a TRN. We ask for their TRN upfront so that we know whether we expect to find them in DQT and can raise a support ticket if required.

### Changes proposed in this pull request

Add a new page at /sign-in/trn/has-trn

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [x] Reminder created to manually clean any removed app settings post deployment
