### PR TITLE
Add utility function to import test users from CSV

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.DevBootstrap/Csv/UserReaderMap.cs
+++ b/dotnet-authserver/src/TeacherIdentity.DevBootstrap/Csv/UserReaderMap.cs
@@ -1,0 +1,20 @@
+using CsvHelper.Configuration;
+using TeacherIdentity.AuthServer.Models;
+
+namespace WorkforceDataApi.DevUtils.Csv;
+
+internal class UserReaderMap : ClassMap<User>
+{
+    public UserReaderMap()
+    {
+        Map(i => i.UserId).Index(0);
+        Map(i => i.EmailAddress).Index(1);
+        Map(i => i.FirstName).Index(2);
+        Map(i => i.LastName).Index(3);
+        Map(i => i.DateOfBirth).Index(4).TypeConverterOption.Format("ddMMyyyy");
+        Map(i => i.UserType).Index(5);
+        Map(i => i.Trn).Index(6);
+        Map(i => i.Created).Convert(row => DateTime.UtcNow);
+        Map(i => i.Updated).Convert(row => DateTime.UtcNow);
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.DevBootstrap/Csv/UserReaderMap.cs
+++ b/dotnet-authserver/src/TeacherIdentity.DevBootstrap/Csv/UserReaderMap.cs
@@ -1,7 +1,7 @@
 using CsvHelper.Configuration;
 using TeacherIdentity.AuthServer.Models;
 
-namespace WorkforceDataApi.DevUtils.Csv;
+namespace TeacherIdentity.DevBootstrap.Csv;
 
 internal class UserReaderMap : ClassMap<User>
 {
@@ -12,7 +12,7 @@ internal class UserReaderMap : ClassMap<User>
         Map(i => i.FirstName).Index(2);
         Map(i => i.LastName).Index(3);
         Map(i => i.DateOfBirth).Index(4).TypeConverterOption.Format("ddMMyyyy");
-        Map(i => i.UserType).Index(5);
+        Map(i => i.UserType).Constant(UserType.Teacher);
         Map(i => i.Trn).Index(6);
         Map(i => i.Created).Convert(row => DateTime.UtcNow);
         Map(i => i.Updated).Convert(row => DateTime.UtcNow);

--- a/dotnet-authserver/src/TeacherIdentity.DevBootstrap/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.DevBootstrap/Program.cs
@@ -1,15 +1,15 @@
 using System.Globalization;
 using Bogus;
-using CsvHelper.Configuration;
 using CsvHelper;
+using CsvHelper.Configuration;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using TeacherIdentity.AuthServer.EventProcessing;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Oidc;
-using static Bogus.DataSets.Name;
 using WorkforceDataApi.DevUtils.Csv;
+using static Bogus.DataSets.Name;
 
 var configuration = new ConfigurationManager();
 

--- a/dotnet-authserver/src/TeacherIdentity.DevBootstrap/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.DevBootstrap/Program.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.DependencyInjection;
 using TeacherIdentity.AuthServer.EventProcessing;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Oidc;
-using WorkforceDataApi.DevUtils.Csv;
+using TeacherIdentity.DevBootstrap.Csv;
 using static Bogus.DataSets.Name;
 
 var configuration = new ConfigurationManager();

--- a/dotnet-authserver/src/TeacherIdentity.DevBootstrap/Properties/launchSettings.json
+++ b/dotnet-authserver/src/TeacherIdentity.DevBootstrap/Properties/launchSettings.json
@@ -7,6 +7,10 @@
     "TeacherIdentity.DevBootstrap Generate Test Users": {
       "commandName": "Project",
       "commandLineArgs": "--environment Local --generate-test-users"
+    },
+    "TeacherIdentity.DevBootstrap Import Test Users": {
+      "commandName": "Project",
+      "commandLineArgs": "--environment Local --import-test-users"
     }
   }
 }

--- a/dotnet-authserver/src/TeacherIdentity.DevBootstrap/TeacherIdentity.DevBootstrap.csproj
+++ b/dotnet-authserver/src/TeacherIdentity.DevBootstrap/TeacherIdentity.DevBootstrap.csproj
@@ -15,6 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Bogus" Version="34.0.2" />
+    <PackageReference Include="CsvHelper" Version="30.0.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
### Context

This branch was started with the intent of adding support for securing workforce data within identity.
This work will now be parked until we have decided if workforce data will be part of identity itself.  

### Changes proposed in this pull request

The only changes in this pull request are within the DevBootstrap utility.
They allow a developer to import multiple identity users using a pre-populated CSV file (as generated by the workforce data mock data generator).

### Guidance to review

Only affects TeacherIdentity.DevBootstrap.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x ] Cleaned commit history
-   [x] Tested by running locally
-   [x] Reminder created to manually clean any removed app settings post deployment
