### PR TITLE
Add 200 character limit to official and preferred names in TRN flow

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/OfficialName.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/OfficialName.cshtml.cs
@@ -16,10 +16,12 @@ public class OfficialName : TrnLookupPageModel
 
     [Display(Name = "First name")]
     [Required(ErrorMessage = "Enter your first name")]
+    [StringLength(200, ErrorMessage = "First name must be 200 characters or less")]
     public string? OfficialFirstName { get; set; }
 
     [Display(Name = "Last name")]
     [Required(ErrorMessage = "Enter your last name")]
+    [StringLength(200, ErrorMessage = "Last name must be 200 characters or less")]
     public string? OfficialLastName { get; set; }
 
     [Display(Name = "Previous first name (optional)")]

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/PreferredName.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/PreferredName.cshtml.cs
@@ -27,10 +27,12 @@ public class PreferredName : PageModel
 
     [Display(Name = "Preferred first name")]
     [RequiredIfTrue(nameof(HasPreferredName), ErrorMessage = "Enter your preferred first name")]
+    [StringLength(200, ErrorMessage = "Preferred first name must be 200 characters or less")]
     public string? PreferredFirstName { get; set; }
 
     [Display(Name = "Preferred last name")]
     [RequiredIfTrue(nameof(HasPreferredName), ErrorMessage = "Enter your preferred last name")]
+    [StringLength(200, ErrorMessage = "Preferred last name must be 200 characters or less")]
     public string? PreferredLastName { get; set; }
 
     public void OnGet()

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/OfficialNameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/OfficialNameTests.cs
@@ -187,7 +187,7 @@ public class OfficialNameTests : TestBase
     {
         // Arrange
         var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
-        var firstName = String.Join("", Enumerable.Repeat("a", 201));
+        var firstName = new string('a', 201);
         var lastName = "last";
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/official-name?{authStateHelper.ToQueryParam()}")
@@ -213,7 +213,7 @@ public class OfficialNameTests : TestBase
         // Arrange
         var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         var firstName = "last";
-        var lastName = String.Join("", Enumerable.Repeat("a", 201));
+        var lastName = new string('a', 201);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/official-name?{authStateHelper.ToQueryParam()}")
         {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/OfficialNameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/OfficialNameTests.cs
@@ -183,6 +183,56 @@ public class OfficialNameTests : TestBase
     }
 
     [Fact]
+    public async Task Post_TooLongOfficialFirstName_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
+        var firstName = String.Join("", Enumerable.Repeat("a", 201));
+        var lastName = "last";
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/official-name?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "OfficialFirstName", firstName },
+                { "OfficialLastName", lastName },
+                { "HasPreviousName", AuthenticationState.HasPreviousNameOption.No },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "OfficialFirstName", "First name must be 200 characters or less");
+    }
+
+    [Fact]
+    public async Task Post_TooLongOfficialLastName_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
+        var firstName = "last";
+        var lastName = String.Join("", Enumerable.Repeat("a", 201));
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/official-name?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "OfficialFirstName", firstName },
+                { "OfficialLastName", lastName },
+                { "HasPreviousName", AuthenticationState.HasPreviousNameOption.No },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "OfficialLastName", "Last name must be 200 characters or less");
+    }
+
+    [Fact]
     public async Task Post_ValidOfficialName_SetsOfficialNameOnAuthenticationStateRedirectsToPreferredName()
     {
         // Arrange

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/PreferredNameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/PreferredNameTests.cs
@@ -176,7 +176,7 @@ public class PreferredNameTests : TestBase
     {
         // Arrange
         var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
-        var firstName = String.Join("", Enumerable.Repeat("a", 201));
+        var firstName = new string('a', 201);
         var lastName = "last";
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/preferred-name?{authStateHelper.ToQueryParam()}")
@@ -202,7 +202,7 @@ public class PreferredNameTests : TestBase
         // Arrange
         var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
         var firstName = "last";
-        var lastName = String.Join("", Enumerable.Repeat("a", 201));
+        var lastName = new string('a', 201);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/preferred-name?{authStateHelper.ToQueryParam()}")
         {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/PreferredNameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/PreferredNameTests.cs
@@ -172,6 +172,56 @@ public class PreferredNameTests : TestBase
     }
 
     [Fact]
+    public async Task Post_TooLongPreferredFirstName_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
+        var firstName = String.Join("", Enumerable.Repeat("a", 201));
+        var lastName = "last";
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/preferred-name?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "HasPreferredName", true },
+                { "PreferredFirstName", firstName },
+                { "PreferredLastName", lastName },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "PreferredFirstName", "Preferred first name must be 200 characters or less");
+    }
+
+    [Fact]
+    public async Task Post_TooLongPreferredLastName_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
+        var firstName = "last";
+        var lastName = String.Join("", Enumerable.Repeat("a", 201));
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/preferred-name?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "HasPreferredName", true },
+                { "PreferredFirstName", firstName },
+                { "PreferredLastName", lastName },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "PreferredLastName", "Preferred last name must be 200 characters or less");
+    }
+
+    [Fact]
     public async Task Post_ValidForm_RedirectsToDateOfBirthPage()
     {
         // Arrange


### PR DESCRIPTION
### Context

The database only allows first names and last name up to 200 characters in length but are we are not currently checking this.

### Changes proposed in this pull request

Add validation to the preferred name and official name pages to check both first and last name are not longer than 200 characters.

### Guidance to review

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [x] Reminder created to manually clean any removed app settings post deployment
