### PR TITLE
Use TestData in e2e tests

### DIFF
--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/HostFixture.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/HostFixture.cs
@@ -10,7 +10,6 @@ using TeacherIdentity.AuthServer.EventProcessing;
 using TeacherIdentity.AuthServer.Oidc;
 using TeacherIdentity.AuthServer.Services.DqtApi;
 using TeacherIdentity.AuthServer.Services.EmailVerification;
-using TeacherIdentity.AuthServer.TestCommon;
 
 namespace TeacherIdentity.AuthServer.EndToEndTests;
 
@@ -47,10 +46,12 @@ public class HostFixture : IAsyncLifetime
 
     public CaptureEventObserver EventObserver => (CaptureEventObserver)AuthServerServices.GetRequiredService<IEventObserver>();
 
+    public string TestClientId => GetTestConfiguration()["Client:ClientId"]!;
+
+    public TestData TestData => AuthServerServices.GetRequiredService<TestData>();
+
     public Task<IBrowserContext> CreateBrowserContext() =>
         Browser!.NewContextAsync(new BrowserNewContextOptions() { BaseURL = ClientBaseUrl });
-
-    public string TestClientId => GetTestConfiguration()["Client:ClientId"]!;
 
     public async Task DisposeAsync()
     {
@@ -134,6 +135,7 @@ public class HostFixture : IAsyncLifetime
                     services.Decorate<IEmailVerificationService>(inner =>
                         new CapturePinsEmailVerificationServiceDecorator(inner, (email, pin) => _capturedEmailConfirmationPins.Add((email, pin))));
                     services.AddSingleton<IEventObserver, CaptureEventObserver>();
+                    services.AddSingleton<TestData>();
                 });
             });
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/UpdateDetails.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/UpdateDetails.cs
@@ -14,35 +14,10 @@ public class UpdateDetails : IClassFixture<HostFixture>
     [Fact]
     public async Task UpdateNameWithinOAuthFlow()
     {
-        var email = Faker.Internet.Email();
-        var firstName = Faker.Name.First();
-        var lastName = Faker.Name.Last();
+        var user = await _hostFixture.TestData.CreateUser(userType: UserType.Default);
 
         var newFirstName = Faker.Name.First();
         var newLastName = Faker.Name.Last();
-
-        {
-            using var scope = _hostFixture.AuthServerServices.GetRequiredService<IServiceScopeFactory>().CreateScope();
-            using var dbContext = scope.ServiceProvider.GetRequiredService<TeacherIdentityServerDbContext>();
-
-            var userId = Guid.NewGuid();
-
-            dbContext.Users.Add(new User()
-            {
-                Created = DateTime.UtcNow,
-                EmailAddress = email,
-                FirstName = firstName,
-                LastName = lastName,
-                UserId = userId,
-                UserType = UserType.Default,
-                DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
-                CompletedTrnLookup = DateTime.UtcNow,
-                Updated = DateTime.UtcNow,
-                TrnLookupStatus = TrnLookupStatus.None
-            });
-
-            await dbContext.SaveChangesAsync();
-        }
 
         await using var context = await _hostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();
@@ -54,7 +29,7 @@ public class UpdateDetails : IClassFixture<HostFixture>
 
         // Fill in the sign in form (email + PIN)
 
-        await page.FillAsync("text=Enter your email address", email);
+        await page.FillAsync("text=Enter your email address", user.EmailAddress);
         await page.ClickAsync("button:text-is('Continue')");
 
         var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
@@ -91,34 +66,9 @@ public class UpdateDetails : IClassFixture<HostFixture>
     [Fact]
     public async Task UpdateEmailWithinOAuthFlow()
     {
-        var email = Faker.Internet.Email();
-        var firstName = Faker.Name.First();
-        var lastName = Faker.Name.Last();
+        var user = await _hostFixture.TestData.CreateUser(userType: UserType.Default);
 
         var newEmail = Faker.Internet.Email();
-
-        {
-            using var scope = _hostFixture.AuthServerServices.GetRequiredService<IServiceScopeFactory>().CreateScope();
-            using var dbContext = scope.ServiceProvider.GetRequiredService<TeacherIdentityServerDbContext>();
-
-            var userId = Guid.NewGuid();
-
-            dbContext.Users.Add(new User()
-            {
-                Created = DateTime.UtcNow,
-                EmailAddress = email,
-                FirstName = firstName,
-                LastName = lastName,
-                UserId = userId,
-                UserType = UserType.Default,
-                DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
-                CompletedTrnLookup = DateTime.UtcNow,
-                Updated = DateTime.UtcNow,
-                TrnLookupStatus = TrnLookupStatus.None
-            });
-
-            await dbContext.SaveChangesAsync();
-        }
 
         await using var context = await _hostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();
@@ -130,7 +80,7 @@ public class UpdateDetails : IClassFixture<HostFixture>
 
         // Fill in the sign in form (email + PIN)
 
-        await page.FillAsync("text=Enter your email address", email);
+        await page.FillAsync("text=Enter your email address", user.EmailAddress);
         await page.ClickAsync("button:text-is('Continue')");
 
         var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Usings.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Usings.cs
@@ -1,1 +1,2 @@
+global using TeacherIdentity.AuthServer.TestCommon;
 global using Xunit;

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TeacherIdentity.AuthServer.TestCommon.csproj
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TeacherIdentity.AuthServer.TestCommon.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Faker.Net" Version="2.0.154" />
     <PackageReference Include="Respawn" Version="6.0.0" />
   </ItemGroup>
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TestData.CreateUser.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TestData.CreateUser.cs
@@ -12,7 +12,8 @@ public partial class TestData
             string? registeredWithClientId = null,
             Guid? mergedWithUserId = null,
             TrnLookupStatus? trnLookupStatus = null,
-            string? firstName = null) =>
+            string? firstName = null,
+            string[]? staffRoles = null) =>
         WithDbContext(async dbContext =>
         {
             if (hasTrn == true && userType != UserType.Default)
@@ -43,10 +44,6 @@ public partial class TestData
             {
                 throw new ArgumentException($"{userType} users should not have {nameof(User.CompletedTrnLookup)} set.");
             }
-            else if (haveCompletedTrnLookup == false && hasTrn == true)
-            {
-                throw new ArgumentException($"Users with a TRN should have {nameof(User.CompletedTrnLookup)} set.");
-            }
 
             var user = new User()
             {
@@ -59,12 +56,13 @@ public partial class TestData
                 UserType = userType,
                 DateOfBirth = userType is UserType.Default ? DateOnly.FromDateTime(Faker.Identification.DateOfBirth()) : null,
                 Trn = hasTrn == true ? GenerateTrn() : null,
-                TrnAssociationSource = hasTrn == true ? TrnAssociationSource.Lookup : null,
+                TrnAssociationSource = hasTrn == true ? (haveCompletedTrnLookup != false ? TrnAssociationSource.Lookup : TrnAssociationSource.Api) : null,
                 TrnLookupStatus = trnLookupStatus ?? (userType == UserType.Default ? (hasTrn == true ? TrnLookupStatus.Found : TrnLookupStatus.None) : null),
                 Updated = _clock.UtcNow,
                 RegisteredWithClientId = registeredWithClientId,
                 MergedWithUserId = mergedWithUserId,
-                IsDeleted = mergedWithUserId != null
+                IsDeleted = mergedWithUserId != null,
+                StaffRoles = userType is UserType.Staff ? staffRoles ?? StaffRoles.All : Array.Empty<string>()
             };
 
             dbContext.Users.Add(user);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TestData.CreateUser.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TestData.CreateUser.cs
@@ -1,6 +1,6 @@
 using TeacherIdentity.AuthServer.Models;
 
-namespace TeacherIdentity.AuthServer.Tests;
+namespace TeacherIdentity.AuthServer.TestCommon;
 
 public partial class TestData
 {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TestData.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TestData.cs
@@ -1,19 +1,20 @@
 using System.Collections.Concurrent;
+using Microsoft.Extensions.DependencyInjection;
 using TeacherIdentity.AuthServer.Models;
 
-namespace TeacherIdentity.AuthServer.Tests;
+namespace TeacherIdentity.AuthServer.TestCommon;
 
 public partial class TestData
 {
     private readonly IServiceProvider _serviceProvider;
-    private readonly TestClock _clock;
+    private readonly IClock _clock;
     private readonly Random _random = new();
     private readonly ConcurrentBag<string> _trns = new();
 
     public TestData(IServiceProvider serviceProvider)
     {
         _serviceProvider = serviceProvider;
-        _clock = (TestClock)serviceProvider.GetRequiredService<IClock>();
+        _clock = serviceProvider.GetRequiredService<IClock>();
     }
 
     public string GenerateTrn()

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/DbFixture.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/DbFixture.cs
@@ -1,6 +1,5 @@
 using TeacherIdentity.AuthServer.EventProcessing;
 using TeacherIdentity.AuthServer.Models;
-using TeacherIdentity.AuthServer.TestCommon;
 using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
 namespace TeacherIdentity.AuthServer.Tests;

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/HostFixture.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/HostFixture.cs
@@ -16,7 +16,6 @@ using TeacherIdentity.AuthServer.Services.EmailVerification;
 using TeacherIdentity.AuthServer.Services.UserImport;
 using TeacherIdentity.AuthServer.Services.Zendesk;
 using TeacherIdentity.AuthServer.State;
-using TeacherIdentity.AuthServer.TestCommon;
 using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
 namespace TeacherIdentity.AuthServer.Tests;

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Startup.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Startup.cs
@@ -1,4 +1,3 @@
-using TeacherIdentity.AuthServer.TestCommon;
 using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
 namespace TeacherIdentity.AuthServer.Tests;

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/TeacherIdentity.AuthServer.Tests.csproj
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/TeacherIdentity.AuthServer.Tests.csproj
@@ -10,8 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="0.17.1" />
-    <PackageReference Include="Faker.Net" Version="2.0.154" />
-    <PackageReference Include="IdentityModel" Version="6.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="Moq" Version="4.18.3" />

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Usings.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Usings.cs
@@ -1,2 +1,3 @@
 global using Moq;
+global using TeacherIdentity.AuthServer.TestCommon;
 global using Xunit;


### PR DESCRIPTION
We use the `TestData.CreateUser()` helper method everywhere in our unit tests. This PR moves the `TestData` class into the `TestCommon` project so we can use it in the end-to-end tests too.