### PR TITLE
Publish a web hook for user merges

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -26,7 +26,7 @@ Notifications are sent as JSON and have a common outer schema called the envelop
 
 ## Message types
 
-Currently the only implemented notification is when a user is changed (name, email address etc.).
+The are two notification messages types currently; one is for when a user is changed (name, email address etc.) and the other is for when two users are merged.
 
 ### `UserUpdated`
 
@@ -56,6 +56,28 @@ Currently the only implemented notification is when a user is changed (name, ema
 
 The `user` object contains the complete set of user information. `dateOfBirth` and `trn` may be `null`.
 The `changes` object contains only those properties that were changed and their updated values.
+
+### `UserMerged`
+
+`UserMerged` is generated when two user accounts are merged. When accounts are merged, one is chosen as the master and is retained while the second account is deleted.
+
+The message contains both the user details for the master account and ID of the deleted account. Upon receipt of this webhook, any references to `mergedUserId` (the deleted account)
+should be replaced with the ID of the `masterUser`.
+
+```json
+{
+  "masterUser": {
+    "userId": "",
+    "emailAddress": "",
+    "firstName": "",
+    "lastName": "",
+    "dateOfBirth": "",
+    "trn": "",
+    "trnLookupStatus": "None|Pending|Found|Failed"
+  },
+  "mergedUserId": ""
+}
+```
 
 
 ## Receiving webhooks

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Notifications/Messages/UserMergedMessage.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Notifications/Messages/UserMergedMessage.cs
@@ -1,0 +1,9 @@
+namespace TeacherIdentity.AuthServer.Notifications.Messages;
+
+public record UserMergedMessage : INotificationMessage
+{
+    public const string MessageTypeName = "UserMerged";
+
+    public required Guid MergedUserId { get; init; }
+    public required User MasterUser { get; init; }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Notifications/PublishNotificationsEventObserver.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Notifications/PublishNotificationsEventObserver.cs
@@ -41,7 +41,7 @@ public class PublishNotificationsEventObserver : IEventObserver
         return Task.CompletedTask;
     }
 
-    private IEnumerable<NotificationEnvelope> GetNotificationsForEvent(EventBase @event)
+    private static IEnumerable<NotificationEnvelope> GetNotificationsForEvent(EventBase @event)
     {
         if (@event is UserUpdatedEvent userUpdated)
         {
@@ -67,6 +67,20 @@ public class PublishNotificationsEventObserver : IEventObserver
                 },
                 MessageType = UserUpdatedMessage.MessageTypeName,
                 TimeUtc = userUpdated.CreatedUtc
+            };
+        }
+        else if (@event is UserMergedEvent userMerged)
+        {
+            yield return new NotificationEnvelope()
+            {
+                NotificationId = Guid.NewGuid(),
+                Message = new UserMergedMessage()
+                {
+                    MasterUser = userMerged.User,
+                    MergedUserId = userMerged.MergedWithUserId
+                },
+                MessageType = UserMergedMessage.MessageTypeName,
+                TimeUtc = userMerged.CreatedUtc
             };
         }
     }


### PR DESCRIPTION
### Context

We need to notify services when user accounts have been merged so they can update their own user records.

### Changes proposed in this pull request

Generate a web hook when user accounts are merged.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
