### PR TITLE
Put the new TRN Optional journey behind the dqt:read scope

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -649,10 +649,12 @@ public class AuthenticationState
 
         List<String> ignoredScopes = new List<string>();
         ignoredScopes.AddRange(CustomScopes.StaffUserTypeScopes);
+#pragma warning disable CS0618 // Type or member is obsolete
         ignoredScopes.Add(CustomScopes.Trn);
+#pragma warning restore CS0618 // Type or member is obsolete
         ignoredScopes.Add(CustomScopes.DqtRead);
 
-        return !OAuthState.HasAnyScope(ignoredScopes);
+        return !OAuthState.HasAnyScope(ignoredScopes) && !UserId.HasValue;
     }
 }
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -650,6 +650,7 @@ public class AuthenticationState
         List<String> ignoredScopes = new List<string>();
         ignoredScopes.AddRange(CustomScopes.StaffUserTypeScopes);
         ignoredScopes.Add(CustomScopes.Trn);
+        ignoredScopes.Add(CustomScopes.DqtRead);
 
         return !OAuthState.HasAnyScope(ignoredScopes);
     }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -692,7 +692,9 @@ public class OAuthAuthorizationState
         return $"{new Uri(RedirectUri).GetLeftPart(UriPartial.Authority)}/{serviceUrl.ToString().TrimStart('/')}";
     }
 
-    public bool HasAnyScope(IEnumerable<string> scopes) => Scope.Split(' ').Any(scopes.Contains);
+    public bool HasScope(string scope) => GetScopes().Contains(scope);
+
+    public bool HasAnyScope(IEnumerable<string> scopes) => GetScopes().Any(scopes.Contains);
 
     public void SetAuthorizationResponse(
         IEnumerable<KeyValuePair<string, string>> responseParameters,
@@ -701,4 +703,6 @@ public class OAuthAuthorizationState
         AuthorizationResponseParameters = responseParameters;
         AuthorizationResponseMode = responseMode;
     }
+
+    private HashSet<string> GetScopes() => new(Scope.Split(' '), StringComparer.OrdinalIgnoreCase);
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
@@ -367,10 +367,12 @@ public class AuthorizationController : Controller
 
             case CustomClaims.Trn:
             case CustomClaims.TrnLookupStatus:
+#pragma warning disable CS0618 // Type or member is obsolete
                 if (principal.HasScope(CustomScopes.Trn) || principal.HasScope(CustomScopes.DqtRead))
                 {
                     yield return Destinations.IdentityToken;
                 }
+#pragma warning restore CS0618 // Type or member is obsolete
 
                 yield break;
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
@@ -367,7 +367,7 @@ public class AuthorizationController : Controller
 
             case CustomClaims.Trn:
             case CustomClaims.TrnLookupStatus:
