### PR TITLE
Require the HasPreviousName question to be answered

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/OfficialName.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/OfficialName.cshtml
@@ -37,10 +37,10 @@
                             <p>You do not have to tell us your previous name, but it will help us identify you.</p>
                             <p>If we cannot match your current name against our records, we’ll try to match your previous name.</p>
                             <p>If you changed your name more than once, please tell us your most recent previous name.</p>
-                            <govuk-input asp-for="PreviousOfficialFirstName" spellcheck="false" autocomplete="given-name">
+                            <govuk-input asp-for="PreviousOfficialFirstName" spellcheck="false">
                                 <govuk-input-label class="govuk-label--s"/>
                             </govuk-input>
-                            <govuk-input asp-for="PreviousOfficialLastName" spellcheck="false" autocomplete="family-name">
+                            <govuk-input asp-for="PreviousOfficialLastName" spellcheck="false">
                                 <govuk-input-label class="govuk-label--s"/>
                             </govuk-input>
                         </govuk-radios-item-conditional>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/OfficialName.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/OfficialName.cshtml.cs
@@ -28,6 +28,7 @@ public class OfficialName : TrnLookupPageModel
     [Display(Name = "Previous last name (optional)")]
     public string? PreviousOfficialLastName { get; set; }
 
+    [Required(ErrorMessage = "Tell us if you have changed your name")]
     public HasPreviousNameOption? HasPreviousName { get; set; }
 
     public void OnGet()

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/OfficialNameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/OfficialNameTests.cs
@@ -117,9 +117,15 @@ public class OfficialNameTests : TestBase
     {
         // Arrange
         var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
+        var lastName = "last";
+
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/official-name?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
+            {
+                { "OfficialLastName", lastName },
+                { "HasPreviousName", AuthenticationState.HasPreviousNameOption.No },
+            }
         };
 
         // Act
@@ -134,9 +140,15 @@ public class OfficialNameTests : TestBase
     {
         // Arrange
         var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
+        var firstName = "first";
+
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/official-name?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
+            {
+                { "OfficialFirstName", firstName },
+                { "HasPreviousName", AuthenticationState.HasPreviousNameOption.No },
+            }
         };
 
         // Act
@@ -144,6 +156,30 @@ public class OfficialNameTests : TestBase
 
         // Assert
         await AssertEx.HtmlResponseHasError(response, "OfficialLastName", "Enter your last name");
+    }
+
+    [Fact]
+    public async Task Post_HasPreviousNameNotSpecified_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
+        var firstName = "first";
+        var lastName = "last";
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/official-name?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "OfficialFirstName", firstName },
+                { "OfficialLastName", lastName }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "HasPreviousName", "Tell us if you have changed your name");
     }
 
     [Fact]


### PR DESCRIPTION
Add validation to ensure the `HasPreviousName` question is answered on the 'Official name' page.