### PR TITLE
Create user on identity check answers form submission

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/AwardedQtsPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/AwardedQtsPage.cshtml.cs
@@ -52,7 +52,7 @@ public class AwardedQtsPage : TrnLookupPageModel
         // We expect to have a verified email and official names at this point but we shouldn't have completed the TRN lookup
         if (string.IsNullOrEmpty(authenticationState.EmailAddress) ||
             !authenticationState.EmailAddressVerified ||
-            !authenticationState.HasOfficialName() ||
+            string.IsNullOrEmpty(authenticationState.GetOfficialName()) ||
             authenticationState.HaveCompletedTrnLookup)
         {
             context.Result = new RedirectResult(authenticationState.GetNextHopUrl(LinkGenerator));

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/CheckAnswers.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/CheckAnswers.cshtml
@@ -84,6 +84,8 @@
                     </govuk-summary-list-row>
                 }
             </govuk-summary-list>
+
+            <govuk-button type="submit">Continue</govuk-button>
         </form>
     </div>
 </div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/CheckAnswers.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/CheckAnswers.cshtml.cs
@@ -1,16 +1,28 @@
+using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Models.Mappings;
+using TeacherIdentity.AuthServer.Services.EmailVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Trn;
 
 public class CheckAnswers : PageModel
 {
-    private IIdentityLinkGenerator _linkGenerator;
+    private readonly IIdentityLinkGenerator _linkGenerator;
+    private readonly TeacherIdentityServerDbContext _dbContext;
+    private readonly IClock _clock;
 
-    public CheckAnswers(IIdentityLinkGenerator linkGenerator)
+    public CheckAnswers(
+        IIdentityLinkGenerator linkGenerator,
+        TeacherIdentityServerDbContext dbContext,
+        IClock clock)
     {
         _linkGenerator = linkGenerator;
+        _dbContext = dbContext;
+        _clock = clock;
     }
 
     public string BackLink => (HttpContext.GetAuthenticationState().HaveIttProvider == true)
@@ -31,8 +43,48 @@ public class CheckAnswers : PageModel
     {
     }
 
-    public void OnPost()
+    public async Task<IActionResult> OnPost()
     {
+        var authenticationState = HttpContext.GetAuthenticationState();
+
+        var userId = Guid.NewGuid();
+        var user = new User()
+        {
+            CompletedTrnLookup = _clock.UtcNow,
+            Created = _clock.UtcNow,
+            DateOfBirth = authenticationState.DateOfBirth,
+            EmailAddress = authenticationState.EmailAddress!,
+            FirstName = string.IsNullOrEmpty(authenticationState.FirstName) ? authenticationState.OfficialFirstName! : authenticationState.FirstName,
+            LastName = string.IsNullOrEmpty(authenticationState.LastName) ? authenticationState.OfficialLastName! : authenticationState.LastName,
+            Updated = _clock.UtcNow,
+            UserId = userId,
+            UserType = UserType.Default,
+            Trn = authenticationState.StatedTrn,
+            TrnAssociationSource = !string.IsNullOrEmpty(authenticationState.Trn) ? TrnAssociationSource.Lookup : null,
+            LastSignedIn = _clock.UtcNow,
+            RegisteredWithClientId = authenticationState.OAuthState?.ClientId,
+            TrnLookupStatus = !string.IsNullOrEmpty(authenticationState.Trn) ? TrnLookupStatus.Found : TrnLookupStatus.None
+        };
+
+        _dbContext.Users.Add(user);
+
+        _dbContext.AddEvent(new Events.UserRegisteredEvent()
+        {
+            ClientId = authenticationState.OAuthState?.ClientId,
+            CreatedUtc = _clock.UtcNow,
+            User = user
+        });
+
+        try
+        {
+            await _dbContext.SaveChangesAsync();
+        }
+        catch (DbUpdateException dex) when (dex.IsUniqueIndexViolation("ix_users_email_address"))
+        {
+            return Redirect(_linkGenerator.TrnInUseChooseEmail());
+        }
+
+        return Redirect(authenticationState.GetNextHopUrl(_linkGenerator));
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
@@ -42,7 +94,7 @@ public class CheckAnswers : PageModel
         // We expect to have a verified email and official names at this point but we shouldn't have completed the TRN lookup
         if (string.IsNullOrEmpty(authenticationState.EmailAddress) ||
             !authenticationState.EmailAddressVerified ||
-            !authenticationState.HasOfficialName() ||
+            string.IsNullOrEmpty(authenticationState.GetOfficialName()) ||
             authenticationState.HaveCompletedTrnLookup)
         {
             context.Result = new RedirectResult(authenticationState.GetNextHopUrl(_linkGenerator));

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/CheckAnswers.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/CheckAnswers.cshtml.cs
@@ -1,11 +1,8 @@
-using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Models;
-using TeacherIdentity.AuthServer.Models.Mappings;
-using TeacherIdentity.AuthServer.Services.EmailVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Trn;
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/DateOfBirthPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/DateOfBirthPage.cshtml.cs
@@ -45,7 +45,7 @@ public class DateOfBirthPage : TrnLookupPageModel
         // We expect to have a verified email and official names at this point but we shouldn't have completed the TRN lookup
         if (string.IsNullOrEmpty(authenticationState.EmailAddress) ||
             !authenticationState.EmailAddressVerified ||
-            !authenticationState.HasOfficialName() ||
+            string.IsNullOrEmpty(authenticationState.GetOfficialName()) ||
             authenticationState.HaveCompletedTrnLookup)
         {
             context.Result = new RedirectResult(authenticationState.GetNextHopUrl(LinkGenerator));

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/HaveNiNumber.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/HaveNiNumber.cshtml.cs
@@ -46,7 +46,7 @@ public class HaveNiNumber : TrnLookupPageModel
         // We expect to have a verified email and official names at this point but we shouldn't have completed the TRN lookup
         if (string.IsNullOrEmpty(authenticationState.EmailAddress) ||
             !authenticationState.EmailAddressVerified ||
-            !authenticationState.HasOfficialName() ||
+            string.IsNullOrEmpty(authenticationState.GetOfficialName()) ||
             authenticationState.HaveCompletedTrnLookup)
         {
             context.Result = new RedirectResult(authenticationState.GetNextHopUrl(LinkGenerator));

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/IttProvider.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/IttProvider.cshtml.cs
@@ -62,7 +62,7 @@ public class IttProvider : TrnLookupPageModel
         // We expect to have a verified email and official names at this point but we shouldn't have completed the TRN lookup
         if (string.IsNullOrEmpty(authenticationState.EmailAddress) ||
             !authenticationState.EmailAddressVerified ||
-            !authenticationState.HasOfficialName() ||
+            string.IsNullOrEmpty(authenticationState.GetOfficialName()) ||
             authenticationState.HaveCompletedTrnLookup)
         {
             context.Result = new RedirectResult(authenticationState.GetNextHopUrl(LinkGenerator));

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/NiNumberPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/NiNumberPage.cshtml.cs
@@ -52,7 +52,7 @@ public class NiNumberPage : TrnLookupPageModel
         // We expect to have a verified email and official names at this point but we shouldn't have completed the TRN lookup
         if (string.IsNullOrEmpty(authenticationState.EmailAddress) ||
             !authenticationState.EmailAddressVerified ||
-            !authenticationState.HasOfficialName() ||
+            string.IsNullOrEmpty(authenticationState.GetOfficialName()) ||
             authenticationState.HaveCompletedTrnLookup)
         {
             context.Result = new RedirectResult(authenticationState.GetNextHopUrl(LinkGenerator));

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/PreferredName.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/PreferredName.cshtml.cs
@@ -59,7 +59,7 @@ public class PreferredName : PageModel
         // We expect to have a verified email and official names at this point but we shouldn't have completed the TRN lookup
         if (string.IsNullOrEmpty(authenticationState.EmailAddress) ||
             !authenticationState.EmailAddressVerified ||
-            !authenticationState.HasOfficialName() ||
+            string.IsNullOrEmpty(authenticationState.GetOfficialName()) ||
             authenticationState.HaveCompletedTrnLookup)
         {
             context.Result = new RedirectResult(authenticationState.GetNextHopUrl(_linkGenerator));

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/CheckAnswersTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/CheckAnswersTests.cs
@@ -1,3 +1,5 @@
+using Microsoft.EntityFrameworkCore;
+
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Trn;
 
 public class CheckAnswersTests : TestBase
@@ -290,5 +292,64 @@ public class CheckAnswersTests : TestBase
 
         var doc = await response.GetDocument();
         Assert.Null(doc.GetSummaryListRowForKey("Did a university, SCITT or school award your QTS?"));
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_CreatesUserRedirectsToNextHop()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.DateOfBirthSet());
+
+        authStateHelper.AuthenticationState.OnAwardedQtsSet(false);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/check-answers?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal(authStateHelper.GetNextHopUrl(), response.Headers.Location?.OriginalString);
+
+        await TestData.WithDbContext(async dbContext =>
+        {
+            var user = await dbContext.Users.Where(u => u.EmailAddress == authStateHelper.AuthenticationState.EmailAddress).SingleOrDefaultAsync();
+            Assert.NotNull(user);
+            Assert.Equal(authStateHelper.AuthenticationState.OfficialFirstName, user.FirstName);
+        });
+    }
+
+    [Fact]
+    public async Task Post_ValidRequestEmailAlreadyAssigned_DoesNotCreateUserRedirectsToTrnChooseEmail()
+    {
+        // Arrange
+        var existingUserWithEmail = await TestData.CreateUser(email: Faker.Internet.Email());
+
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.DateOfBirthSet(
+            email: existingUserWithEmail.EmailAddress,
+            officialFirstName: existingUserWithEmail.FirstName + "new"));
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/check-answers?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/trn/choose-email", response.Headers.Location?.OriginalString);
+
+        await TestData.WithDbContext(async dbContext =>
+        {
+            var user = await dbContext.Users.Where(u => u.EmailAddress == authStateHelper.AuthenticationState.EmailAddress).SingleOrDefaultAsync();
+            Assert.NotNull(user);
+            Assert.NotEqual(authStateHelper.AuthenticationState.OfficialFirstName, user.FirstName);
+            Assert.Equal(existingUserWithEmail.FirstName, user.FirstName);
+        });
     }
 }


### PR DESCRIPTION
### Context

As a user
I want to create an Identity account
So that I can sign in to Teacher Services services

### Changes proposed in this pull request

When a user clicks Continue on the Check Answers page, create a User record and save it into the Identity database.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
