### PR TITLE
Update authentication state to store HasPreviousNameOption enum

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -475,7 +475,7 @@ public class AuthenticationState
         HasTrn = hasTrn;
     }
 
-    public void OnHasPreviousNameSet(OfficialName.HasPreviousNameOption hasPreviousName)
+    public void OnHasPreviousNameSet(OfficialName.HasPreviousNameOption? hasPreviousName)
     {
         if (hasPreviousName == OfficialName.HasPreviousNameOption.No)
         {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -7,6 +7,7 @@ using Flurl;
 using TeacherIdentity.AuthServer.Infrastructure.Json;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Oidc;
+using TeacherIdentity.AuthServer.Pages.SignIn.Trn;
 using static OpenIddict.Abstractions.OpenIddictConstants;
 
 namespace TeacherIdentity.AuthServer;
@@ -95,6 +96,8 @@ public class AuthenticationState
     [JsonInclude]
     public bool? HasTrn { get; private set; }
     public string? StatedTrn { get; set; }
+    [JsonInclude]
+    public OfficialName.HasPreviousNameOption? HasPreviousName { get; private set; }
 
 
     /// <summary>
@@ -470,6 +473,17 @@ public class AuthenticationState
         }
 
         HasTrn = hasTrn;
+    }
+
+    public void OnHasPreviousNameSet(OfficialName.HasPreviousNameOption hasPreviousName)
+    {
+        if (hasPreviousName == OfficialName.HasPreviousNameOption.No)
+        {
+            PreviousOfficialFirstName = null;
+            PreviousOfficialLastName = null;
+        }
+
+        HasPreviousName = hasPreviousName;
     }
 
     public void OnHaveResumedCompletedJourney()

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/OfficialName.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/OfficialName.cshtml
@@ -30,9 +30,8 @@
                         Have you ever changed your name?
                     </govuk-radios-fieldset-legend>
 
-                    <govuk-radios-item value="@OfficialName.PreviousName.False">No</govuk-radios-item>
-                    <govuk-radios-item value="@OfficialName.PreviousName.True">
-                        Yes
+                    <govuk-radios-item value="@OfficialName.HasPreviousNameOption.No">No</govuk-radios-item>
+                    <govuk-radios-item value="@OfficialName.HasPreviousNameOption.Yes">Yes
                         <govuk-radios-item-conditional>
                             <h2 class="govuk-heading-m">What was your previous name?</h2>
                             <p>You do not have to tell us your previous name, but it will help us identify you.</p>
@@ -46,7 +45,7 @@
                             </govuk-input>
                         </govuk-radios-item-conditional>
                     </govuk-radios-item>
-                    <govuk-radios-item value="@OfficialName.PreviousName.PreferNotToSay">Prefer not to say</govuk-radios-item>
+                    <govuk-radios-item value="@OfficialName.HasPreviousNameOption.PreferNotToSay">Prefer not to say</govuk-radios-item>
                 </govuk-radios-fieldset>
             </govuk-radios>
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/OfficialName.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/OfficialName.cshtml.cs
@@ -29,7 +29,7 @@ public class OfficialName : PageModel
     [Display(Name = "Previous last name (optional)")]
     public string? PreviousOfficialLastName { get; set; }
 
-    public PreviousName? HasPreviousName { get; set; }
+    public HasPreviousNameOption? HasPreviousName { get; set; }
 
     public void OnGet()
     {
@@ -43,11 +43,13 @@ public class OfficialName : PageModel
             return this.PageWithErrors();
         }
 
+        HttpContext.GetAuthenticationState().OnHasPreviousNameSet((HasPreviousNameOption)HasPreviousName!);
+
         HttpContext.GetAuthenticationState().OnOfficialNameSet(
             OfficialFirstName!,
             OfficialLastName!,
-            HasPreviousName == PreviousName.True ? PreviousOfficialFirstName : null,
-            HasPreviousName == PreviousName.True ? PreviousOfficialLastName : null);
+            HasPreviousName == HasPreviousNameOption.Yes ? PreviousOfficialFirstName : null,
+            HasPreviousName == HasPreviousNameOption.Yes ? PreviousOfficialLastName : null);
 
         return Redirect(_linkGenerator.TrnPreferredName());
     }
@@ -65,10 +67,10 @@ public class OfficialName : PageModel
         }
     }
 
-    public enum PreviousName
+    public enum HasPreviousNameOption
     {
-        True,
-        False,
+        Yes,
+        No,
         PreferNotToSay
     }
 
@@ -78,8 +80,6 @@ public class OfficialName : PageModel
         OfficialLastName ??= HttpContext.GetAuthenticationState().OfficialLastName;
         PreviousOfficialFirstName ??= HttpContext.GetAuthenticationState().PreviousOfficialFirstName;
         PreviousOfficialLastName ??= HttpContext.GetAuthenticationState().PreviousOfficialLastName;
-
-        HasPreviousName ??= !string.IsNullOrEmpty(PreviousOfficialFirstName) ||
-                          !string.IsNullOrEmpty(PreviousOfficialLastName) ? PreviousName.True : null;
+        HasPreviousName ??= HttpContext.GetAuthenticationState().HasPreviousName;
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/OfficialNameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/OfficialNameTests.cs
@@ -1,3 +1,5 @@
+using TeacherIdentity.AuthServer.Pages.SignIn.Trn;
+
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Trn;
 
 public class OfficialNameTests : TestBase
@@ -111,6 +113,7 @@ public class OfficialNameTests : TestBase
             {
                 { "OfficialFirstName", firstName },
                 { "OfficialLastName", lastName },
+                { "HasPreviousName", OfficialName.HasPreviousNameOption.No },
             }
         };
 
@@ -143,7 +146,7 @@ public class OfficialNameTests : TestBase
                 { "OfficialLastName", "last" },
                 { "PreviousOfficialFirstName", previousFirstName },
                 { "PreviousOfficialLastName", previousLastName },
-                { "HasPreviousName", hasPreviousName},
+                { "HasPreviousName", hasPreviousName ? OfficialName.HasPreviousNameOption.Yes : OfficialName.HasPreviousNameOption.No },
             }
         };
 


### PR DESCRIPTION
### Context

Store HasPreviousName on authentication state in order to correctly populate default value of HasPreviousName on OfficialName page

### Changes proposed in this pull request

Store HasPreviousName on authentication state

### Checklist

-   [ ] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [x] Reminder created to manually clean any removed app settings post deployment