-                if (principal.HasScope(CustomScopes.Trn))
+                if (principal.HasScope(CustomScopes.Trn) || principal.HasScope(CustomScopes.DqtRead))
                 {
                     yield return Destinations.IdentityToken;
                 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Oidc/CustomScopes.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Oidc/CustomScopes.cs
@@ -5,6 +5,7 @@ public static class CustomScopes
     public const string GetAnIdentitySupport = "get-an-identity:support";
     public const string UserRead = "user:read";
     public const string UserWrite = "user:write";
+    public const string DqtRead = "dqt:read";
     public const string Trn = "trn";
 
     public static string[] All => StaffUserTypeScopes.Concat(DefaultUserTypesScopes).ToArray();
@@ -18,6 +19,7 @@ public static class CustomScopes
 
     public static string[] DefaultUserTypesScopes { get; } = new[]
     {
+        DqtRead,
         Trn
     };
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Oidc/CustomScopes.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Oidc/CustomScopes.cs
@@ -6,6 +6,7 @@ public static class CustomScopes
     public const string UserRead = "user:read";
     public const string UserWrite = "user:write";
     public const string DqtRead = "dqt:read";
+    [Obsolete("Use DqtRead instead.")]
     public const string Trn = "trn";
 
     public static string[] All => StaffUserTypeScopes.Concat(DefaultUserTypesScopes).ToArray();
@@ -20,6 +21,8 @@ public static class CustomScopes
     public static string[] DefaultUserTypesScopes { get; } = new[]
     {
         DqtRead,
+#pragma warning disable CS0618 // Type or member is obsolete
         Trn
+#pragma warning restore CS0618 // Type or member is obsolete
     };
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn.cshtml.cs
@@ -1,6 +1,7 @@
 using Flurl;
 using Flurl.Util;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeacherIdentity.AuthServer.Oidc;
 using TeacherIdentity.AuthServer.Services.TrnLookup;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn;
@@ -29,7 +30,7 @@ public class TrnModel : PageModel
     {
         var authenticationState = HttpContext.GetAuthenticationState();
 
-        if (_findALostTrnIntegrationHelper.Options.UseNewTrnLookupJourney)
+        if (authenticationState.OAuthState?.HasScope(CustomScopes.DqtRead) == true)
         {
             var nextPage = _linkGenerator.TrnHasTrn();
             HandoverUrl = new Url(nextPage).RemoveQuery();

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/TrnLookup/FindALostTrnIntegrationOptions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/TrnLookup/FindALostTrnIntegrationOptions.cs
@@ -12,7 +12,4 @@ public class FindALostTrnIntegrationOptions
 
     [Required]
     public required bool EnableStubEndpoints { get; set; }
-
-    [Required]
-    public bool UseNewTrnLookupJourney { get; set; }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/UserClaimHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/UserClaimHelper.cs
@@ -239,7 +239,7 @@ public static class UserClaimHelper
             yield return new Claim(Claims.Birthdate, dateOfBirth!.Value.ToString(CustomClaims.DateFormat));
         }
 
-        if (hasScope(CustomScopes.Trn))
+        if (hasScope(CustomScopes.Trn) || hasScope(CustomScopes.DqtRead))
         {
             yield return new Claim(CustomClaims.TrnLookupStatus, trnLookupStatus!.Value.ToString());
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/UserClaimHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/UserClaimHelper.cs
@@ -239,6 +239,7 @@ public static class UserClaimHelper
             yield return new Claim(Claims.Birthdate, dateOfBirth!.Value.ToString(CustomClaims.DateFormat));
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         if (hasScope(CustomScopes.Trn) || hasScope(CustomScopes.DqtRead))
         {
             yield return new Claim(CustomClaims.TrnLookupStatus, trnLookupStatus!.Value.ToString());
@@ -248,5 +249,6 @@ public static class UserClaimHelper
                 yield return new Claim(CustomClaims.Trn, trn);
             }
         }
+#pragma warning restore CS0618 // Type or member is obsolete
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/UserRequirements.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/UserRequirements.cs
@@ -58,7 +58,7 @@ public static class UserRequirementsExtensions
     {
         userRequirements = UserRequirements.DefaultUserType;
 
-        if (hasScope(CustomScopes.Trn))
+        if (hasScope(CustomScopes.Trn) || hasScope(CustomScopes.DqtRead))
         {
             userRequirements = UserRequirements.DefaultUserType | UserRequirements.TrnHolder;
         }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/UserRequirements.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/UserRequirements.cs
@@ -58,10 +58,12 @@ public static class UserRequirementsExtensions
     {
         userRequirements = UserRequirements.DefaultUserType;
 
+#pragma warning disable CS0618 // Type or member is obsolete
         if (hasScope(CustomScopes.Trn) || hasScope(CustomScopes.DqtRead))
         {
             userRequirements = UserRequirements.DefaultUserType | UserRequirements.TrnHolder;
         }
+#pragma warning restore CS0618 // Type or member is obsolete
 
         if (hasScope(CustomScopes.GetAnIdentitySupport))
         {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Development.json
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Development.json
@@ -18,7 +18,7 @@
         "https://localhost:7261/oidc/signout-callback"
       ],
       "ServiceUrl": "/",
-      "Scopes": [ "trn", "get-an-identity:support", "user:read", "user:write" ],
+      "Scopes": [ "trn", "get-an-identity:support", "user:read", "user:write", "dqt:read" ],
       "PostSignInMessage": "continue with the Test Client"
     },
     {
@@ -41,8 +41,7 @@
   "FindALostTrnIntegration": {
     "HandoverEndpoint": "/FindALostTrn/Identity",
     "SharedKey": "OKqdp0+u8QSzwk5unfZrTRZzqwYJSOuo0pOsOIVhkog=",
-    "EnableStubEndpoints": true,
-    "UseNewTrnLookupJourney": true
+    "EnableStubEndpoints": true
   },
   "AdminCredentials": {
     "Username": "developer",

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Development.json
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Development.json
@@ -27,7 +27,7 @@
       "RedirectUris": [
         "https://localhost:7236/swagger/oauth2-redirect.html"
       ],
-      "Scopes": [ "trn", "get-an-identity:support", "user:read", "user:write" ]
+      "Scopes": [ "trn", "get-an-identity:support", "user:read", "user:write", "dqt:read" ]
     },
     {
       "ClientId": "testcc",

--- a/dotnet-authserver/src/TeacherIdentity.TestClient/Views/Home/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.TestClient/Views/Home/Index.cshtml
@@ -1,5 +1,5 @@
 <form asp-action="Profile" method="get">
-    <govuk-input name="scope" value="email openid profile trn" input-class="govuk-input--width-20">
+    <govuk-input name="scope" value="email openid profile dqt:read" input-class="govuk-input--width-20">
         <govuk-input-label>Scope</govuk-input-label>
     </govuk-input>
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Api.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Api.cs
@@ -47,16 +47,16 @@ public class Api : IClassFixture<HostFixture>
         // Fill in the sign in form (email + PIN)
 
         await page.FillAsync("text=Enter your email address", email);
-        await page.ClickAsync("button:has-text('Continue')");
+        await page.ClickAsync("button:text-is('Continue')");
 
         var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
         await page.FillAsync("text=Enter your code", pin);
-        await page.ClickAsync("button:has-text('Continue')");
+        await page.ClickAsync("button:text-is('Continue')");
 
         // Should now be on the confirmation page
 
         Assert.Equal(1, await page.Locator("data-testid=known-user-content").CountAsync());
-        await page.ClickAsync("button:has-text('Continue')");
+        await page.ClickAsync("button:text-is('Continue')");
 
         // Should now be back at the client, signed in
 
@@ -139,16 +139,16 @@ public class Api : IClassFixture<HostFixture>
         // Fill in the sign in form (email + PIN)
 
         await page.FillAsync("text=Enter your email address", email);
-        await page.ClickAsync("button:has-text('Continue')");
+        await page.ClickAsync("button:text-is('Continue')");
 
         var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
         await page.FillAsync("text=Enter your code", pin);
-        await page.ClickAsync("button:has-text('Continue')");
+        await page.ClickAsync("button:text-is('Continue')");
 
         // Should now be on the confirmation page
 
         Assert.Equal(1, await page.Locator("data-testid=known-user-content").CountAsync());
-        await page.ClickAsync("button:has-text('Continue')");
+        await page.ClickAsync("button:text-is('Continue')");
 
         // Should now be back at the client, signed in
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/HostFixture.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/HostFixture.cs
@@ -1,9 +1,9 @@
 using System.Diagnostics;
-using FakeItEasy;
 using Microsoft.AspNetCore.Authentication.OpenIdConnect;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Playwright;
+using Moq;
 using OpenIddict.Server.AspNetCore;
 using TeacherIdentity.AuthServer.EndToEndTests.Infrastructure;
 using TeacherIdentity.AuthServer.EventProcessing;
@@ -41,7 +41,7 @@ public class HostFixture : IAsyncLifetime
 
     public DbHelper? DbHelper { get; private set; }
 
-    public IDqtApiClient DqtApiClient = A.Fake<IDqtApiClient>();
+    public Mock<IDqtApiClient> DqtApiClient { get; } = new();
 
     public IEmailVerificationService? EmailConfirmationService { get; private set; }
 
@@ -116,7 +116,7 @@ public class HostFixture : IAsyncLifetime
 
     public void OnTestStarting()
     {
-        Fake.ClearRecordedCalls(DqtApiClient);
+        DqtApiClient.Reset();
         EventObserver.Clear();
     }
 
@@ -130,7 +130,7 @@ public class HostFixture : IAsyncLifetime
                 builder.ConfigureServices(services =>
                 {
                     services.Configure<OpenIddictServerAspNetCoreOptions>(options => options.DisableTransportSecurityRequirement = true);
-                    services.AddSingleton<IDqtApiClient>(DqtApiClient);
+                    services.AddSingleton<IDqtApiClient>(DqtApiClient.Object);
                     services.Decorate<IEmailVerificationService>(inner =>
                         new CapturePinsEmailVerificationServiceDecorator(inner, (email, pin) => _capturedEmailConfirmationPins.Add((email, pin))));
                     services.AddSingleton<IEventObserver, CaptureEventObserver>();

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignIn.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignIn.cs
@@ -483,8 +483,7 @@ public class SignIn : IClassFixture<HostFixture>
     {
         // Start on the client app and try to access a protected area
 
-        await page.GotoAsync("/");
-        await page.ClickAsync("text=Profile");
+        await page.GotoAsync("/profile?scope=email+openid+profile+trn");
 
         // Fill in the sign in form (email + PIN)
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignOut.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignOut.cs
@@ -52,16 +52,16 @@ public class SignOut : IClassFixture<HostFixture>
         // Fill in the sign in form (email + PIN)
 
         await page.FillAsync("text=Enter your email address", email);
-        await page.ClickAsync("button:has-text('Continue')");
+        await page.ClickAsync("button:text-is('Continue')");
 
         var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
         await page.FillAsync("text=Enter your code", pin);
-        await page.ClickAsync("button:has-text('Continue')");
+        await page.ClickAsync("button:text-is('Continue')");
 
         // Should now be on the confirmation page
 
         Assert.Equal(1, await page.Locator("data-testid=known-user-content").CountAsync());
-        await page.ClickAsync("button:has-text('Continue')");
+        await page.ClickAsync("button:text-is('Continue')");
 
         // Should now be back at the client, signed in
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/TeacherIdentity.AuthServer.EndToEndTests.csproj
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/TeacherIdentity.AuthServer.EndToEndTests.csproj
@@ -9,11 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FakeItEasy" Version="7.3.1" />
     <PackageReference Include="Faker.Net" Version="2.0.154" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="Microsoft.Playwright" Version="1.28.0" />
+    <PackageReference Include="Moq" Version="4.18.3" />
     <PackageReference Include="xunit" Version="2.4.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/UpdateDetails.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/UpdateDetails.cs
@@ -55,28 +55,28 @@ public class UpdateDetails : IClassFixture<HostFixture>
         // Fill in the sign in form (email + PIN)
 
         await page.FillAsync("text=Enter your email address", email);
-        await page.ClickAsync("button:has-text('Continue')");
+        await page.ClickAsync("button:text-is('Continue')");
 
         var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
         await page.FillAsync("text=Enter your code", pin);
-        await page.ClickAsync("button:has-text('Continue')");
+        await page.ClickAsync("button:text-is('Continue')");
 
         // Confirm your details page
 
-        await page.WaitForSelectorAsync("h1:has-text('Your details')");
+        await page.WaitForSelectorAsync("h1:text-is('Your details')");
         await page.Locator("*:has(> dt:text('Name'))").GetByText("Change").ClickAsync();
 
         // Update your name page
 
-        await page.WaitForSelectorAsync("h1:has-text('Update your name')");
+        await page.WaitForSelectorAsync("h1:text-is('Update your name')");
         await page.FillAsync("text=First name", newFirstName);
         await page.FillAsync("text=Last name", newLastName);
-        await page.ClickAsync("button:has-text('Continue')");
+        await page.ClickAsync("button:text-is('Continue')");
 
         // Confirm your details
 
-        await page.WaitForSelectorAsync("h1:has-text('Your details')");
-        await page.ClickAsync("button:has-text('Continue')");
+        await page.WaitForSelectorAsync("h1:text-is('Your details')");
+        await page.ClickAsync("button:text-is('Continue')");
 
         // Test Client app
 
@@ -131,34 +131,34 @@ public class UpdateDetails : IClassFixture<HostFixture>
         // Fill in the sign in form (email + PIN)
 
         await page.FillAsync("text=Enter your email address", email);
-        await page.ClickAsync("button:has-text('Continue')");
+        await page.ClickAsync("button:text-is('Continue')");
 
         var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
         await page.FillAsync("text=Enter your code", pin);
-        await page.ClickAsync("button:has-text('Continue')");
+        await page.ClickAsync("button:text-is('Continue')");
 
         // Confirm your details page
 
-        await page.WaitForSelectorAsync("h1:has-text('Your details')");
+        await page.WaitForSelectorAsync("h1:text-is('Your details')");
         await page.Locator("*:has(> dt:text('Email address'))").GetByText("Change").ClickAsync();
 
         // Update your email page
 
-        await page.WaitForSelectorAsync("h1:has-text('Change your email address')");
+        await page.WaitForSelectorAsync("h1:text-is('Change your email address')");
         await page.FillAsync("text=Enter your new email address", newEmail);
-        await page.ClickAsync("button:has-text('Continue')");
+        await page.ClickAsync("button:text-is('Continue')");
 
         // Confirm your email address page
 
-        await page.WaitForSelectorAsync("h1:has-text('Confirm your email address')");
+        await page.WaitForSelectorAsync("h1:text-is('Confirm your email address')");
         pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
         await page.FillAsync("text=Enter your code", pin);
-        await page.ClickAsync("button:has-text('Continue')");
+        await page.ClickAsync("button:text-is('Continue')");
 
         // Confirm your details page
 
-        await page.WaitForSelectorAsync("h1:has-text('Your details')");
-        await page.ClickAsync("button:has-text('Continue')");
+        await page.WaitForSelectorAsync("h1:text-is('Your details')");
+        await page.ClickAsync("button:text-is('Continue')");
 
         // Test Client app
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/appsettings.json
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/appsettings.json
@@ -32,7 +32,7 @@
       "PostLogoutRedirectUris": [
         "http://localhost:55342/oidc/signout-callback"
       ],
-      "Scopes": [ "trn", "user:read", "user:write" ]
+      "Scopes": [ "trn", "user:read", "user:write", "dqt:read" ]
     },
     {
       "ClientId": "testcc",

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
@@ -33,7 +33,7 @@ public sealed class AuthenticationStateHelper
         var journeyId = Guid.NewGuid();
         var codeChallenge = Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes("12345")));
         var client = TestClients.Client1;
-        var fullScope = $"email profile {additionalScopes}";
+        var fullScope = $"email profile {additionalScopes}".Trim();
         var redirectUri = client.RedirectUris.First().ToString();
 
         var splitScopes = new HashSet<string>(fullScope.Split(' ', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries), StringComparer.OrdinalIgnoreCase);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/CompleteTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/CompleteTests.cs
@@ -23,14 +23,14 @@ public class CompleteTests : TestBase
     [Fact]
     public async Task Get_JourneyIsAlreadyCompleted_DoesNotRedirectToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_DoesNotRedirectToPostSignInUrl(HttpMethod.Get, "/sign-in/complete");
+        await JourneyIsAlreadyCompleted_DoesNotRedirectToPostSignInUrl(additionalScopes: null, HttpMethod.Get, "/sign-in/complete");
     }
 
     [Fact]
     public async Task Get_JourneyHasExpired_RendersErrorPage()
     {
         var user = await TestData.CreateUser(hasTrn: true);
-        await JourneyHasExpired_RendersErrorPage(c => c.Completed(user), HttpMethod.Get, "/sign-in/complete");
+        await JourneyHasExpired_RendersErrorPage(c => c.Completed(user), additionalScopes: null, HttpMethod.Get, "/sign-in/complete");
     }
 
     [Theory]
@@ -46,7 +46,7 @@ public class CompleteTests : TestBase
     {
         // Arrange
         var user = await TestData.CreateUser(hasTrn: true);
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Completed(user, firstTimeSignIn: true));
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Completed(user, firstTimeSignIn: true), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/complete?{authStateHelper.ToQueryParam()}");
 
         // Act
@@ -66,7 +66,7 @@ public class CompleteTests : TestBase
     {
         // Arrange
         var user = await TestData.CreateUser(hasTrn: false);
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Completed(user, firstTimeSignIn: true));
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Completed(user, firstTimeSignIn: true), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/complete?{authStateHelper.ToQueryParam()}");
 
         // Act
@@ -84,7 +84,7 @@ public class CompleteTests : TestBase
     {
         // Arrange
         var user = await TestData.CreateUser();
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Completed(user, firstTimeSignIn: false));
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Completed(user, firstTimeSignIn: false), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/complete?{authStateHelper.ToQueryParam()}");
 
         // Act

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
@@ -29,13 +29,13 @@ public class EmailConfirmationTests : TestBase
     [Fact]
     public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Get, "/sign-in/email-confirmation");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, HttpMethod.Get, "/sign-in/email-confirmation");
     }
 
     [Fact]
     public async Task Get_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(c => c.EmailSet(), HttpMethod.Get, "/sign-in/email-confirmation");
+        await JourneyHasExpired_RendersErrorPage(c => c.EmailSet(), additionalScopes: null, HttpMethod.Get, "/sign-in/email-confirmation");
     }
 
     [Theory]
@@ -50,7 +50,7 @@ public class EmailConfirmationTests : TestBase
     public async Task Get_EmailNotKnown_RedirectsToEmailPage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}");
 
         // Act
@@ -65,7 +65,7 @@ public class EmailConfirmationTests : TestBase
     public async Task Get_ValidRequest_RendersExpectedContent()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}");
 
         // Act
@@ -93,13 +93,13 @@ public class EmailConfirmationTests : TestBase
     [Fact]
     public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Post, "/sign-in/email-confirmation");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, HttpMethod.Post, "/sign-in/email-confirmation");
     }
 
     [Fact]
     public async Task Post_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(c => c.EmailSet(), HttpMethod.Post, "/sign-in/email-confirmation");
