### PR TITLE
Added table displaying list of user imports in UI

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/UserImports.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/UserImports.cshtml
@@ -4,10 +4,27 @@
     ViewBag.Title = "User Imports";
 }
 
-<h1 class="govuk-heading-xl">@ViewBag.Title</h1>
-
-@*<table class="govuk-table">
-    <caption class="govuk-table__caption govuk-table__caption--xl">@ViewBag.Title</caption>    
-</table>*@
+<table class="govuk-table">
+    <caption class="govuk-table__caption govuk-table__caption--xl">@ViewBag.Title</caption>
+    <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">File</th>
+            <th scope="col" class="govuk-table__header">Uploaded</th>
+            <th scope="col" class="govuk-table__header">Status</th>
+            <th scope="col" class="govuk-table__header">Success / Total</th>
+        </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+        @foreach (var userImport in Model.UserImports!)
+        {
+            <tr class="govuk-table__row" data-testid="user-import-@userImport.UserImportJobId">
+                <td class="govuk-table__cell" data-testid="file-@userImport.UserImportJobId">@userImport.Filename</td>
+                <td class="govuk-table__cell" data-testid="uploaded-@userImport.UserImportJobId">@userImport.Uploaded</td>
+                <td class="govuk-table__cell" data-testid="status-@userImport.UserImportJobId">@userImport.Status</td>
+                <td class="govuk-table__cell" data-testid="summary-@userImport.UserImportJobId">@userImport.SuccessSummary</td>
+            </tr>
+        }
+    </tbody>
+</table>
 
 <p><a asp-page="AddUserImport">Import Users</a></p>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/UserImports.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/UserImports.cshtml.cs
@@ -1,13 +1,45 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Infrastructure.Security;
+using TeacherIdentity.AuthServer.Models;
 
 namespace TeacherIdentity.AuthServer.Pages.Admin;
 
 [Authorize(AuthorizationPolicies.GetAnIdentityAdmin)]
 public class UserImportsModel : PageModel
 {
-    public void OnGet()
+    private readonly TeacherIdentityServerDbContext _dbContext;
+
+    public UserImportsModel(TeacherIdentityServerDbContext dbContext)
     {
+        _dbContext = dbContext;
+    }
+
+    public UserImportJobInfo[]? UserImports { get; set; }
+
+    public async Task OnGet()
+    {
+        UserImports = await _dbContext.UserImportJobs
+            .OrderByDescending(j => j.Uploaded)
+            .Select(j => new UserImportJobInfo()
+            {
+                UserImportJobId = j.UserImportJobId,
+                Filename = j.OriginalFilename,
+                Uploaded = j.Uploaded.ToString("dd/MM/yyyy HH:mm"),
+                Status = j.UserImportJobStatus.ToString(),
+                SuccessSummary = j.UserImportJobRows == null ? "TBC" : $"{j.UserImportJobRows.Count(r => r.UserId != null)} / {j.UserImportJobRows.Count()}"
+            })
+            .ToArrayAsync();
+    }
+
+    public class UserImportJobInfo
+    {
+        public required Guid UserImportJobId { get; init; }
+        public required string Filename { get; init; }
+        public required string Uploaded { get; init; }
+        public required string Status { get; init; }
+        public required string SuccessSummary { get; init; }
+
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/UserImportsTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/UserImportsTests.cs
@@ -1,3 +1,5 @@
+using TeacherIdentity.AuthServer.Models;
+
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Admin;
 
 public class UserImportsTests : TestBase
@@ -24,11 +26,72 @@ public class UserImportsTests : TestBase
     {
         // Arrange
         var request = new HttpRequestMessage(HttpMethod.Get, "/admin/user-imports");
+        var userImportJobId = Guid.NewGuid();
+        var userImportJobRowSuccess1 = new UserImportJobRow
+        {
+            UserImportJobId = userImportJobId,
+            RowNumber = 1,
+            Id = Guid.NewGuid().ToString(),
+            UserId = Guid.NewGuid()
+        };
+
+        var userImportJobRowFailure = new UserImportJobRow
+        {
+            UserImportJobId = userImportJobId,
+            RowNumber = 2,
+            Id = Guid.NewGuid().ToString(),
+            Errors = new List<string> { "There is something wrong with this row" }
+        };
+
+        var userImportJobRowSuccess2 = new UserImportJobRow
+        {
+            UserImportJobId = userImportJobId,
+            RowNumber = 3,
+            Id = Guid.NewGuid().ToString(),
+            UserId = Guid.NewGuid()
+        };
+
+        var userImportJob = new UserImportJob
+        {
+            UserImportJobId = userImportJobId,
+            OriginalFilename = "my-test.csv",
+            StoredFilename = "stored.csv",
+            UserImportJobStatus = UserImportJobStatus.Processed,
+            Uploaded = DateTime.UtcNow,
+            UserImportJobRows = new List<UserImportJobRow>
+            {
+                userImportJobRowSuccess1,
+                userImportJobRowFailure,
+                userImportJobRowSuccess2,
+            }
+        };
+
+        await TestData.WithDbContext(async dbContext =>
+        {
+            dbContext.UserImportJobs.Add(userImportJob);
+            await dbContext.SaveChangesAsync();
+        });
 
         // Act
         var response = await HttpClient.SendAsync(request);
 
         // Assert
         Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+        var tableRow = doc.GetElementByTestId($"user-import-{userImportJobId}");
+        Assert.NotNull(tableRow);
+        var file = tableRow.GetElementByTestId($"file-{userImportJobId}");
+        Assert.NotNull(file);
+        Assert.Equal(userImportJob.OriginalFilename, file.TextContent);
+        var uploaded = tableRow.GetElementByTestId($"uploaded-{userImportJobId}");
+        Assert.NotNull(uploaded);
+        Assert.Equal(userImportJob.Uploaded.ToString("dd/MM/yyyy HH:mm"), uploaded.TextContent);
+        var status = tableRow.GetElementByTestId($"status-{userImportJobId}");
+        Assert.NotNull(status);
+        Assert.Equal(userImportJob.UserImportJobStatus.ToString(), status.TextContent);
+        var summary = tableRow.GetElementByTestId($"summary-{userImportJobId}");
+        Assert.NotNull(summary);
+        Assert.Equal("2 / 3", summary.TextContent);
     }
 }


### PR DESCRIPTION
### Context

Continuation of functionality to allow admin users to imports users into identity via a CSV file

### Changes proposed in this pull request

Change to user imports screen to display a list of previous user imports

### Guidance to review

Change to page + test

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [x] Reminder created to manually clean any removed app settings post deployment
