### PR TITLE
Add DQT lookup integration to new TRN journey

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -406,7 +406,7 @@ public class AuthenticationState
         EmailAddress = email;
     }
 
-    public void OnNameChanged(string firstName, string lastName)
+    public void OnNameSet(string firstName, string lastName)
     {
         FirstName = firstName;
         LastName = lastName;
@@ -416,12 +416,12 @@ public class AuthenticationState
         string officialFirstName,
         string officialLastName,
         string? previousOfficialFirstName,
-        string? previousOfficiaLastName)
+        string? previousOfficialLastName)
     {
         OfficialFirstName = officialFirstName;
         OfficialLastName = officialLastName;
         PreviousOfficialFirstName = previousOfficialFirstName;
-        PreviousOfficialLastName = previousOfficiaLastName;
+        PreviousOfficialLastName = previousOfficialLastName;
     }
 
     public bool HasOfficialName()
@@ -521,6 +521,11 @@ public class AuthenticationState
         return !string.IsNullOrEmpty(firstName) && !string.IsNullOrEmpty(lastName)
             ? $"{firstName} {lastName}"
             : null;
+    }
+
+    public void OnTrnLookupCompleted(string? trn)
+    {
+        Trn = trn;
     }
 
     public string Serialize() => JsonSerializer.Serialize(this, _jsonSerializerOptions);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Authenticated/UpdateName.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Authenticated/UpdateName.cshtml.cs