+        await JourneyHasExpired_RendersErrorPage(c => c.EmailSet(), additionalScopes: null, HttpMethod.Post, "/sign-in/email-confirmation");
     }
 
     [Theory]
@@ -114,7 +114,7 @@ public class EmailConfirmationTests : TestBase
     public async Task Post_EmailNotKnown_RedirectsToEmailPage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}");
 
         // Act
@@ -134,7 +134,7 @@ public class EmailConfirmationTests : TestBase
         // The real PIN generation service never generates pins that start with a '0'
         var pin = "01234";
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email));
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -157,7 +157,7 @@ public class EmailConfirmationTests : TestBase
         var email = Faker.Internet.Email();
         var pin = "0";
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email));
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -180,7 +180,7 @@ public class EmailConfirmationTests : TestBase
         var email = Faker.Internet.Email();
         var pin = "0123345678";
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email));
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -203,7 +203,7 @@ public class EmailConfirmationTests : TestBase
         var email = Faker.Internet.Email();
         var pin = "abc";
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email));
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -230,7 +230,7 @@ public class EmailConfirmationTests : TestBase
         Clock.AdvanceBy(TimeSpan.FromHours(1));
         Spy.Get<IEmailVerificationService>().Reset();
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email));
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -260,7 +260,7 @@ public class EmailConfirmationTests : TestBase
         Clock.AdvanceBy(TimeSpan.FromHours(2) + TimeSpan.FromSeconds(emailVerificationOptions.Value.PinLifetimeSeconds));
         Spy.Get<IEmailVerificationService>().Reset();
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email));
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -278,8 +278,10 @@ public class EmailConfirmationTests : TestBase
         HostFixture.EmailVerificationService.Verify(mock => mock.GeneratePin(email), Times.Never);
     }
 
-    [Fact]
-    public async Task Post_ValidPinForNewUser_UpdatesAuthenticationStateAndRedirects()
+    [Theory]
+    // Only TrnHolder-like scopes support registration currently
+    [InlineData(CustomScopes.DqtRead)]
+    public async Task Post_ValidPinForNewUser_UpdatesAuthenticationStateAndRedirects(string scope)
     {
         // Arrange
         var email = Faker.Internet.Email();
@@ -287,7 +289,7 @@ public class EmailConfirmationTests : TestBase
         var emailVerificationService = HostFixture.Services.GetRequiredService<IEmailVerificationService>();
         var pinResult = await emailVerificationService.GeneratePin(email);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email));
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email), scope);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -318,7 +320,7 @@ public class EmailConfirmationTests : TestBase
         var emailVerificationService = HostFixture.Services.GetRequiredService<IEmailVerificationService>();
         var pinResult = await emailVerificationService.GeneratePin(user.EmailAddress);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(user.EmailAddress));
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(user.EmailAddress), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -429,7 +431,7 @@ public class EmailConfirmationTests : TestBase
         var emailVerificationService = HostFixture.Services.GetRequiredService<IEmailVerificationService>();
         var pinResult = await emailVerificationService.GeneratePin(email);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email));
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -454,7 +456,9 @@ public class EmailConfirmationTests : TestBase
         var emailVerificationService = HostFixture.Services.GetRequiredService<IEmailVerificationService>();
         var pinResult = await emailVerificationService.GeneratePin(user.EmailAddress);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(user.EmailAddress), additionalScopes: CustomScopes.Trn);
+        var authStateHelper = await CreateAuthenticationStateHelper(
+            c => c.EmailSet(user.EmailAddress),
+            additionalScopes: CustomScopes.DefaultUserTypesScopes.First());
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailTests.cs
@@ -25,13 +25,13 @@ public class EmailTests : TestBase
     [Fact]
     public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Get, "/sign-in/email");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, HttpMethod.Get, "/sign-in/email");
     }
 
     [Fact]
     public async Task Get_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(c => c.Start(), HttpMethod.Get, "/sign-in/email");
+        await JourneyHasExpired_RendersErrorPage(c => c.Start(), additionalScopes: null, HttpMethod.Get, "/sign-in/email");
     }
 
     [Theory]
@@ -45,7 +45,7 @@ public class EmailTests : TestBase
     [Fact]
     public async Task Get_ValidRequest_RendersContent()
     {
-        await ValidRequest_RendersContent("/sign-in/email", c => c.Start());
+        await ValidRequest_RendersContent("/sign-in/email", c => c.Start(), additionalScopes: null);
     }
 
     [Fact]
@@ -63,13 +63,13 @@ public class EmailTests : TestBase
     [Fact]
     public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Post, "/sign-in/email");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, HttpMethod.Post, "/sign-in/email");
     }
 
     [Fact]
     public async Task Post_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(c => c.Start(), HttpMethod.Post, "/sign-in/email");
+        await JourneyHasExpired_RendersErrorPage(c => c.Start(), additionalScopes: null, HttpMethod.Post, "/sign-in/email");
     }
 
     [Theory]
@@ -84,7 +84,7 @@ public class EmailTests : TestBase
     public async Task Post_ValidEmailWithBlockedClient_ReturnsTooManyRequestsStatusCode()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null);
         var email = Faker.Internet.Email();
 
         HostFixture.RateLimitStore.Setup(x => x.IsClientIpBlockedForPinGeneration(TestRequestClientIpProvider.ClientIpAddress)).ReturnsAsync(true);
@@ -108,7 +108,7 @@ public class EmailTests : TestBase
     public async Task Post_EmptyEmail_ReturnsError()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -125,7 +125,7 @@ public class EmailTests : TestBase
     public async Task Post_InvalidEmail_ReturnsError()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -147,7 +147,7 @@ public class EmailTests : TestBase
     public async Task Post_ValidEmail_SetsEmailOnAuthenticationStateGeneratesPinAndRedirectsToConfirmation(bool emailIsKnown)
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null);
         var email = Faker.Internet.Email();
 
         if (emailIsKnown)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/LandingTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/LandingTests.cs
@@ -22,18 +22,18 @@ public class LandingTests : TestBase
     [Fact]
     public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Get, "/sign-in/landing");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, HttpMethod.Get, "/sign-in/landing");
     }
 
     [Fact]
     public async Task Get_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(c => c.Start(), HttpMethod.Get, "/sign-in/landing");
+        await JourneyHasExpired_RendersErrorPage(c => c.Start(), additionalScopes: null, HttpMethod.Get, "/sign-in/landing");
     }
 
     [Fact]
     public async Task Get_ValidRequest_RendersContent()
     {
-        await ValidRequest_RendersContent("/sign-in/landing", c => c.Start());
+        await ValidRequest_RendersContent("/sign-in/landing", c => c.Start(), additionalScopes: null);
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailConfirmationTests.cs
@@ -28,20 +28,20 @@ public class EmailConfirmationTests : TestBase
     [Fact]
     public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Get, "/sign-in/register/email-confirmation");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, HttpMethod.Get, "/sign-in/register/email-confirmation");
     }
 
     [Fact]
     public async Task Get_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(c => c.EmailSet(), HttpMethod.Get, "/sign-in/register/email-confirmation");
+        await JourneyHasExpired_RendersErrorPage(c => c.EmailSet(), additionalScopes: null, HttpMethod.Get, "/sign-in/register/email-confirmation");
     }
 
     [Fact]
     public async Task Get_ValidRequest_RendersExpectedContent()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/email-confirmation?{authStateHelper.ToQueryParam()}");
 
         // Act
@@ -69,13 +69,13 @@ public class EmailConfirmationTests : TestBase
     [Fact]
     public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Post, "/sign-in/register/email-confirmation");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, HttpMethod.Post, "/sign-in/register/email-confirmation");
     }
 
     [Fact]
     public async Task Post_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(c => c.EmailSet(), HttpMethod.Post, "/sign-in/register/email-confirmation");
+        await JourneyHasExpired_RendersErrorPage(c => c.EmailSet(), additionalScopes: null, HttpMethod.Post, "/sign-in/register/email-confirmation");
     }
 
     [Fact]
@@ -87,7 +87,7 @@ public class EmailConfirmationTests : TestBase
         // The real PIN generation service never generates pins that start with a '0'
         var pin = "01234";
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email));
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -110,7 +110,7 @@ public class EmailConfirmationTests : TestBase
         var email = Faker.Internet.Email();
         var pin = "0";
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email));
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -133,7 +133,7 @@ public class EmailConfirmationTests : TestBase
         var email = Faker.Internet.Email();
         var pin = "0123345678";
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email));
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -156,7 +156,7 @@ public class EmailConfirmationTests : TestBase
         var email = Faker.Internet.Email();
         var pin = "abc";
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email));
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -183,7 +183,7 @@ public class EmailConfirmationTests : TestBase
         Clock.AdvanceBy(TimeSpan.FromHours(1));
         Spy.Get<IEmailVerificationService>().Reset();
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email));
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -213,7 +213,7 @@ public class EmailConfirmationTests : TestBase
         Clock.AdvanceBy(TimeSpan.FromHours(2) + TimeSpan.FromSeconds(emailVerificationOptions.Value.PinLifetimeSeconds));
         Spy.Get<IEmailVerificationService>().Reset();
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email));
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -240,7 +240,7 @@ public class EmailConfirmationTests : TestBase
         var emailVerificationService = HostFixture.Services.GetRequiredService<IEmailVerificationService>();
         var pinResult = await emailVerificationService.GeneratePin(email);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email));
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -268,7 +268,7 @@ public class EmailConfirmationTests : TestBase
         var emailVerificationService = HostFixture.Services.GetRequiredService<IEmailVerificationService>();
         var pinResult = await emailVerificationService.GeneratePin(email);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email));
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailTests.cs
@@ -25,19 +25,19 @@ public class EmailTests : TestBase
     [Fact]
     public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Get, "/sign-in/register/email");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, HttpMethod.Get, "/sign-in/register/email");
     }
 
     [Fact]
     public async Task Get_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(c => c.Start(), HttpMethod.Get, "/sign-in/register/email");
+        await JourneyHasExpired_RendersErrorPage(c => c.Start(), additionalScopes: null, HttpMethod.Get, "/sign-in/register/email");
     }
 
     [Fact]
     public async Task Get_ValidRequest_RendersContent()
     {
-        await ValidRequest_RendersContent("/sign-in/register/email", c => c.Start());
+        await ValidRequest_RendersContent("/sign-in/register/email", c => c.Start(), additionalScopes: null);
     }
 
     [Fact]
@@ -55,20 +55,20 @@ public class EmailTests : TestBase
     [Fact]
     public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Post, "/sign-in/register/email");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, HttpMethod.Post, "/sign-in/register/email");
     }
 
     [Fact]
     public async Task Post_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(c => c.Start(), HttpMethod.Post, "/sign-in/register/email");
+        await JourneyHasExpired_RendersErrorPage(c => c.Start(), additionalScopes: null, HttpMethod.Post, "/sign-in/register/email");
     }
 
     [Fact]
     public async Task Post_ValidEmailWithBlockedClient_ReturnsTooManyRequestsStatusCode()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null);
         var email = Faker.Internet.Email();
 
         HostFixture.RateLimitStore.Setup(x => x.IsClientIpBlockedForPinGeneration(TestRequestClientIpProvider.ClientIpAddress)).ReturnsAsync(true);
