### PR TITLE
Set HasPreviousNameOption via OnOfficialNameSet method

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -7,7 +7,6 @@ using Flurl;
 using TeacherIdentity.AuthServer.Infrastructure.Json;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Oidc;
-using TeacherIdentity.AuthServer.Pages.SignIn.Trn;
 using static OpenIddict.Abstractions.OpenIddictConstants;
 
 namespace TeacherIdentity.AuthServer;
@@ -99,8 +98,7 @@ public class AuthenticationState
     [JsonInclude]
     public string? StatedTrn { get; private set; }
     [JsonInclude]
-    public OfficialName.HasPreviousNameOption? HasPreviousName { get; private set; }
-
+    public HasPreviousNameOption? HasPreviousName { get; private set; }
 
     /// <summary>
     /// Whether the user has gone back to an earlier page after this journey has been completed.
@@ -417,11 +415,13 @@ public class AuthenticationState
     public void OnOfficialNameSet(
         string officialFirstName,
         string officialLastName,
+        HasPreviousNameOption hasPreviousName,
         string? previousOfficialFirstName,
         string? previousOfficialLastName)
     {
         OfficialFirstName = officialFirstName;
         OfficialLastName = officialLastName;
+        HasPreviousName = hasPreviousName;
         PreviousOfficialFirstName = previousOfficialFirstName;
         PreviousOfficialLastName = previousOfficialLastName;
     }
@@ -477,17 +477,6 @@ public class AuthenticationState
     {
         HasTrn = trn is not null;
         StatedTrn = trn;
-    }
-
-    public void OnHasPreviousNameSet(OfficialName.HasPreviousNameOption? hasPreviousName)
-    {
-        if (hasPreviousName == OfficialName.HasPreviousNameOption.No)
-        {
-            PreviousOfficialFirstName = null;
-            PreviousOfficialLastName = null;
-        }
-
-        HasPreviousName = hasPreviousName;
     }
 
     public void OnHaveResumedCompletedJourney()
@@ -554,6 +543,13 @@ public class AuthenticationState
 
         var claims = GetInternalClaims();
         await httpContext.SignInCookies(claims, resetIssued: true, AuthCookieLifetime);
+    }
+
+    public enum HasPreviousNameOption
+    {
+        Yes,
+        No,
+        PreferNotToSay
     }
 
     public enum TrnLookupState

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/OfficialName.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/OfficialName.cshtml
@@ -1,5 +1,5 @@
 @page "/sign-in/trn/official-name"
-@using TeacherIdentity.AuthServer.Pages.SignIn.Trn
+@using static TeacherIdentity.AuthServer.AuthenticationState
 @model TeacherIdentity.AuthServer.Pages.SignIn.Trn.OfficialName
 @{
     ViewBag.Title = "What’s your name?";
@@ -30,8 +30,8 @@
                         Have you ever changed your name?
                     </govuk-radios-fieldset-legend>
 
-                    <govuk-radios-item value="@OfficialName.HasPreviousNameOption.No">No</govuk-radios-item>
-                    <govuk-radios-item value="@OfficialName.HasPreviousNameOption.Yes">Yes
+                    <govuk-radios-item value="@HasPreviousNameOption.No">No</govuk-radios-item>
+                    <govuk-radios-item value="@HasPreviousNameOption.Yes">Yes
                         <govuk-radios-item-conditional>
                             <h2 class="govuk-heading-m">What was your previous name?</h2>
                             <p>You do not have to tell us your previous name, but it will help us identify you.</p>
@@ -45,7 +45,7 @@
                             </govuk-input>
                         </govuk-radios-item-conditional>
                     </govuk-radios-item>
-                    <govuk-radios-item value="@OfficialName.HasPreviousNameOption.PreferNotToSay">Prefer not to say</govuk-radios-item>
+                    <govuk-radios-item value="@HasPreviousNameOption.PreferNotToSay">Prefer not to say</govuk-radios-item>
                 </govuk-radios-fieldset>
             </govuk-radios>
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/OfficialName.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/OfficialName.cshtml.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using static TeacherIdentity.AuthServer.AuthenticationState;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Trn;
 
@@ -40,11 +41,10 @@ public class OfficialName : TrnLookupPageModel
             return this.PageWithErrors();
         }
 
-        HttpContext.GetAuthenticationState().OnHasPreviousNameSet((HasPreviousNameOption)HasPreviousName!);
-
         HttpContext.GetAuthenticationState().OnOfficialNameSet(
             OfficialFirstName!,
             OfficialLastName!,
+            (HasPreviousNameOption)HasPreviousName!,
             HasPreviousName == HasPreviousNameOption.Yes ? PreviousOfficialFirstName : null,
             HasPreviousName == HasPreviousNameOption.Yes ? PreviousOfficialLastName : null);
 
@@ -62,13 +62,6 @@ public class OfficialName : TrnLookupPageModel
         {
             context.Result = new RedirectResult(authenticationState.GetNextHopUrl(LinkGenerator));
         }
-    }
-
-    public enum HasPreviousNameOption
-    {
-        Yes,
-        No,
-        PreferNotToSay
     }
 
     private void SetDefaultInputValues()

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
@@ -125,6 +125,7 @@ public sealed class AuthenticationStateHelper
                 s.OnOfficialNameSet(
                     officialFirstName ?? Faker.Name.First(),
                     officialLastName ?? Faker.Name.Last(),
+                    previousOfficialFirstName is not null ? AuthenticationState.HasPreviousNameOption.Yes : AuthenticationState.HasPreviousNameOption.No,
                     previousOfficialFirstName,
                     previousOfficialLastName);
             };

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/CheckAnswersTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/CheckAnswersTests.cs
@@ -64,10 +64,10 @@ public class CheckAnswersTests : TestBase
         var previousFirstName = Faker.Name.First();
         var previousLastName = Faker.Name.Last();
 