@@ -99,7 +99,7 @@ public class UpdateNameModel : PageModel
 
             if (HttpContext.TryGetAuthenticationState(out var authenticationState))
             {
-                authenticationState.OnNameChanged(FirstName!, LastName!);
+                authenticationState.OnNameSet(FirstName!, LastName!);
 
                 // If we're inside an OAuth journey we need to redirect back to the authorize endpoint so the
                 // OpenIddict auth handler can SignIn again with the revised user details

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/CheckAnswers.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/CheckAnswers.cshtml
@@ -53,20 +53,26 @@
                         <govuk-summary-list-row-action href="@LinkGenerator.TrnDateOfBirth()">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
-                <govuk-summary-list-row>
-                    <govuk-summary-list-row-key>National Insurance number</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value>@(Model.NationalInsuranceNumber ?? "Not given")</govuk-summary-list-row-value>
-                    <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.TrnHaveNiNumber()">Change</govuk-summary-list-row-action>
-                    </govuk-summary-list-row-actions>
-                </govuk-summary-list-row>
-                <govuk-summary-list-row>
-                    <govuk-summary-list-row-key>Have you been awarded QTS?</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value>@(Model.AwardedQts == true ? "Yes" : "No")</govuk-summary-list-row-value>
-                    <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.TrnAwardedQts()">Change</govuk-summary-list-row-action>
-                    </govuk-summary-list-row-actions>
-                </govuk-summary-list-row>
+                @if (Model.HaveNationalInsuranceNumber is not null)
+                {
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>National Insurance number</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value>@(Model.NationalInsuranceNumber ?? "Not given")</govuk-summary-list-row-value>
+                        <govuk-summary-list-row-actions>
+                            <govuk-summary-list-row-action href="@LinkGenerator.TrnHaveNiNumber()">Change</govuk-summary-list-row-action>
+                        </govuk-summary-list-row-actions>
+                    </govuk-summary-list-row>
+                }
+                @if (Model.AwardedQts is not null)
+                {
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Have you been awarded QTS?</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value>@(Model.AwardedQts == true ? "Yes" : "No")</govuk-summary-list-row-value>
+                        <govuk-summary-list-row-actions>
+                            <govuk-summary-list-row-action href="@LinkGenerator.TrnAwardedQts()">Change</govuk-summary-list-row-action>
+                        </govuk-summary-list-row-actions>
+                    </govuk-summary-list-row>
+                }
                 @if (Model.AwardedQts == true)
                 {
                     <govuk-summary-list-row>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/CheckAnswers.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/CheckAnswers.cshtml.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Trn;
 
-[BindProperties]
 public class CheckAnswers : PageModel
 {
     private IIdentityLinkGenerator _linkGenerator;
@@ -14,18 +13,19 @@ public class CheckAnswers : PageModel
         _linkGenerator = linkGenerator;
     }
 
-    public string? BackLink => (HttpContext.GetAuthenticationState().HaveIttProvider == true)
+    public string BackLink => (HttpContext.GetAuthenticationState().HaveIttProvider == true)
         ? _linkGenerator.TrnIttProvider()
         : _linkGenerator.TrnAwardedQts();
+
     public string? EmailAddress => HttpContext.GetAuthenticationState().EmailAddress;
     public string? OfficialName => HttpContext.GetAuthenticationState().GetOfficialName();
     public string? PreviousOfficialName => HttpContext.GetAuthenticationState().GetPreviousOfficialName();
     public string? PreferredName => HttpContext.GetAuthenticationState().GetPreferredName();
     public DateOnly? DateOfBirth => HttpContext.GetAuthenticationState().DateOfBirth;
+    public bool? HaveNationalInsuranceNumber => HttpContext.GetAuthenticationState().HaveNationalInsuranceNumber;
     public string? NationalInsuranceNumber => HttpContext.GetAuthenticationState().NationalInsuranceNumber;
     public bool? AwardedQts => HttpContext.GetAuthenticationState().AwardedQts;
     public string? IttProviderName => HttpContext.GetAuthenticationState().IttProviderName;
-
 
     public void OnGet()
     {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/PreferredName.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/PreferredName.cshtml.cs
@@ -46,7 +46,7 @@ public class PreferredName : PageModel
 
         if (HasPreferredName == true)
         {
-            HttpContext.GetAuthenticationState().OnNameChanged(PreferredFirstName!, PreferredLastName!);
+            HttpContext.GetAuthenticationState().OnNameSet(PreferredFirstName!, PreferredLastName!);
         }
 
         return Redirect(_linkGenerator.TrnDateOfBirth());

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/TrnLookupPageModel.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/TrnLookupPageModel.cs
@@ -1,0 +1,69 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeacherIdentity.AuthServer.Services.DqtApi;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn.Trn;
+
+public abstract class TrnLookupPageModel : PageModel
+{
+    private static readonly TimeSpan _trnLookupTimeout = TimeSpan.FromSeconds(5);
+
+    private readonly ILogger<TrnLookupPageModel> _logger;
+
+    protected TrnLookupPageModel(
+        IIdentityLinkGenerator linkGenerator,
+        IDqtApiClient dqtApiClient,
+        ILogger<TrnLookupPageModel> logger)
+    {
+        LinkGenerator = linkGenerator;
+        DqtApiClient = dqtApiClient;
+        _logger = logger;
+    }
+
+    public IIdentityLinkGenerator LinkGenerator { get; }
+
+    public IDqtApiClient DqtApiClient { get; }
+
+    protected async Task<IActionResult?> TryFindTrn()
+    {
+        var authenticationState = HttpContext.GetAuthenticationState();
+
+        using var cts = new CancellationTokenSource();
+        cts.CancelAfter(_trnLookupTimeout);
+
+        string? lookupResult = null;
+
+        try
+        {
+            var lookupResponse = await DqtApiClient.FindTeachers(
+                new FindTeachersRequest()
+                {
+                    DateOfBirth = authenticationState.DateOfBirth,
+                    EmailAddress = authenticationState.EmailAddress,
+                    FirstName = authenticationState.OfficialFirstName,
+                    LastName = authenticationState.OfficialLastName,
+                    IttProviderName = authenticationState.IttProviderName,
+                    NationalInsuranceNumber = authenticationState.NationalInsuranceNumber,
+                    PreviousFirstName = authenticationState.PreviousOfficialFirstName,
+                    PreviousLastName = authenticationState.PreviousOfficialLastName,
+                    Trn = authenticationState.StatedTrn
+                },
+                cts.Token);
+
+            lookupResult = lookupResponse.Results.Length == 1 ? lookupResponse.Results[0].Trn : null;
+        }
+        catch (OperationCanceledException ex)
+        {
+            _logger.LogError(ex, "Timeout calling DQT API.");
+            return null;
+        }
+        finally
+        {
+            // We're deliberately setting the result here, even on failure to ensure we don't hold onto a
+            // previously-found TRN that may now be invalid.
+            authenticationState.OnTrnLookupCompleted(lookupResult);
+        }
+
+        return lookupResult is not null ? new RedirectResult(LinkGenerator.TrnCheckAnswers()) : null;
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
@@ -110,37 +110,36 @@ public sealed class AuthenticationStateHelper
                 s.OnEmailVerified(user);
             };
 
-        public Func<AuthenticationState, Task> OfficialNameSet(string? email = null, User? user = null) =>
+        public Func<AuthenticationState, Task> OfficialNameSet(
+            string? email = null,
+            string? officialFirstName = null,
+            string? officialLastName = null,
+            string? previousOfficialFirstName = null,
+            string? previousOfficialLastName = null) =>
             async s =>
             {
-                if (email is not null && user is not null && email != user?.EmailAddress)
-                {
-                    throw new ArgumentException("Email does not match user's email.", nameof(email));
-                }
+                email ??= Faker.Internet.Email();
 
-                await EmailSet(email ?? user?.EmailAddress)(s);
-                s.OnEmailVerified(user);
-                s.OnOfficialNameSet(Faker.Name.First(), Faker.Name.Last(), null, null);
+                await EmailSet(email)(s);
+                s.OnEmailVerified();
+                s.OnOfficialNameSet(
+                    officialFirstName ?? Faker.Name.First(),
+                    officialLastName ?? Faker.Name.Last(),
+                    previousOfficialFirstName,
+                    previousOfficialLastName);
             };
 
-        public Func<AuthenticationState, Task> TrnIdentityJourneyComplete(string? email = null, User? user = null) =>
+        public Func<AuthenticationState, Task> DateOfBirthSet(
+            DateOnly? dateOfBirth = null,
+            string? email = null,
+            string? officialFirstName = null,
+            string? officialLastName = null,
+            string? previousOfficialFirstName = null,
+            string? previousOfficialLastName = null) =>
             async s =>
             {
-                if (email is not null && user is not null && email != user?.EmailAddress)
-                {
-                    throw new ArgumentException("Email does not match user's email.", nameof(email));
-                }
-
-                await EmailSet(email ?? user?.EmailAddress)(s);
-                s.OnEmailVerified(user);
-                s.OnOfficialNameSet(Faker.Name.First(), Faker.Name.Last(), Faker.Name.First(), Faker.Name.Last());
-                s.OnNameChanged(Faker.Name.First(), Faker.Name.Last());
-                s.OnDateOfBirthSet(DateOnly.Parse("1/1/2000"));
-                s.OnHaveNationalInsuranceNumberSet(true);
-                s.NationalInsuranceNumber = "QQ 12 34 56 C";
-                s.OnAwardedQtsSet(true);
-                s.OnHaveIttProviderSet(true);
-                s.IttProviderName = "provider";
+                await OfficialNameSet(email, officialFirstName, officialLastName, previousOfficialFirstName, previousOfficialLastName)(s);
+                s.OnDateOfBirthSet(dateOfBirth ?? DateOnly.FromDateTime(Faker.Identification.DateOfBirth()));
             };
 
         public Func<AuthenticationState, Task> TrnLookupCallbackCompleted(

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/PreferredNameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/PreferredNameTests.cs
@@ -1,5 +1,6 @@
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Trn;
 
+[Collection(nameof(DisableParallelization))]  // Relies on mocks
 public class PreferredNameTests : TestBase
 {
     public PreferredNameTests(HostFixture hostFixture)
@@ -172,7 +173,7 @@ public class PreferredNameTests : TestBase
         var preferredLastName = "preferred last";
 
         var authStateHelper = await CreateAuthenticationStateHelper(c => c.OfficialNameSet());
-        authStateHelper.AuthenticationState.OnNameChanged(initialFirstName, initialLastName);
+        authStateHelper.AuthenticationState.OnNameSet(initialFirstName, initialLastName);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/preferred-name?{authStateHelper.ToQueryParam()}")
         {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/HostFixture.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/HostFixture.cs
@@ -82,6 +82,9 @@ public class HostFixture : WebApplicationFactory<TeacherIdentity.AuthServer.Prog
         EmailSender.Reset();
         EmailVerificationService.Reset();
         RateLimitStore.Reset();
+
+        DqtApiClient.Setup(mock => mock.FindTeachers(It.IsAny<FindTeachersRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FindTeachersResponse() { Results = Array.Empty<FindTeachersResponseResult>() });
     }
 
     // N.B. Don't call this from InitializeAsync - it won't work


### PR DESCRIPTION
### Context

We're bringing TRN lookup 'in house' into ID rather than integrating with Find. This PR adds the DQT API integration (to do the actual TRN lookup). It also adds the short-circuiting logic to avoid asking any more questions when we've already found the TRN.

### Changes proposed in this pull request

Adds a TRN lookup to the end of `POST` page handlers for most pages under `/sign-in/trn.`. There are a few places where we deliberately don't do a lookup; the 'have NINO' and 'have QTS' pages when the answer is 'Yes'. In those cases, we always want to go to the next page (the 'NINO' and 'ITT Provider' pages, respectively) since these pages provide the input to the TRN lookup and we don't want any short circuiting there.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
