### PR TITLE
Add missing properties to Reset method

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -99,7 +99,6 @@ public class AuthenticationState
     public string? StatedTrn { get; private set; }
     [JsonInclude]
     public HasPreviousNameOption? HasPreviousName { get; private set; }
-
     /// <summary>
     /// Whether the user has gone back to an earlier page after this journey has been completed.
     /// </summary>
@@ -228,6 +227,10 @@ public class AuthenticationState
         EmailAddressVerified = default;
         FirstName = default;
         LastName = default;
+        OfficialFirstName = default;
+        OfficialLastName = default;
+        PreviousOfficialFirstName = default;
+        PreviousOfficialLastName = default;
         DateOfBirth = default;
         Trn = default;
         UserType = default;
@@ -236,6 +239,13 @@ public class AuthenticationState
         TrnLookup = default;
         TrnOwnerEmailAddress = default;
         TrnLookupStatus = default;
+        HaveNationalInsuranceNumber = default;
+        NationalInsuranceNumber = default;
+        AwardedQts = default;
+        HaveIttProvider = default;
+        HasTrn = default;
+        StatedTrn = default;
+        HasPreviousName = default;
     }
 
     public void OnEmailSet(string email)


### PR DESCRIPTION
### Context

When an authentication journey expires we reset it to an empty state so the user has to begin again. We were missing a few properties from the `Reset()` method so we weren't completely clearing out state.

### Changes proposed in this pull request

Add missing properties to the `Reset()` method on `AuthenticationState`.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