-        authState.OnHasPreviousNameSet(Pages.SignIn.Trn.OfficialName.HasPreviousNameOption.Yes);
         authState.OnOfficialNameSet(
             authState.OfficialFirstName!,
             authState.OfficialLastName!,
+            AuthenticationState.HasPreviousNameOption.Yes,
             previousFirstName,
             previousLastName);
 
@@ -93,10 +93,10 @@ public class CheckAnswersTests : TestBase
         var previousFirstName = Faker.Name.First();
         var previousLastName = Faker.Name.Last();
 
-        authState.OnHasPreviousNameSet(Pages.SignIn.Trn.OfficialName.HasPreviousNameOption.Yes);
         authState.OnOfficialNameSet(
             authState.OfficialFirstName!,
             authState.OfficialLastName!,
+            AuthenticationState.HasPreviousNameOption.Yes,
             previousOfficialFirstName: null,
             previousOfficialLastName: null);
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/NoMatchTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/NoMatchTests.cs
@@ -68,10 +68,10 @@ public class NoMatchTests : TestBase
         var previousFirstName = Faker.Name.First();
         var previousLastName = Faker.Name.Last();
 
-        authState.OnHasPreviousNameSet(Pages.SignIn.Trn.OfficialName.HasPreviousNameOption.Yes);
         authState.OnOfficialNameSet(
             authState.OfficialFirstName!,
             authState.OfficialLastName!,
+            AuthenticationState.HasPreviousNameOption.Yes,
             previousFirstName,
             previousLastName);
         authState.OnTrnLookupCompleted(trn: null, TrnLookupStatus.Pending);
@@ -98,10 +98,10 @@ public class NoMatchTests : TestBase
         var previousFirstName = Faker.Name.First();
         var previousLastName = Faker.Name.Last();
 
-        authState.OnHasPreviousNameSet(Pages.SignIn.Trn.OfficialName.HasPreviousNameOption.Yes);
         authState.OnOfficialNameSet(
             authState.OfficialFirstName!,
             authState.OfficialLastName!,
+            AuthenticationState.HasPreviousNameOption.No,
             previousOfficialFirstName: null,
             previousOfficialLastName: null);
         authState.OnTrnLookupCompleted(trn: null, TrnLookupStatus.Pending);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/OfficialNameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/OfficialNameTests.cs
@@ -1,5 +1,3 @@
-using TeacherIdentity.AuthServer.Pages.SignIn.Trn;
-
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Trn;
 
 [Collection(nameof(DisableParallelization))]  // Relies on mocks
@@ -114,7 +112,7 @@ public class OfficialNameTests : TestBase
             {
                 { "OfficialFirstName", firstName },
                 { "OfficialLastName", lastName },
-                { "HasPreviousName", OfficialName.HasPreviousNameOption.No },
+                { "HasPreviousName", AuthenticationState.HasPreviousNameOption.No },
             }
         };
 
@@ -147,7 +145,7 @@ public class OfficialNameTests : TestBase
                 { "OfficialLastName", "last" },
                 { "PreviousOfficialFirstName", previousFirstName },
                 { "PreviousOfficialLastName", previousLastName },
-                { "HasPreviousName", hasPreviousName ? OfficialName.HasPreviousNameOption.Yes : OfficialName.HasPreviousNameOption.No },
+                { "HasPreviousName", hasPreviousName ? AuthenticationState.HasPreviousNameOption.Yes : AuthenticationState.HasPreviousNameOption.No },
             }
         };
 
@@ -182,7 +180,7 @@ public class OfficialNameTests : TestBase
             {
                 { "OfficialFirstName", "first" },
                 { "OfficialLastName", "last" },
-                { "HasPreviousName", OfficialName.HasPreviousNameOption.No },
+                { "HasPreviousName", AuthenticationState.HasPreviousNameOption.No },
             }
         };
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/TrnLookupHelperTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/TrnLookupHelperTests.cs
@@ -313,7 +313,12 @@ public class TrnLookupHelperTests
         authState.OnEmailSet(Faker.Internet.Email());
         authState.OnEmailVerified();
         authState.OnHasTrnSet(statedTrn);
-        authState.OnOfficialNameSet(Faker.Name.First(), Faker.Name.Last(), previousOfficialFirstName: null, previousOfficialLastName: null);
+        authState.OnOfficialNameSet(
+            Faker.Name.First(),
+            Faker.Name.Last(),
+            AuthenticationState.HasPreviousNameOption.No,
+            previousOfficialFirstName: null,
+            previousOfficialLastName: null);
         authState.OnDateOfBirthSet(DateOnly.FromDateTime(Faker.Identification.DateOfBirth()));
         authState.OnAwardedQtsSet(awardedQts);
 


### PR DESCRIPTION
### Context

We've converged on a pattern where each page sets the data on `AuthenticationState` via a single `OnXxxSet` method. The only place left where we had two calls that set state from a single page is on the `OfficialName` page.

### Changes proposed in this pull request

Move the `HasPreviousNameOption` onto the `OnOfficialNameSet` method. Also moves the `HasPreviousNameOption` enum into `AuthenticationState`'s namespace.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