@@ -93,7 +93,7 @@ public class EmailTests : TestBase
     public async Task Post_EmptyEmail_ReturnsError()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -110,7 +110,7 @@ public class EmailTests : TestBase
     public async Task Post_InvalidEmail_ReturnsError()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -132,7 +132,7 @@ public class EmailTests : TestBase
     public async Task Post_ValidEmail_SetsEmailOnAuthenticationStateGeneratesPinAndRedirectsToRegisterEmailConfirmation(bool emailIsKnown)
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null);
         var email = Faker.Internet.Email();
 
         if (emailIsKnown)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/IndexTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/IndexTests.cs
@@ -22,18 +22,18 @@ public class IndexTests : TestBase
     [Fact]
     public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Get, "/sign-in/register");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, HttpMethod.Get, "/sign-in/register");
     }
 
     [Fact]
     public async Task Get_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(c => c.Start(), HttpMethod.Get, "/sign-in/register");
+        await JourneyHasExpired_RendersErrorPage(c => c.Start(), additionalScopes: null, HttpMethod.Get, "/sign-in/register");
     }
 
     [Fact]
     public async Task Get_ValidRequest_RendersContent()
     {
-        await ValidRequest_RendersContent("/sign-in/register", c => c.Start());
+        await ValidRequest_RendersContent("/sign-in/register", c => c.Start(), additionalScopes: null);
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/ResendEmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/ResendEmailConfirmationTests.cs
@@ -25,20 +25,20 @@ public class ResendEmailConfirmationTests : TestBase
     [Fact]
     public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Get, "/sign-in/resend-email-confirmation");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, HttpMethod.Get, "/sign-in/resend-email-confirmation");
     }
 
     [Fact]
     public async Task Get_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(c => c.EmailVerified(), HttpMethod.Get, "/sign-in/resend-email-confirmation");
+        await JourneyHasExpired_RendersErrorPage(c => c.EmailVerified(), additionalScopes: null, HttpMethod.Get, "/sign-in/resend-email-confirmation");
     }
 
     [Fact]
     public async Task Get_EmailNotKnown_RedirectsToEmailPage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/resend-email-confirmation?{authStateHelper.ToQueryParam()}");
 
         // Act
@@ -53,7 +53,7 @@ public class ResendEmailConfirmationTests : TestBase
     public async Task Get_EmailAlreadyVerified_RedirectsToNextPage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified(), additionalScopes: null);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/resend-email-confirmation?{authStateHelper.ToQueryParam()}");
 
@@ -69,7 +69,7 @@ public class ResendEmailConfirmationTests : TestBase
     public async Task Get_ValidRequest_RendersExpectedContent()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/resend-email-confirmation?{authStateHelper.ToQueryParam()}");
 
         // Act
@@ -97,20 +97,20 @@ public class ResendEmailConfirmationTests : TestBase
     [Fact]
     public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Post, "/sign-in/resend-email-confirmation");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, HttpMethod.Post, "/sign-in/resend-email-confirmation");
     }
 
     [Fact]
     public async Task Post_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(c => c.EmailVerified(), HttpMethod.Post, "/sign-in/resend-email-confirmation");
+        await JourneyHasExpired_RendersErrorPage(c => c.EmailVerified(), additionalScopes: null, HttpMethod.Post, "/sign-in/resend-email-confirmation");
     }
 
     [Fact]
     public async Task Post_EmailNotKnown_RedirectsToEmailPage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null);
         var differentEmail = Faker.Internet.Email();
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/resend-email-confirmation?{authStateHelper.ToQueryParam()}")
@@ -134,7 +134,7 @@ public class ResendEmailConfirmationTests : TestBase
     {
         // Arrange
         var email = Faker.Internet.Email();
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified(), additionalScopes: null);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/resend-email-confirmation?{authStateHelper.ToQueryParam()}")
         {
@@ -156,7 +156,7 @@ public class ResendEmailConfirmationTests : TestBase
     public async Task Post_EmptyEmail_ReturnsError()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(), additionalScopes: null);
         var differentEmail = "";
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/resend-email-confirmation?{authStateHelper.ToQueryParam()}")
@@ -178,7 +178,7 @@ public class ResendEmailConfirmationTests : TestBase
     public async Task Post_InvalidEmail_ReturnsError()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(), additionalScopes: null);
         var differentEmail = "xx";
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/resend-email-confirmation?{authStateHelper.ToQueryParam()}")
@@ -200,7 +200,7 @@ public class ResendEmailConfirmationTests : TestBase
     public async Task Post_ValidEmailWithBlockedClient_ReturnsTooManyRequestsStatusCode()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(), additionalScopes: null);
         var differentEmail = "valid@email.com";
 
         HostFixture.RateLimitStore.Setup(x => x.IsClientIpBlockedForPinGeneration(TestRequestClientIpProvider.ClientIpAddress)).ReturnsAsync(true);
@@ -224,7 +224,7 @@ public class ResendEmailConfirmationTests : TestBase
     public async Task Post_ValidRequest_SetsEmailOnAuthenticationStateGeneratesPinAndRedirectsToConfirmation()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(), additionalScopes: null);
         var differentEmail = Faker.Internet.Email();
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/resend-email-confirmation?{authStateHelper.ToQueryParam()}")

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/ResendTrnOwnerEmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/ResendTrnOwnerEmailConfirmationTests.cs
@@ -1,3 +1,5 @@
+using TeacherIdentity.AuthServer.Oidc;
+
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn;
 
 [Collection(nameof(DisableParallelization))]  // Depends on mocks
@@ -23,7 +25,7 @@ public class ResendTrnOwnerEmailConfirmationTests : TestBase
     [Fact]
     public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Get, "/sign-in/trn/resend-email-confirmation");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/trn/resend-email-confirmation");
     }
 
     [Fact]
@@ -34,6 +36,7 @@ public class ResendTrnOwnerEmailConfirmationTests : TestBase
 
         await JourneyHasExpired_RendersErrorPage(
             c => c.TrnLookupCompletedForExistingTrn(email, existingTrnOwner),
+            CustomScopes.DqtRead,
             HttpMethod.Get,
             "/sign-in/trn/resend-email-confirmation");
     }
@@ -45,7 +48,9 @@ public class ResendTrnOwnerEmailConfirmationTests : TestBase
         var email = Faker.Internet.Email();
         var existingTrnOwner = await TestData.CreateUser(hasTrn: true);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.TrnLookupCompletedForExistingTrn(email, existingTrnOwner));
+        var authStateHelper = await CreateAuthenticationStateHelper(
+            c => c.TrnLookupCompletedForExistingTrn(email, existingTrnOwner),
+            CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/resend-email-confirmation?{authStateHelper.ToQueryParam()}");
 
@@ -71,7 +76,7 @@ public class ResendTrnOwnerEmailConfirmationTests : TestBase
     [Fact]
     public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Post, "/sign-in/trn/resend-email-confirmation");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/trn/resend-email-confirmation");
     }
 
     [Fact]
@@ -82,6 +87,7 @@ public class ResendTrnOwnerEmailConfirmationTests : TestBase
 
         await JourneyHasExpired_RendersErrorPage(
             c => c.TrnLookupCompletedForExistingTrn(email, existingTrnOwner),
+            CustomScopes.DqtRead,
             HttpMethod.Post,
             "/sign-in/trn/resend-email-confirmation");
     }
@@ -93,7 +99,9 @@ public class ResendTrnOwnerEmailConfirmationTests : TestBase
         var email = Faker.Internet.Email();
         var existingTrnOwner = await TestData.CreateUser(hasTrn: true);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.TrnLookupCompletedForExistingTrn(email, existingTrnOwner));
+        var authStateHelper = await CreateAuthenticationStateHelper(
+            c => c.TrnLookupCompletedForExistingTrn(email, existingTrnOwner),
+            CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/resend-email-confirmation?{authStateHelper.ToQueryParam()}");
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TestBase.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TestBase.cs
@@ -1,6 +1,5 @@
 using TeacherIdentity.AuthServer.Services.DqtApi;
 using TeacherIdentity.AuthServer.Tests.Infrastructure;
-using static TeacherIdentity.AuthServer.Tests.AuthenticationStateHelper;
 
 namespace TeacherIdentity.AuthServer.Tests;
 
@@ -30,7 +29,9 @@ public abstract partial class TestBase
 
     public TestData TestData => HostFixture.Services.GetRequiredService<TestData>();
 
-    public Task<AuthenticationStateHelper> CreateAuthenticationStateHelper(Func<Configure, Func<AuthenticationState, Task>> configure, string? additionalScopes = "trn") =>
+    public Task<AuthenticationStateHelper> CreateAuthenticationStateHelper(
+        Func<AuthenticationStateHelper.Configure, Func<AuthenticationState, Task>> configure,
+        string? additionalScopes) =>
         AuthenticationStateHelper.Create(configure, HostFixture, additionalScopes);
 
     public void ConfigureDqtApiClientToReturnSingleMatch(AuthenticationStateHelper authStateHelper)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TestBase.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TestBase.cs
@@ -15,7 +15,6 @@ public abstract partial class TestBase
         });
 
         HostFixture.ResetMocks();
-        HostFixture.ResetUseNewTrnLookupJourney();
         HostFixture.InitEventObserver();
     }
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/AwardedQtsPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/AwardedQtsPageTests.cs
@@ -1,3 +1,5 @@
+using TeacherIdentity.AuthServer.Oidc;
+
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Trn;
 
 [Collection(nameof(DisableParallelization))]  // Relies on mocks
@@ -23,13 +25,13 @@ public class AwardedQtsPageTests : TestBase
     [Fact]
     public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Get, "/sign-in/trn/awarded-qts");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/trn/awarded-qts");
     }
 
     [Fact]
     public async Task Get_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, HttpMethod.Get, "/sign-in/trn/awarded-qts");
+        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/trn/awarded-qts");
     }
 
     [Theory]
@@ -44,7 +46,7 @@ public class AwardedQtsPageTests : TestBase
     public async Task Get_HasNinoNotSet_RedirectsToHasNinoPage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.DateOfBirthSet());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.DateOfBirthSet(), CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/awarded-qts?{authStateHelper.ToQueryParam()}");
 
@@ -60,7 +62,9 @@ public class AwardedQtsPageTests : TestBase
     public async Task Get_HasNinoButNinoNotSet_RedirectsToHasNiNumberPage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.HasNationalInsuranceNumberSet(hasNationalInsuranceNumber: true));
