### PR TITLE
Ensure email prefix valid for TRN Sign-In journey

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Email.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Email.cshtml.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel.DataAnnotations;
-using Microsoft.EntityFrameworkCore;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Services.EmailVerification;
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Email.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Email.cshtml.cs
@@ -36,6 +36,12 @@ public class EmailModel : PageModel
             return this.PageWithErrors();
         }
 
+        if (_invalidEmailPrefixes.Contains(Email!.Split("@")[0]))
+        {
+            ModelState.AddModelError(nameof(Email), "Enter a personal email address. It cannot be one that other people may get access to.");
+            return this.PageWithErrors();
+        }
+
         HttpContext.GetAuthenticationState().OnEmailSet(Email!);
 
         var pinGenerationResult = await _emailVerificationService.GeneratePin(Email!);
@@ -56,4 +62,48 @@ public class EmailModel : PageModel
 
         return Redirect(_linkGenerator.EmailConfirmation());
     }
+
+    private static readonly string[] _invalidEmailPrefixes = new[]
+    {
+        "headteacher",
+        "head.teacher",
+        "head",
+        "ht",
+        "principal",
+        "headofschool",
+        "headmistress",
+        "info",
+        "office",
+        "office1",
+        "reception",
+        "secretary",
+        "admin",
+        "admin1",
+        "admin2",
+        "administration",
+        "adminoffice",
+        "schooloffice",
+        "schoolmanager",
+        "enquiries",
+        "enquiry",
+        "generalenquiries",
+        "post",
+        "pa",
+        "headspa",
+        "headteacherpa",
+        "contact",
+        "school",
+        "academy",
+        "bursar",
+        "finance",
+        "hr",
+        "secretary",
+        "businessmanager",
+        "deputy",
+        "deputyhead",
+        "exechead",
+        "ceo",
+        "cfo",
+        "coo"
+    };
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailTests.cs
@@ -142,6 +142,28 @@ public class EmailTests : TestBase
     }
 
     [Theory]
+    [InlineData("admin")]
+    [InlineData("academy")]
+    public async Task Post_EmailWithInvalidPrefix_ReturnsError(string emailPrefix)
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Email", $"{emailPrefix}@foo.com" }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Email", "Enter a personal email address. It cannot be one that other people may get access to.");
+    }
+
+    [Theory]
     [InlineData(true)]
     [InlineData(false)]
     public async Task Post_ValidEmail_SetsEmailOnAuthenticationStateGeneratesPinAndRedirectsToConfirmation(bool emailIsKnown)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailTests.cs
@@ -163,6 +163,29 @@ public class EmailTests : TestBase
         await AssertEx.HtmlResponseHasError(response, "Email", "Enter a personal email address. It cannot be one that other people may get access to.");
     }
 
+    [Fact]
+    public async Task Post_EmailWithInvalidPrefixAlreadyExists_DoNotReturnError()
+    {
+        // Arrange
+        var invalidPrefix = "headteacher";
+        var user = await TestData.CreateUser(email: $"{invalidPrefix}@foo.com");
+
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Email", user.EmailAddress }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailTests.cs
@@ -147,7 +147,7 @@ public class EmailTests : TestBase
     public async Task Post_EmailWithInvalidPrefix_ReturnsError(string emailPrefix)
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -170,7 +170,7 @@ public class EmailTests : TestBase
         var invalidPrefix = "headteacher";
         var user = await TestData.CreateUser(email: $"{invalidPrefix}@foo.com");
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()


### PR DESCRIPTION
### Context

As an Identity administrator
I want to prevent users signing up with shared email addresses
So that users do not lose access to their account when they change jobs

### Changes proposed in this pull request

Validate supplied Email does not have invalid prefix in list

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [x] Reminder created to manually clean any removed app settings post deployment
