### PR TITLE
Add admin no trn page to mark user as not in DQT

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/NoTrn.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/NoTrn.cshtml
@@ -1,0 +1,24 @@
+@page "/admin/users/{userId}/no-trn"
+@model TeacherIdentity.AuthServer.Pages.Admin.AssignTrn.NoTrn
+@{
+    ViewBag.Title = @Html.DisplayNameFor(m => m.HasNoTrn);
+}
+
+@section BeforeContent {
+    <govuk-back-link asp-page="/Admin/User" asp-route-userId="@Model.UserId" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <form asp-page="NoTrn" asp-route-userId="@Model.UserId">
+            <govuk-checkboxes asp-for="HasNoTrn">
+                <govuk-checkboxes-fieldset>
+                    <govuk-checkboxes-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--xl"/>
+                    <govuk-checkboxes-item value="@true">User is not in DQT</govuk-checkboxes-item>
+                </govuk-checkboxes-fieldset>
+            </govuk-checkboxes>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Trn.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Trn.cshtml.cs
@@ -25,7 +25,7 @@ public class TrnModel : PageModel
     [BindProperty]
     [Display(Name = "What is their teacher reference number (TRN)?")]
     [Required(ErrorMessage = "Enter a TRN")]
-    [RegularExpression(@"\A\D*(\d{1}\D*){7}\D*\Z", ErrorMessage = "TRN must be 7 digits")]
+    [RegularExpression(@"^\d{7}$", ErrorMessage = "TRN must be 7 digits")]
     public string? Trn { get; set; }
 
     [FromRoute]

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Users.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Users.cshtml
@@ -26,7 +26,7 @@
                     @foreach (var user in Model.Open!)
                     {
                         <tr class="govuk-table__row" data-testid="user-@user.UserId">
-                            <td class="govuk-table__cell"><a asp-page="EditUser" asp-route-userId="@user.UserId">@user.Name</a></td>
+                            <td class="govuk-table__cell"><a asp-page="User" asp-route-userId="@user.UserId">@user.Name</a></td>
                             <td class="govuk-table__cell">@user.EmailAddress</td>
                             <td class="govuk-table__cell"><a asp-page="AssignTrn/Trn" asp-route-userId="@user.UserId">Add a DQT record</a></td>
                         </tr>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Users.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Users.cshtml
@@ -20,6 +20,7 @@
                         <th scope="col" class="govuk-table__header">Name</th>
                         <th scope="col" class="govuk-table__header">Email</th>
                         <th scope="col" class="govuk-table__header"></th>
+                        <th scope="col" class="govuk-table__header"></th>
                     </tr>
                 </thead>
                 <tbody class="govuk-table__body">
@@ -29,6 +30,7 @@
                             <td class="govuk-table__cell"><a asp-page="User" asp-route-userId="@user.UserId">@user.Name</a></td>
                             <td class="govuk-table__cell">@user.EmailAddress</td>
                             <td class="govuk-table__cell"><a asp-page="AssignTrn/Trn" asp-route-userId="@user.UserId">Add a DQT record</a></td>
+                            <td class="govuk-table__cell"><a asp-page="AssignTrn/NoTrn" asp-route-userId="@user.UserId">Mark as non DQT</a></td>
                         </tr>
                     }
                 </tbody>

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AssignTrn/NoTrnTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AssignTrn/NoTrnTests.cs
@@ -1,0 +1,181 @@
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Admin.AssignTrn;
+
+public class NoTrnTests : TestBase
+{
+    public NoTrnTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_UnauthenticatedUser_RedirectsToSignIn()
+    {
+        var user = await TestData.CreateUser(userType: UserType.Default, hasTrn: false);
+
+        await UnauthenticatedUser_RedirectsToSignIn(HttpMethod.Get, $"/admin/users/{user.UserId}/no-trn");
+    }
+
+    [Fact]
+    public async Task Get_AuthenticatedUserDoesNotHavePermission_ReturnsForbidden()
+    {
+        var user = await TestData.CreateUser(userType: UserType.Default, hasTrn: false);
+
+        await AuthenticatedUserDoesNotHavePermission_ReturnsForbidden(HttpMethod.Get, $"/admin/users/{user.UserId}/no-trn");
+    }
+
+    [Fact]
+    public async Task Get_UserDoesNotExist_ReturnsNotFound()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/users/{userId}/no-trn");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_UserAlreadyHasTrnAssigned_ReturnsBadRequest()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default, hasTrn: true);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/users/{user.UserId}/no-trn");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_ReturnsOk()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default, hasTrn: false);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/users/{user.UserId}/no-trn");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_UnauthenticatedUser_RedirectsToSignIn()
+    {
+        var user = await TestData.CreateUser(userType: UserType.Default, hasTrn: false);
+
+        await UnauthenticatedUser_RedirectsToSignIn(HttpMethod.Post, $"/admin/users/{user.UserId}/no-trn");
+    }
+
+    [Fact]
+    public async Task Post_AuthenticatedUserDoesNotHavePermission_ReturnsForbidden()
+    {
+        var user = await TestData.CreateUser(userType: UserType.Default, hasTrn: false);
+
+        await AuthenticatedUserDoesNotHavePermission_ReturnsForbidden(HttpMethod.Post, $"/admin/users/{user.UserId}/no-trn");
+    }
+
+    [Fact]
+    public async Task Post_UserDoesNotExist_ReturnsNotFound()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{userId}/no-trn");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_UserAlreadyHasTrnAssigned_ReturnsBadRequest()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default, hasTrn: true);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{user.UserId}/no-trn");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_NullHasNoTrn_DoesNotUpdateUserRedirectsToUserPage()
+    {
+
+        var user = await TestData.CreateUser(userType: UserType.Default, hasTrn: false, trnLookupStatus: TrnLookupStatus.Pending);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{user.UserId}/no-trn");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/admin/users/{user.UserId}", response.Headers.Location?.OriginalString);
+
+        await TestData.WithDbContext(async dbContext =>
+        {
+            user = await dbContext.Users.SingleAsync(u => u.UserId == user.UserId);
+            Assert.Null(user.Trn);
+            Assert.Null(user.TrnAssociationSource);
+            Assert.Equal(TrnLookupStatus.Pending, user.TrnLookupStatus);
+            Assert.Equal(user.Created, user.Updated);
+        });
+    }
+
+    [Fact]
+    public async Task Post_HasNoTrnTrue_UpdatesUserEmitsEventAndRedirects()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default, hasTrn: false, trnLookupStatus: TrnLookupStatus.Pending);
+        var trn = TestData.GenerateTrn();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{user.UserId}/no-trn")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "HasNoTrn", bool.TrueString }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/admin/users/{user.UserId}", response.Headers.Location?.OriginalString);
+
+        await TestData.WithDbContext(async dbContext =>
+        {
+            user = await dbContext.Users.SingleAsync(u => u.UserId == user.UserId);
+            Assert.Null(user.Trn);
+            Assert.Equal(TrnAssociationSource.SupportUi, user.TrnAssociationSource);
+            Assert.Equal(TrnLookupStatus.Failed, user.TrnLookupStatus);
+            Assert.Equal(Clock.UtcNow, user.Updated);
+        });
+
+        EventObserver.AssertEventsSaved(
+            e =>
+            {
+                var userUpdatedEvent = Assert.IsType<UserUpdatedEvent>(e);
+                Assert.Equal(Clock.UtcNow, userUpdatedEvent.CreatedUtc);
+                Assert.Equal(UserUpdatedEventSource.SupportUi, userUpdatedEvent.Source);
+                Assert.Equal(UserUpdatedEventChanges.TrnLookupStatus, userUpdatedEvent.Changes);
+                Assert.Equal(user.UserId, userUpdatedEvent.User.UserId);
+            });
+    }
+}


### PR DESCRIPTION
### Context

As a TRA helpdesk agent
I want to record that I have searched for a user in DQT but not found a match
So that NPQ can be informed that the user does not have a TRN

### Changes proposed in this pull request

Add no TRN page. When user marked as not in DQT, update TRN lookup status

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