+        var authStateHelper = await CreateAuthenticationStateHelper(
+            c => c.Trn.HasNationalInsuranceNumberSet(hasNationalInsuranceNumber: true),
+            CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/awarded-qts?{authStateHelper.ToQueryParam()}");
 
@@ -75,7 +79,7 @@ public class AwardedQtsPageTests : TestBase
     [Fact]
     public async Task Get_ValidRequest_RendersContent()
     {
-        await ValidRequest_RendersContent("/sign-in/trn/awarded-qts", ConfigureValidAuthenticationState);
+        await ValidRequest_RendersContent("/sign-in/trn/awarded-qts", ConfigureValidAuthenticationState, CustomScopes.DqtRead);
     }
 
     [Fact]
@@ -93,13 +97,13 @@ public class AwardedQtsPageTests : TestBase
     [Fact]
     public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Post, "/sign-in/trn/awarded-qts");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/trn/awarded-qts");
     }
 
     [Fact]
     public async Task Post_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, HttpMethod.Post, "/sign-in/trn/awarded-qts");
+        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/trn/awarded-qts");
     }
 
     [Theory]
@@ -114,7 +118,7 @@ public class AwardedQtsPageTests : TestBase
     public async Task Post_HasNinoNotSet_RedirectsToHasNinoPage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.DateOfBirthSet());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.DateOfBirthSet(), CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/awarded-qts?{authStateHelper.ToQueryParam()}");
 
@@ -130,7 +134,9 @@ public class AwardedQtsPageTests : TestBase
     public async Task Post_HasNinoButNinoNotSet_RedirectsToHasNiNumberPage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.HasNationalInsuranceNumberSet(hasNationalInsuranceNumber: true));
+        var authStateHelper = await CreateAuthenticationStateHelper(
+            c => c.Trn.HasNationalInsuranceNumberSet(hasNationalInsuranceNumber: true),
+            CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/awarded-qts?{authStateHelper.ToQueryParam()}");
 
@@ -146,7 +152,7 @@ public class AwardedQtsPageTests : TestBase
     public async Task Post_NullAwardedQts_ReturnsError()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/awarded-qts?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -165,7 +171,7 @@ public class AwardedQtsPageTests : TestBase
     public async Task Post_ValidForm_SetsAwardedQtsOnAuthenticationStateRedirectsToCorrectPage(bool awardedQts)
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/awarded-qts?{authStateHelper.ToQueryParam()}")
         {
@@ -196,7 +202,7 @@ public class AwardedQtsPageTests : TestBase
     public async Task Post_TrnLookupFindsExactlyOneResultAndAwardedQtsFalse_RedirectsToCheckAnswersPage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         ConfigureDqtApiClientToReturnSingleMatch(authStateHelper);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/awarded-qts?{authStateHelper.ToQueryParam()}")
@@ -219,7 +225,7 @@ public class AwardedQtsPageTests : TestBase
     public async Task Post_AwardedQtsTrue_DoesNotAttemptTrnLookup()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         ConfigureDqtApiClientToReturnSingleMatch(authStateHelper);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/awarded-qts?{authStateHelper.ToQueryParam()}")

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/DateOfBirthPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/DateOfBirthPageTests.cs
@@ -1,3 +1,5 @@
+using TeacherIdentity.AuthServer.Oidc;
+
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Trn;
 
 [Collection(nameof(DisableParallelization))]  // Relies on mocks
@@ -23,13 +25,13 @@ public class DateOfBirthPageTests : TestBase
     [Fact]
     public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Get, "/sign-in/trn/date-of-birth");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/trn/date-of-birth");
     }
 
     [Fact]
     public async Task Get_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, HttpMethod.Get, "/sign-in/trn/date-of-birth");
+        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/trn/date-of-birth");
     }
 
     [Theory]
@@ -44,7 +46,7 @@ public class DateOfBirthPageTests : TestBase
     public async Task Get_PreferredNameNotSet_RedirectsToPreferredNamePage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.OfficialNameSet());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.OfficialNameSet(), CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/date-of-birth?{authStateHelper.ToQueryParam()}");
 
@@ -59,7 +61,7 @@ public class DateOfBirthPageTests : TestBase
     [Fact]
     public async Task Get_ValidRequest_RendersContent()
     {
-        await ValidRequest_RendersContent("/sign-in/trn/date-of-birth", ConfigureValidAuthenticationState);
+        await ValidRequest_RendersContent("/sign-in/trn/date-of-birth", ConfigureValidAuthenticationState, CustomScopes.DqtRead);
     }
 
     [Fact]
@@ -77,13 +79,13 @@ public class DateOfBirthPageTests : TestBase
     [Fact]
     public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Post, "/sign-in/trn/date-of-birth");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/trn/date-of-birth");
     }
 
     [Fact]
     public async Task Post_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, HttpMethod.Post, "/sign-in/trn/date-of-birth");
+        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/trn/date-of-birth");
     }
 
     [Theory]
@@ -98,7 +100,7 @@ public class DateOfBirthPageTests : TestBase
     public async Task Post_PreferredNameNotSet_RedirectsToPreferredNamePage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.OfficialNameSet());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.OfficialNameSet(), CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/date-of-birth?{authStateHelper.ToQueryParam()}");
 
@@ -114,7 +116,7 @@ public class DateOfBirthPageTests : TestBase
     public async Task Post_NullDateOfBirth_ReturnsError()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/date-of-birth?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -133,7 +135,7 @@ public class DateOfBirthPageTests : TestBase
         // Arrange
         var dateOfBirth = new DateOnly(2100, 1, 1);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/date-of-birth?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -157,7 +159,7 @@ public class DateOfBirthPageTests : TestBase
         // Arrange
         var dateOfBirth = new DateOnly(2000, 1, 1);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/date-of-birth?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -183,7 +185,7 @@ public class DateOfBirthPageTests : TestBase
     {
         // Arrange
         var dateOfBirth = new DateOnly(2000, 1, 1);
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
 
         ConfigureDqtApiClientToReturnSingleMatch(authStateHelper);
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/HasNiNumberPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/HasNiNumberPageTests.cs
@@ -1,3 +1,5 @@
+using TeacherIdentity.AuthServer.Oidc;
+
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Trn;
 
 [Collection(nameof(DisableParallelization))]  // Relies on mocks
@@ -23,7 +25,7 @@ public class HasNiNumberPageTests : TestBase
     [Fact]
     public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Get, "/sign-in/trn/has-nino");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/trn/has-nino");
     }
 
     [Theory]
@@ -38,7 +40,7 @@ public class HasNiNumberPageTests : TestBase
     public async Task Get_DateOfBirthNotSet_RedirectsToDateOfBirthPage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.PreferredNameSet());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.PreferredNameSet(), CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/has-nino?{authStateHelper.ToQueryParam()}");
 
@@ -53,7 +55,7 @@ public class HasNiNumberPageTests : TestBase
     [Fact]
     public async Task Get_ValidRequest_RendersContent()
     {
-        await ValidRequest_RendersContent("/sign-in/trn/has-nino", ConfigureValidAuthenticationState);
+        await ValidRequest_RendersContent("/sign-in/trn/has-nino", ConfigureValidAuthenticationState, CustomScopes.DqtRead);
     }
 
     [Fact]
@@ -71,7 +73,7 @@ public class HasNiNumberPageTests : TestBase
     [Fact]
     public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Post, "/sign-in/trn/has-nino");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/trn/has-nino");
     }
 
     [Theory]
@@ -86,7 +88,7 @@ public class HasNiNumberPageTests : TestBase
     public async Task Post_DateOfBirthNotSet_RedirectsToDateOfBirthPage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.PreferredNameSet());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.PreferredNameSet(), CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/has-nino?{authStateHelper.ToQueryParam()}");
 
@@ -102,7 +104,7 @@ public class HasNiNumberPageTests : TestBase
     public async Task Post_NullHasNiNumber_ReturnsError()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/has-nino?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -121,7 +123,7 @@ public class HasNiNumberPageTests : TestBase
     public async Task Post_ValidForm_SetsHasNiNumberOnAuthenticationState(bool hasNiNumber)
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/has-nino?{authStateHelper.ToQueryParam()}")
         {
@@ -143,7 +145,7 @@ public class HasNiNumberPageTests : TestBase
     public async Task Post_HasNiNumberTrue_RedirectsToNiNumberPage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/has-nino?{authStateHelper.ToQueryParam()}")
         {
@@ -165,7 +167,7 @@ public class HasNiNumberPageTests : TestBase
     public async Task Post_HasNiNumberFalse_RedirectsToAwardedQtsPage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/has-nino?{authStateHelper.ToQueryParam()}")
         {
@@ -187,7 +189,7 @@ public class HasNiNumberPageTests : TestBase
     public async Task Post_TrnLookupFindsExactlyOneResultAndHasNiNumberFalse_RedirectsToCheckAnswersPage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         ConfigureDqtApiClientToReturnSingleMatch(authStateHelper);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/has-nino?{authStateHelper.ToQueryParam()}")
@@ -210,7 +212,7 @@ public class HasNiNumberPageTests : TestBase
     public async Task Post_NiNumberTrue_DoesNotAttemptTrnLookup()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         ConfigureDqtApiClientToReturnSingleMatch(authStateHelper);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/has-nino?{authStateHelper.ToQueryParam()}")

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/HasTrnPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/HasTrnPageTests.cs
@@ -1,3 +1,5 @@
+using TeacherIdentity.AuthServer.Oidc;
+
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Trn;
 
 [Collection(nameof(DisableParallelization))]  // Relies on mocks
@@ -23,13 +25,13 @@ public class HasTrnPageTests : TestBase
     [Fact]
     public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Get, "/sign-in/trn/has-trn");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/trn/has-trn");
     }
 
     [Fact]
     public async Task Get_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, HttpMethod.Get, "/sign-in/trn/has-trn");
+        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/trn/has-trn");
     }
 
     [Theory]
@@ -43,7 +45,7 @@ public class HasTrnPageTests : TestBase
     [Fact]
     public async Task Get_ValidRequest_RendersContent()
     {
-        await ValidRequest_RendersContent("/sign-in/trn/has-trn", ConfigureValidAuthenticationState);
+        await ValidRequest_RendersContent("/sign-in/trn/has-trn", ConfigureValidAuthenticationState, CustomScopes.DqtRead);
     }
 
     [Fact]
@@ -61,13 +63,13 @@ public class HasTrnPageTests : TestBase
     [Fact]
     public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Post, "/sign-in/trn/has-trn");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/trn/has-trn");
     }
 
     [Fact]
     public async Task Post_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, HttpMethod.Post, "/sign-in/trn/has-trn");
+        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/trn/has-trn");
     }
 
     [Theory]
