### PR TITLE
Add FirstTimeUser property to analytics event for Complete page

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Complete.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Complete.cshtml.cs
@@ -1,3 +1,4 @@
+using Dfe.Analytics.AspNetCore;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.State;
@@ -42,5 +43,7 @@ public class CompleteModel : PageModel
         Trn = authenticationState.Trn;
         AlreadyCompleted = authenticationState.HaveResumedCompletedJourney;
         UserType = authenticationState.UserType!.Value;
+
+        HttpContext.Features.Get<WebRequestEventFeature>()?.Event.AddTag(FirstTimeSignInForEmail ? "FirstTimeUser" : "ReturningUser");
     }
 }


### PR DESCRIPTION
### Context

In analytics we want to be able to differentiate between newly-registered and returning users completing the authorization journey.

### Changes proposed in this pull request

Add a `FirstTimeUser` data property to the Analytics event in the Complete page.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
