### PR TITLE
Add Zendesk settings to Terraform and add a health check

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/Zendesk/ServiceCollectionExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/Zendesk/ServiceCollectionExtensions.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 using ZendeskApi.Client;
 using ZendeskApi.Client.Options;
 
@@ -23,6 +24,14 @@ public static class ServiceCollectionExtensions
                 services.AddScoped<IZendeskClient, ZendeskClient>();
                 services.AddScoped<IZendeskApiClient, ZendeskApiClientFactory>();
                 services.AddScoped<IZendeskApiWrapper, ZendeskApiWrapper>();
+                services.AddTransient<ZendeskHealthCheck>();
+
+                services.AddHealthChecks().Add(
+                    new HealthCheckRegistration(
+                        "Zendesk",
+                        sp => sp.GetRequiredService<ZendeskHealthCheck>(),
+                        HealthStatus.Unhealthy,
+                        tags: null));
             }
         }
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/Zendesk/ZendeskHealthCheck.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/Zendesk/ZendeskHealthCheck.cs
@@ -1,0 +1,28 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using ZendeskApi.Client;
+using ZendeskApi.Client.Models;
+
+namespace TeacherIdentity.AuthServer.Services.Zendesk;
+
+public class ZendeskHealthCheck : IHealthCheck
+{
+    private readonly IZendeskClient _zendeskClient;
+
+    public ZendeskHealthCheck(IZendeskClient zendeskClient)
+    {
+        _zendeskClient = zendeskClient;
+    }
+
+    public async Task<HealthCheckResult> CheckHealthAsync(HealthCheckContext context, CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var tickets = await _zendeskClient.Tickets.GetAllAsync(new CursorPager() { Size = 10 }, cancellationToken);
+            return HealthCheckResult.Healthy();
+        }
+        catch (Exception ex)
+        {
+            return HealthCheckResult.Unhealthy(exception: ex);
+        }
+    }
+}

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -50,7 +50,11 @@ locals {
       Serilog__WriteTo__2__Args__uri               = local.infrastructure_secrets.LOGSTASH_ENDPOINT,
       WEBSITE_SWAP_WARMUP_PING_PATH                = "/status",
       WEBSITE_SWAP_WARMUP_PING_STATUSES            = "200",
-      BaseAddress                                  = local.infrastructure_secrets.BASE_ADDRESS
+      BaseAddress                                  = local.infrastructure_secrets.BASE_ADDRESS,
+      Zendesk__EndpointUri                         = lookup(local.infrastructure_secrets, "ZENDESK_ENDPOINT", ""),
+      Zendesk__Token                               = lookup(local.infrastructure_secrets, "ZENDESK_TOKEN", ""),
+      Zendesk__Username                            = lookup(local.infrastructure_secrets, "ZENDESK_USERNAME", ""),
+      Zendesk__UseFakeClient                       = lookup(local.infrastructure_secrets, "ZENDESK_TOKEN", "") == "" ? "true" : "false"
     }
   )
 


### PR DESCRIPTION
Production Zendesk configuration was missed from PR that added integration. This updates Terraform to get the config from Key Vault and adds a health check to ensure we can successfully talk to API.