@@ -82,7 +84,7 @@ public class HasTrnPageTests : TestBase
     public async Task Post_NullHasTrn_ReturnsError()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/has-trn?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -99,7 +101,7 @@ public class HasTrnPageTests : TestBase
     public async Task Post_EmptyStatedTrn_ReturnsError()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/has-trn?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -122,7 +124,7 @@ public class HasTrnPageTests : TestBase
     public async Task Post_InvalidStatedTrn_ReturnsError(string statedTrn)
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/has-trn?{authStateHelper.ToQueryParam()}")
         {
@@ -144,7 +146,7 @@ public class HasTrnPageTests : TestBase
     public async Task Post_FalseHasTrn_UpdatesAuthenticationStateRedirectsToTrnOfficialName()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/has-trn?{authStateHelper.ToQueryParam()}")
         {
@@ -170,7 +172,7 @@ public class HasTrnPageTests : TestBase
     public async Task Post_ValidStatedTrn_UpdatesAuthenticationStateRedirectsToTrnOfficialName(string statedTrn)
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/has-trn?{authStateHelper.ToQueryParam()}")
         {
@@ -196,7 +198,7 @@ public class HasTrnPageTests : TestBase
     public async Task Post_TrnLookupFindsExactlyOneResult_RedirectsToCheckAnswersPage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         ConfigureDqtApiClientToReturnSingleMatch(authStateHelper);
 
         var statedTrn = TestData.GenerateTrn();

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/IttProviderTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/IttProviderTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Caching.Memory;
+using TeacherIdentity.AuthServer.Oidc;
 using TeacherIdentity.AuthServer.Services.DqtApi;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Trn;
@@ -35,13 +36,13 @@ public class IttProviderTests : TestBase
     [Fact]
     public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Get, "/sign-in/trn/itt-provider");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/trn/itt-provider");
     }
 
     [Fact]
     public async Task Get_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, HttpMethod.Get, "/sign-in/trn/itt-provider");
+        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/trn/itt-provider");
     }
 
     [Theory]
@@ -56,7 +57,7 @@ public class IttProviderTests : TestBase
     public async Task Get_AwardedQtsNotSet_RedirectsToAwardedQtsPage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.NationalInsuranceNumberSet());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.NationalInsuranceNumberSet(), CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/itt-provider?{authStateHelper.ToQueryParam()}");
 
@@ -72,7 +73,7 @@ public class IttProviderTests : TestBase
     public async Task Get_ValidRequest_StoresIttProviderNamesInCache()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/itt-provider?{authStateHelper.ToQueryParam()}");
 
         // Act
@@ -100,13 +101,13 @@ public class IttProviderTests : TestBase
     [Fact]
     public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Post, "/sign-in/trn/itt-provider");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/trn/itt-provider");
     }
 
     [Fact]
     public async Task Post_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, HttpMethod.Post, "/sign-in/trn/itt-provider");
+        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/trn/itt-provider");
     }
 
     [Theory]
@@ -121,7 +122,7 @@ public class IttProviderTests : TestBase
     public async Task Post_AwardedQtsNotSet_RedirectsToAwardedQtsPage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.NationalInsuranceNumberSet());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.NationalInsuranceNumberSet(), CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/itt-provider?{authStateHelper.ToQueryParam()}");
 
@@ -137,7 +138,7 @@ public class IttProviderTests : TestBase
     public async Task Post_NullHasIttProvider_ReturnsError()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/itt-provider?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -154,7 +155,7 @@ public class IttProviderTests : TestBase
     public async Task Post_EmptyIttProviderName_ReturnsError()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/itt-provider?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -178,7 +179,7 @@ public class IttProviderTests : TestBase
         // Arrange
         var ittProviderName = "provider";
 
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/itt-provider?{authStateHelper.ToQueryParam()}")
         {
@@ -206,7 +207,7 @@ public class IttProviderTests : TestBase
         // Arrange
         var ittProviderName = "provider";
 
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         ConfigureDqtApiClientToReturnSingleMatch(authStateHelper);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/itt-provider?{authStateHelper.ToQueryParam()}")

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/NiNumberPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/NiNumberPageTests.cs
@@ -1,3 +1,5 @@
+using TeacherIdentity.AuthServer.Oidc;
+
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Trn;
 
 [Collection(nameof(DisableParallelization))]  // Relies on mocks
@@ -23,7 +25,7 @@ public class NiNumberPageTests : TestBase
     [Fact]
     public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Get, "/sign-in/trn/ni-number");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/trn/ni-number");
     }
 
     [Theory]
@@ -38,7 +40,7 @@ public class NiNumberPageTests : TestBase
     public async Task Get_HaveNationalInsuranceNumberNotSet_RedirectsToHasNiNumberPage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.DateOfBirthSet());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.DateOfBirthSet(), CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/ni-number?{authStateHelper.ToQueryParam()}");
 
@@ -53,7 +55,7 @@ public class NiNumberPageTests : TestBase
     [Fact]
     public async Task Get_ValidRequest_RendersContent()
     {
-        await ValidRequest_RendersContent("/sign-in/trn/ni-number", ConfigureValidAuthenticationState);
+        await ValidRequest_RendersContent("/sign-in/trn/ni-number", ConfigureValidAuthenticationState, CustomScopes.DqtRead);
     }
 
     [Fact]
@@ -71,7 +73,7 @@ public class NiNumberPageTests : TestBase
     [Fact]
     public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Post, "/sign-in/trn/ni-number");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/trn/ni-number");
     }
 
     [Theory]
@@ -86,7 +88,7 @@ public class NiNumberPageTests : TestBase
     public async Task Post_HaveNationalInsuranceNumberNotSet_RedirectsToHasNiNumberPage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.DateOfBirthSet());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.DateOfBirthSet(), CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/ni-number?{authStateHelper.ToQueryParam()}");
 
@@ -102,7 +104,7 @@ public class NiNumberPageTests : TestBase
     public async Task Post_EmptyNiNumber_ReturnsError()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/ni-number?{authStateHelper.ToQueryParam()}")
         {
@@ -123,7 +125,7 @@ public class NiNumberPageTests : TestBase
     public async Task Post_InvalidNiNumber_ReturnsError(string niNumber)
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/ni-number?{authStateHelper.ToQueryParam()}")
         {
@@ -148,7 +150,7 @@ public class NiNumberPageTests : TestBase
     public async Task Post_ValidNiNumber_SetsNiNumberOnAuthenticationStateRedirectsToAwardedQtsPage(string niNumber)
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/ni-number?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -172,7 +174,7 @@ public class NiNumberPageTests : TestBase
     public async Task Post_NiNumberNotKnown_Returns302Found()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/ni-number?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -192,7 +194,7 @@ public class NiNumberPageTests : TestBase
     public async Task Post_TrnLookupFindsExactlyOneResult_RedirectsToCheckAnswersPage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         ConfigureDqtApiClientToReturnSingleMatch(authStateHelper);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/ni-number?{authStateHelper.ToQueryParam()}")

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/OfficialNameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/OfficialNameTests.cs
@@ -1,3 +1,5 @@
+using TeacherIdentity.AuthServer.Oidc;
+
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Trn;
 
 [Collection(nameof(DisableParallelization))]  // Relies on mocks
@@ -23,13 +25,13 @@ public class OfficialNameTests : TestBase
     [Fact]
     public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Get, "/sign-in/trn/official-name");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/trn/official-name");
     }
 
     [Fact]
     public async Task Get_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, HttpMethod.Get, "/sign-in/trn/official-name");
+        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/trn/official-name");
     }
 
     [Theory]
@@ -44,7 +46,7 @@ public class OfficialNameTests : TestBase
     public async Task Get_HasTrnNotSet_RedirectsToHasTrnPage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified(), CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/official-name?{authStateHelper.ToQueryParam()}");
 
@@ -59,7 +61,7 @@ public class OfficialNameTests : TestBase
     [Fact]
     public async Task Get_ValidRequest_RendersContent()
     {
-        await ValidRequest_RendersContent("/sign-in/trn/official-name", ConfigureValidAuthenticationState);
+        await ValidRequest_RendersContent("/sign-in/trn/official-name", ConfigureValidAuthenticationState, CustomScopes.DqtRead);
     }
 
     [Fact]
@@ -77,13 +79,13 @@ public class OfficialNameTests : TestBase
     [Fact]
     public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Post, "/sign-in/trn/official-name");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/trn/official-name");
     }
 
     [Fact]
     public async Task Post_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, HttpMethod.Post, "/sign-in/trn/official-name");
+        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/trn/official-name");
     }
 
     [Theory]
@@ -98,7 +100,7 @@ public class OfficialNameTests : TestBase
     public async Task Post_HasTrnNotSet_RedirectsToHasTrnPage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified(), CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/official-name?{authStateHelper.ToQueryParam()}");
 
@@ -114,7 +116,7 @@ public class OfficialNameTests : TestBase
     public async Task Post_EmptyOfficialFirstName_ReturnsError()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/official-name?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -131,7 +133,7 @@ public class OfficialNameTests : TestBase
     public async Task Post_EmptyOfficialLastName_ReturnsError()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/official-name?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -148,7 +150,7 @@ public class OfficialNameTests : TestBase
     public async Task Post_ValidOfficialName_SetsOfficialNameOnAuthenticationStateRedirectsToPreferredName()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         var firstName = "first";
         var lastName = "last";
 
@@ -179,7 +181,7 @@ public class OfficialNameTests : TestBase
     public async Task Post_HasPreviousOfficialNames_SetsPreviousOfficialNameOnAuthenticationState(bool hasPreviousName)
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         var previousFirstName = "previous first";
         var previousLastName = "previous last";
 
@@ -217,7 +219,7 @@ public class OfficialNameTests : TestBase
     public async Task Post_TrnLookupFindsExactlyOneResult_RedirectsToCheckAnswersPage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         ConfigureDqtApiClientToReturnSingleMatch(authStateHelper);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/official-name?{authStateHelper.ToQueryParam()}")

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/PreferredNameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/PreferredNameTests.cs
@@ -1,3 +1,5 @@
+using TeacherIdentity.AuthServer.Oidc;
+
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Trn;
 
 [Collection(nameof(DisableParallelization))]  // Relies on mocks
@@ -23,13 +25,13 @@ public class PreferredNameTests : TestBase
     [Fact]
     public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Get, "/sign-in/trn/preferred-name");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/trn/preferred-name");
     }
 
     [Fact]
     public async Task Get_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, HttpMethod.Get, "/sign-in/trn/preferred-name");
+        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/trn/preferred-name");
     }
 
     [Theory]
@@ -44,7 +46,7 @@ public class PreferredNameTests : TestBase
     public async Task Get_OfficialNameNotSet_RedirectsToOfficialNamePage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.HasTrnSet());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.HasTrnSet(), CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/preferred-name?{authStateHelper.ToQueryParam()}");
 
@@ -59,7 +61,7 @@ public class PreferredNameTests : TestBase
     [Fact]
     public async Task Get_ValidRequest_RendersContent()
     {
-        await ValidRequest_RendersContent("/sign-in/trn/preferred-name", ConfigureValidAuthenticationState);
+        await ValidRequest_RendersContent("/sign-in/trn/preferred-name", ConfigureValidAuthenticationState, CustomScopes.DqtRead);
     }
 
     [Fact]
@@ -77,13 +79,13 @@ public class PreferredNameTests : TestBase
     [Fact]
     public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Post, "/sign-in/trn/preferred-name");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/trn/preferred-name");
     }
 
     [Fact]
     public async Task Post_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, HttpMethod.Post, "/sign-in/trn/preferred-name");
+        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/trn/preferred-name");
     }
 
     [Theory]
@@ -98,7 +100,7 @@ public class PreferredNameTests : TestBase
     public async Task Post_OfficialNameNotSet_RedirectsToOfficialNamePage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.HasTrnSet());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.HasTrnSet(), CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/preferred-name?{authStateHelper.ToQueryParam()}");
 
