### PR TITLE
Reduce the width of the filters panel

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Users.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Users.cshtml
@@ -20,12 +20,12 @@
                         <govuk-button type="submit">Apply filters</govuk-button>
 
                         <govuk-input asp-for="UserSearch">
-                            <govuk-input-label class="govuk-label--m"/>
+                            <govuk-input-label class="govuk-label--s"/>
                         </govuk-input>
 
-                        <govuk-checkboxes asp-for="LookupStatus">
+                        <govuk-checkboxes asp-for="LookupStatus" class="govuk-checkboxes--small">
                             <govuk-checkboxes-fieldset>
-                                <govuk-checkboxes-fieldset-legend class="govuk-fieldset__legend--m"/>
+                                <govuk-checkboxes-fieldset-legend class="govuk-fieldset__legend--s"/>
                                 @foreach (var status in Enum.GetValues(typeof(TrnLookupStatus)))
                                 {
                                     <govuk-checkboxes-item value="@status">@status</govuk-checkboxes-item>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/wwwroot/Styles/site.scss
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/wwwroot/Styles/site.scss
@@ -102,9 +102,7 @@ $app-button-inverse-hover-background-colour: govuk-tint($app-button-inverse-fore
   @include govuk-media-query(desktop) {
     float: left;
     margin-right: govuk-spacing(7);
-    max-width: 385px;
-    min-width: 260px;
-    width: 100%;
+    width: 260px;
   }
 }
 


### PR DESCRIPTION
With production data the filter on the user list page is so wide some of the columns of the user list are truncated. This change reduces the width of the filter panel and reduces the size of the labels and checkboxes used within it.

It does mean our filter component CSS is non-standard but as we only use this in one place right now I think that's ok.