@@ -114,7 +116,7 @@ public class PreferredNameTests : TestBase
     public async Task Post_NullHasPreferredName_ReturnsError()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/preferred-name?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -131,7 +133,7 @@ public class PreferredNameTests : TestBase
     public async Task Post_EmptyPreferredFirstName_ReturnsError()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/preferred-name?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -152,7 +154,7 @@ public class PreferredNameTests : TestBase
     public async Task Post_EmptyPreferredLastName_ReturnsError()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/preferred-name?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -173,7 +175,7 @@ public class PreferredNameTests : TestBase
     public async Task Post_ValidForm_RedirectsToDateOfBirthPage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/preferred-name?{authStateHelper.ToQueryParam()}")
         {
@@ -202,7 +204,7 @@ public class PreferredNameTests : TestBase
         var preferredFirstName = "preferred first";
         var preferredLastName = "preferred last";
 
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState);
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         authStateHelper.AuthenticationState.OnNameSet(initialFirstName, initialLastName);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/preferred-name?{authStateHelper.ToQueryParam()}")

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnCallbackTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnCallbackTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Events;
 using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Oidc;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn;
 
@@ -27,7 +28,7 @@ public class TrnCallbackTests : TestBase
     [Fact]
     public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Get, "/sign-in/trn/callback");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/trn/callback");
     }
 
     [Fact]
@@ -41,6 +42,7 @@ public class TrnCallbackTests : TestBase
 
         await JourneyHasExpired_RendersErrorPage(
             c => c.TrnLookupCallbackCompleted(email, trn, dateOfBirth, firstName, lastName),
+            CustomScopes.DqtRead,
             HttpMethod.Get,
             "/sign-in/trn/callback");
     }
@@ -54,7 +56,7 @@ public class TrnCallbackTests : TestBase
         // Arrange
         var user = await TestData.CreateUser(hasTrn: true);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.TrnLookup(trnLookupState, user));
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.TrnLookup(trnLookupState, user), CustomScopes.DqtRead);
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/callback?{authStateHelper.ToQueryParam()}");
 
         // Act
@@ -69,7 +71,7 @@ public class TrnCallbackTests : TestBase
     public async Task Get_MissingStateInDb_ReturnsError()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified(), CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/callback?{authStateHelper.ToQueryParam()}");
 
@@ -94,7 +96,8 @@ public class TrnCallbackTests : TestBase
 
         var authStateHelper = await CreateAuthenticationStateHelper(
             c => c.TrnLookupCallbackCompleted(
-                email, trn, dateOfBirth, firstName, lastName, preferredFirstName: preferredFirstName, preferredLastName: preferredLastName));
+                email, trn, dateOfBirth, firstName, lastName, preferredFirstName: preferredFirstName, preferredLastName: preferredLastName),
+            CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/callback?{authStateHelper.ToQueryParam()}");
 
@@ -132,7 +135,8 @@ public class TrnCallbackTests : TestBase
         var trn = hasTrn ? TestData.GenerateTrn() : null;
 
         var authStateHelper = await CreateAuthenticationStateHelper(
-            c => c.TrnLookupCallbackCompleted(email, trn, dateOfBirth, firstName, lastName, supportTicketCreated));
+            c => c.TrnLookupCallbackCompleted(email, trn, dateOfBirth, firstName, lastName, supportTicketCreated),
+            CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/callback?{authStateHelper.ToQueryParam()}");
 
@@ -200,7 +204,8 @@ public class TrnCallbackTests : TestBase
         var trn = existingUserWithTrn.Trn;
 
         var authStateHelper = await CreateAuthenticationStateHelper(
-            c => c.TrnLookupCallbackCompleted(email, trn, dateOfBirth, firstName, lastName));
+            c => c.TrnLookupCallbackCompleted(email, trn, dateOfBirth, firstName, lastName),
+            CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/callback?{authStateHelper.ToQueryParam()}");
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnInUseChooseEmailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnInUseChooseEmailTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Oidc;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn;
 
@@ -25,7 +26,7 @@ public class TrnInUseChooseEmailTests : TestBase
     [Fact]
     public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Get, "/sign-in/trn/choose-email");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/trn/choose-email");
     }
 
     [Fact]
@@ -36,6 +37,7 @@ public class TrnInUseChooseEmailTests : TestBase
 
         await JourneyHasExpired_RendersErrorPage(
             c => c.TrnLookupCompletedForExistingTrnAndOwnerEmailVerified(email, existingTrnOwner),
+            CustomScopes.DqtRead,
             HttpMethod.Get,
             "/sign-in/trn/choose-email");
     }
@@ -49,7 +51,10 @@ public class TrnInUseChooseEmailTests : TestBase
         // Arrange
         var existingTrnOwner = await TestData.CreateUser(hasTrn: true);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.TrnLookup(trnLookupState, existingTrnOwner));
+        var authStateHelper = await CreateAuthenticationStateHelper(
+            c => c.TrnLookup(trnLookupState, existingTrnOwner),
+            CustomScopes.DqtRead);
+
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/choose-email?{authStateHelper.ToQueryParam()}");
 
         // Act
@@ -67,7 +72,10 @@ public class TrnInUseChooseEmailTests : TestBase
         var email = Faker.Internet.Email();
         var existingTrnOwner = await TestData.CreateUser(hasTrn: true);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.TrnLookupCompletedForExistingTrnAndOwnerEmailVerified(email, existingTrnOwner));
+        var authStateHelper = await CreateAuthenticationStateHelper(
+            c => c.TrnLookupCompletedForExistingTrnAndOwnerEmailVerified(email, existingTrnOwner),
+            CustomScopes.DqtRead);
+
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/choose-email?{authStateHelper.ToQueryParam()}");
 
         // Act
@@ -95,7 +103,7 @@ public class TrnInUseChooseEmailTests : TestBase
     [Fact]
     public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Post, "/sign-in/trn/choose-email");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/trn/choose-email");
     }
 
     [Fact]
@@ -106,6 +114,7 @@ public class TrnInUseChooseEmailTests : TestBase
 
         await JourneyHasExpired_RendersErrorPage(
             c => c.TrnLookupCompletedForExistingTrnAndOwnerEmailVerified(email, existingTrnOwner),
+            CustomScopes.DqtRead,
             HttpMethod.Post,
             "/sign-in/trn/choose-email");
     }
@@ -120,7 +129,10 @@ public class TrnInUseChooseEmailTests : TestBase
         var email = Faker.Internet.Email();
         var existingTrnOwner = await TestData.CreateUser(hasTrn: true);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.TrnLookup(trnLookupState, existingTrnOwner));
+        var authStateHelper = await CreateAuthenticationStateHelper(
+            c => c.TrnLookup(trnLookupState, existingTrnOwner),
+            CustomScopes.DqtRead);
+
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/choose-email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -144,7 +156,10 @@ public class TrnInUseChooseEmailTests : TestBase
         var email = Faker.Internet.Email();
         var existingTrnOwner = await TestData.CreateUser(hasTrn: true);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.TrnLookupCompletedForExistingTrnAndOwnerEmailVerified(email, existingTrnOwner));
+        var authStateHelper = await CreateAuthenticationStateHelper(
+            c => c.TrnLookupCompletedForExistingTrnAndOwnerEmailVerified(email, existingTrnOwner),
+            CustomScopes.DqtRead);
+
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/choose-email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -165,7 +180,10 @@ public class TrnInUseChooseEmailTests : TestBase
         var existingTrnOwner = await TestData.CreateUser(hasTrn: true);
         var submittedEmail = Faker.Internet.Email();
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.TrnLookupCompletedForExistingTrnAndOwnerEmailVerified(email, existingTrnOwner));
+        var authStateHelper = await CreateAuthenticationStateHelper(
+            c => c.TrnLookupCompletedForExistingTrnAndOwnerEmailVerified(email, existingTrnOwner),
+            CustomScopes.DqtRead);
+
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/choose-email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -191,7 +209,10 @@ public class TrnInUseChooseEmailTests : TestBase
         var existingTrnOwner = await TestData.CreateUser(hasTrn: true);
         var chosenEmail = newEmailChosen ? email : existingTrnOwner.EmailAddress;
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.TrnLookupCompletedForExistingTrnAndOwnerEmailVerified(email, existingTrnOwner));
+        var authStateHelper = await CreateAuthenticationStateHelper(
+            c => c.TrnLookupCompletedForExistingTrnAndOwnerEmailVerified(email, existingTrnOwner),
+            CustomScopes.DqtRead);
+
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/choose-email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnInUseTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnInUseTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Options;
+using TeacherIdentity.AuthServer.Oidc;
 using TeacherIdentity.AuthServer.Services;
 using TeacherIdentity.AuthServer.Services.EmailVerification;
 
@@ -27,7 +28,7 @@ public class TrnInUseTests : TestBase
     [Fact]
     public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Get, "/sign-in/trn/different-email");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/trn/different-email");
     }
 
     [Fact]
@@ -38,6 +39,7 @@ public class TrnInUseTests : TestBase
 
         await JourneyHasExpired_RendersErrorPage(
             c => c.TrnLookupCompletedForExistingTrn(email, existingTrnOwner),
+            CustomScopes.DqtRead,
             HttpMethod.Get,
             "/sign-in/trn/different-email");
     }
@@ -51,7 +53,10 @@ public class TrnInUseTests : TestBase
         // Arrange
         var existingTrnOwner = await TestData.CreateUser(hasTrn: true);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.TrnLookup(trnLookupState, existingTrnOwner));
+        var authStateHelper = await CreateAuthenticationStateHelper(
+            c => c.TrnLookup(trnLookupState, existingTrnOwner),
+            CustomScopes.DqtRead);
+
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/different-email?{authStateHelper.ToQueryParam()}");
 
         // Act
@@ -69,7 +74,10 @@ public class TrnInUseTests : TestBase
         var email = Faker.Internet.Email();
         var existingTrnOwner = await TestData.CreateUser(hasTrn: true);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.TrnLookupCompletedForExistingTrn(email, existingTrnOwner));
+        var authStateHelper = await CreateAuthenticationStateHelper(
+            c => c.TrnLookupCompletedForExistingTrn(email, existingTrnOwner),
+            CustomScopes.DqtRead);
+
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/different-email?{authStateHelper.ToQueryParam()}");
 
         // Act
@@ -97,7 +105,7 @@ public class TrnInUseTests : TestBase
     [Fact]
     public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Post, "/sign-in/trn/different-email");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/trn/different-email");
     }
 
     [Fact]
@@ -108,6 +116,7 @@ public class TrnInUseTests : TestBase
 
         await JourneyHasExpired_RendersErrorPage(
             c => c.TrnLookupCompletedForExistingTrn(email, existingTrnOwner),
+            CustomScopes.DqtRead,
             HttpMethod.Post,
             "/sign-in/trn/different-email");
     }
@@ -124,7 +133,10 @@ public class TrnInUseTests : TestBase
         var emailVerificationService = HostFixture.Services.GetRequiredService<IEmailVerificationService>();
         var pin = await emailVerificationService.GeneratePin(existingTrnOwner.EmailAddress);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.TrnLookup(trnLookupState, existingTrnOwner));
+        var authStateHelper = await CreateAuthenticationStateHelper(
+            c => c.TrnLookup(trnLookupState, existingTrnOwner),
+            CustomScopes.DqtRead);
+
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/different-email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -151,7 +163,10 @@ public class TrnInUseTests : TestBase
         // The real PIN generation service never generates pins that start with a '0'
         var pin = "01234";
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.TrnLookupCompletedForExistingTrn(email, existingTrnOwner));
+        var authStateHelper = await CreateAuthenticationStateHelper(
+            c => c.TrnLookupCompletedForExistingTrn(email, existingTrnOwner),
+            CustomScopes.DqtRead);
+
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/different-email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -175,7 +190,10 @@ public class TrnInUseTests : TestBase
         var existingTrnOwner = await TestData.CreateUser(hasTrn: true);
         var pin = "0";
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.TrnLookupCompletedForExistingTrn(email, existingTrnOwner));
+        var authStateHelper = await CreateAuthenticationStateHelper(
+            c => c.TrnLookupCompletedForExistingTrn(email, existingTrnOwner),
+            CustomScopes.DqtRead);
+
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/different-email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -199,7 +217,10 @@ public class TrnInUseTests : TestBase
         var existingTrnOwner = await TestData.CreateUser(hasTrn: true);
         var pin = "0123345678";
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.TrnLookupCompletedForExistingTrn(email, existingTrnOwner));
+        var authStateHelper = await CreateAuthenticationStateHelper(
+            c => c.TrnLookupCompletedForExistingTrn(email, existingTrnOwner),
+            CustomScopes.DqtRead);
+
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/different-email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -223,7 +244,10 @@ public class TrnInUseTests : TestBase
         var existingTrnOwner = await TestData.CreateUser(hasTrn: true);
         var pin = "abc";
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.TrnLookupCompletedForExistingTrn(email, existingTrnOwner));
+        var authStateHelper = await CreateAuthenticationStateHelper(
+            c => c.TrnLookupCompletedForExistingTrn(email, existingTrnOwner),
+            CustomScopes.DqtRead);
+
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/different-email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -250,7 +274,10 @@ public class TrnInUseTests : TestBase
         Clock.AdvanceBy(TimeSpan.FromHours(1));
         Spy.Get<IEmailVerificationService>().Reset();
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.TrnLookupCompletedForExistingTrn(email, existingTrnOwner));
+        var authStateHelper = await CreateAuthenticationStateHelper(
+            c => c.TrnLookupCompletedForExistingTrn(email, existingTrnOwner),
+            CustomScopes.DqtRead);
+
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/different-email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -281,7 +308,10 @@ public class TrnInUseTests : TestBase
         Clock.AdvanceBy(TimeSpan.FromHours(2) + TimeSpan.FromSeconds(emailVerificationOptions.Value.PinLifetimeSeconds));
         Spy.Get<IEmailVerificationService>().Reset();
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.TrnLookupCompletedForExistingTrn(email, existingTrnOwner));
+        var authStateHelper = await CreateAuthenticationStateHelper(
+            c => c.TrnLookupCompletedForExistingTrn(email, existingTrnOwner),
+            CustomScopes.DqtRead);
+
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/different-email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -308,7 +338,10 @@ public class TrnInUseTests : TestBase
         var emailVerificationService = HostFixture.Services.GetRequiredService<IEmailVerificationService>();
         var pinResult = await emailVerificationService.GeneratePin(existingTrnOwner.EmailAddress);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.TrnLookupCompletedForExistingTrn(email, existingTrnOwner));
+        var authStateHelper = await CreateAuthenticationStateHelper(
+            c => c.TrnLookupCompletedForExistingTrn(email, existingTrnOwner),
+            CustomScopes.DqtRead);
+
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/different-email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnTests.cs
@@ -4,7 +4,6 @@ using TeacherIdentity.AuthServer.Services.TrnLookup;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn;
 
-[Collection(nameof(DisableParallelization))]  // Modifies options
 public class TrnTests : TestBase
 {
     public TrnTests(HostFixture hostFixture)
@@ -60,12 +59,9 @@ public class TrnTests : TestBase
     }
 
     [Fact]
-    public async Task Get_WhenUseNewTrnLookupJourneyTrue_SubmitsToTrnHasTrn()
+    public async Task Get_WhenDqtReadScopeSpecified_SubmitsToTrnHasTrn()
     {
         // Arrange
-        var trnConfig = HostFixture.Services.GetRequiredService<IOptions<FindALostTrnIntegrationOptions>>().Value;
-        trnConfig.UseNewTrnLookupJourney = true;
-
         var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified(), CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn?{authStateHelper.ToQueryParam()}");
@@ -80,5 +76,29 @@ public class TrnTests : TestBase
         var form = doc.GetElementsByTagName("form").Single();
         Assert.StartsWith("/sign-in/trn/has-trn", form.GetAttribute("action"));
         Assert.Equal("GET", form.GetAttribute("method"));
+    }
+
+    [Fact]
+    public async Task Get_WhenDqtReadScopeNotSpecified_SubmitsToHandoverEndpoint()
+    {
+        // Arrange
+#pragma warning disable CS0618 // Type or member is obsolete
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified(), CustomScopes.Trn);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+        var handoverEndpoint = HostFixture.Services.GetRequiredService<IOptions<FindALostTrnIntegrationOptions>>().Value.HandoverEndpoint;
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+        var form = doc.GetElementsByTagName("form").Single();
+        Assert.Equal(handoverEndpoint, form.GetAttribute("action"));
+        Assert.Equal("POST", form.GetAttribute("method"));
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Options;
+using TeacherIdentity.AuthServer.Oidc;
 using TeacherIdentity.AuthServer.Services.TrnLookup;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn;
@@ -26,13 +27,13 @@ public class TrnTests : TestBase
     [Fact]
     public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(HttpMethod.Get, "/sign-in/trn");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/trn");
     }
 
     [Fact]
     public async Task Get_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(c => c.EmailVerified(), HttpMethod.Get, "/sign-in/trn");
+        await JourneyHasExpired_RendersErrorPage(c => c.EmailVerified(), CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/trn");
     }
 
     [Theory]
@@ -47,7 +48,7 @@ public class TrnTests : TestBase
     public async Task Get_ValidRequest_ReturnsOk()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified(), CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn?{authStateHelper.ToQueryParam()}");
 
@@ -65,7 +66,7 @@ public class TrnTests : TestBase
         var trnConfig = HostFixture.Services.GetRequiredService<IOptions<FindALostTrnIntegrationOptions>>().Value;
         trnConfig.UseNewTrnLookupJourney = true;
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified());
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified(), CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn?{authStateHelper.ToQueryParam()}");
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/HostFixture.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/HostFixture.cs
@@ -5,7 +5,6 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApplicationModels;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.AspNetCore.TestHost;
-using Microsoft.Extensions.Options;
 using OpenIddict.Abstractions;
 using OpenIddict.Server.AspNetCore;
 using TeacherIdentity.AuthServer.EventProcessing;
@@ -14,7 +13,6 @@ using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Services.DqtApi;
 using TeacherIdentity.AuthServer.Services.Email;
 using TeacherIdentity.AuthServer.Services.EmailVerification;
-using TeacherIdentity.AuthServer.Services.TrnLookup;
 using TeacherIdentity.AuthServer.Services.UserImport;
 using TeacherIdentity.AuthServer.Services.Zendesk;
 using TeacherIdentity.AuthServer.State;
@@ -98,15 +96,6 @@ public class HostFixture : WebApplicationFactory<TeacherIdentity.AuthServer.Prog
     // N.B. Don't call this from InitializeAsync - it won't work
     public void SetUserId(Guid? userId) => Services.GetRequiredService<CurrentUserIdContainer>().CurrentUserId.Value = userId;
 
-    public void ResetUseNewTrnLookupJourney()
-    {
-        var trnConfig = Configuration.GetSection("FindALostTrnIntegration:UseNewTrnLookupJourney");
-        if (bool.TryParse(trnConfig.Value, out var useNewTrnLookupJourney))
-        {
-            var trnOptions = Services.GetRequiredService<IOptions<FindALostTrnIntegrationOptions>>().Value;
-            trnOptions.UseNewTrnLookupJourney = useNewTrnLookupJourney;
-        }
-    }
     protected override void ConfigureWebHost(IWebHostBuilder builder)
     {
         builder.UseEnvironment("UnitTests");

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/TestClients.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/TestClients.cs
@@ -27,6 +27,7 @@ public static class TestClients
             Permissions.ResponseTypes.Code,
             Permissions.Scopes.Email,
             Permissions.Scopes.Profile,
+            $"{Permissions.Prefixes.Scope}{CustomScopes.DqtRead}",
             $"{Permissions.Prefixes.Scope}{CustomScopes.GetAnIdentitySupport}",
             $"{Permissions.Prefixes.Scope}{CustomScopes.UserRead}",
             $"{Permissions.Prefixes.Scope}{CustomScopes.UserWrite}",

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/TestClients.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/TestClients.cs
@@ -31,7 +31,9 @@ public static class TestClients
             $"{Permissions.Prefixes.Scope}{CustomScopes.GetAnIdentitySupport}",
             $"{Permissions.Prefixes.Scope}{CustomScopes.UserRead}",
             $"{Permissions.Prefixes.Scope}{CustomScopes.UserWrite}",
+#pragma warning disable CS0618 // Type or member is obsolete
             $"{Permissions.Prefixes.Scope}{CustomScopes.Trn}",
+#pragma warning restore CS0618 // Type or member is obsolete
         },
         Requirements =
         {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/UserClaimHelperTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/UserClaimHelperTests.cs
@@ -28,9 +28,11 @@ public class UserClaimHelperTests
         };
 
         // Act
+#pragma warning disable CS0618 // Type or member is obsolete
         var result = UserClaimHelper.GetPublicClaims(
             user,
             hasScope: scope => scope == CustomScopes.Trn && haveTrnScope);
+#pragma warning restore CS0618 // Type or member is obsolete
 
         // Assert
         var expectedClaims = new List<Claim>()
@@ -74,7 +76,9 @@ public class UserClaimHelperTests
             TrnLookupStatus = TrnLookupStatus.Found
         };
 
+#pragma warning disable CS0618 // Type or member is obsolete
         Func<string, bool> hasScope = s => s == CustomScopes.Trn && haveTrnScope;
+#pragma warning restore CS0618 // Type or member is obsolete
 
         var userRequirements = UserRequirementsExtensions.GetUserRequirementsForScopes(hasScope);
 


### PR DESCRIPTION
### Context

We want to rename the `trn` scope to `dqt:read` and we need a way for NPQ to 'opt-in' to the new TRN Optional journey. This solves both issues by putting the new journey behind the new scope.

### Changes proposed in this pull request

Add the `dqt:read` scope and amend the routing logic for the TRN Optional journey to look for this scope instead of a config flag.

Also adds basic e2e tests for the TRN Optional journey.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
