### PR TITLE
Update SignIn landing page with client specific content

### DIFF
--- a/.github/workflows/actions/deploy-environment/action.yml
+++ b/.github/workflows/actions/deploy-environment/action.yml
@@ -143,7 +143,7 @@ runs:
 
     - uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '7.0.x'
+        dotnet-version: '7.0.103'
 
     - name: Smoke tests
       uses: ./.github/workflows/actions/test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '7.0.x'
+          dotnet-version: '7.0.103'
 
       - name: Lint
         run: |

--- a/dotnet-authserver/TeacherIdentity.sln
+++ b/dotnet-authserver/TeacherIdentity.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 	ProjectSection(SolutionItems) = preProject
 		.editorconfig = .editorconfig
 		Directory.Build.props = Directory.Build.props
+		global.json = global.json
 		nuget.config = nuget.config
 	EndProjectSection
 EndProject

--- a/dotnet-authserver/global.json
+++ b/dotnet-authserver/global.json
@@ -1,0 +1,6 @@
+{
+    "sdk": {
+        "version": "7.0.103",
+        "rollForward": "disable"
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/TeacherIdentityServerDbContext.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/TeacherIdentityServerDbContext.cs
@@ -67,7 +67,9 @@ public class TeacherIdentityServerDbContext : DbContext
         modelBuilder.Entity<Token>().ToTable("tokens");
     }
 
+    #pragma warning disable CS0809
     [Obsolete($"Use {nameof(SaveChangesAsync)} instead.")]
+    #pragma warning restore CS0809
     public override int SaveChanges(bool acceptAllChangesOnSuccess)
     {
         throw new NotSupportedException($"Use {nameof(SaveChangesAsync)} instead.");

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/TeacherIdentityServerDbContext.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/TeacherIdentityServerDbContext.cs
@@ -67,9 +67,9 @@ public class TeacherIdentityServerDbContext : DbContext
         modelBuilder.Entity<Token>().ToTable("tokens");
     }
 
-    #pragma warning disable CS0809
+#pragma warning disable CS0809
     [Obsolete($"Use {nameof(SaveChangesAsync)} instead.")]
-    #pragma warning restore CS0809
+#pragma warning restore CS0809
     public override int SaveChanges(bool acceptAllChangesOnSuccess)
     {
         throw new NotSupportedException($"Use {nameof(SaveChangesAsync)} instead.");

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/TeacherIdentityServerDbContext.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/TeacherIdentityServerDbContext.cs
@@ -69,11 +69,11 @@ public class TeacherIdentityServerDbContext : DbContext
 
 #pragma warning disable CS0809
     [Obsolete($"Use {nameof(SaveChangesAsync)} instead.")]
-#pragma warning restore CS0809
     public override int SaveChanges(bool acceptAllChangesOnSuccess)
     {
         throw new NotSupportedException($"Use {nameof(SaveChangesAsync)} instead.");
     }
+#pragma warning restore CS0809
 
     public override async Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default)
     {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Landing.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Landing.cshtml
@@ -1,17 +1,20 @@
 @page "/sign-in/landing"
 @{
-    ViewBag.Title = "You need a Teaching Services account to continue";
+    ViewBag.Title = "Create a Teaching services account";
 }
 
 <div class="govuk-grid-row">
-    <div class="govuk-grid-column-two-thirds-from-desktop">
+    <div class="govuk-grid-column-two-thirds-from-desktop" data-testid="landing-content">
         <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
 
-        <p>A teaching services account lets you:</p>
+        <p>It will only take a few minutes and you’ll need:</p>
         <ul class="govuk-list govuk-list--bullet">
-            <li>access different teaching services with one login</li>
-            <li>update your details in one place</li>
+            <li>an email address (used for contact and account security)</li>
+            <li>a mobile phone number (used for account security)</li>
+            <li>your name and date of birth</li>
         </ul>
+
+        <vc:client-scoped-partial view-name="_SignIn.Landing.{0}.Content" />
 
         <govuk-button-link href="@LinkGenerator.Register()">Create an account</govuk-button-link>
 
@@ -20,5 +23,13 @@
         <p>
             <a href="@LinkGenerator.Email()">Sign in</a> to use your existing account details
         </p>
+
+        <govuk-details>
+            <govuk-details-summary>About Teaching services accounts</govuk-details-summary>
+            <govuk-details-text>
+                <p>Teaching services accounts are new. They let teachers and teaching professionals access different DfE services with one login. You can also update your details with DfE in one place.</p>
+                <p>At the moment there are only a few DfE services using Teaching services accounts. In the future, you’ll be able to use your account details to sign in to most DfE teaching services.</p>
+            </govuk-details-text>
+        </govuk-details>
     </div>
 </div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn.cshtml
@@ -4,7 +4,7 @@
     ViewBag.Title = (await Component.InvokeAsync("ClientScopedPartial", new { viewName = "_TrnLookup.StartBookend.{0}.Title" })).RenderToString();
 }
 
-<govuk-panel class="app-panel--interruption">
+<govuk-panel class="app-panel--interruption" data-testid="trn-panel-content">
     <govuk-panel-title>
         <vc:client-scoped-partial view-name="_TrnLookup.StartBookend.{0}.Title" />
     </govuk-panel-title>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/_SignIn.Landing.ApplyForQTS.Content.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/_SignIn.Landing.ApplyForQTS.Content.cshtml
@@ -1,0 +1,1 @@
+<p>Once you’ve created an account, you can continue to Apply for qualified teacher status (QTS) in England.</p>

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text;
 using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Oidc;
 using TeacherIdentity.AuthServer.State;
 using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
@@ -26,13 +27,15 @@ public sealed class AuthenticationStateHelper
     public static async Task<AuthenticationStateHelper> Create(
         Func<Configure, Func<AuthenticationState, Task>> configureAuthenticationState,
         HostFixture hostFixture,
-        string? additionalScopes)
+        string? additionalScopes,
+        TeacherIdentityApplicationDescriptor? client)
     {
         var authenticationStateProvider = (TestAuthenticationStateProvider)hostFixture.Services.GetRequiredService<IAuthenticationStateProvider>();
 
+        client ??= TestClients.Client1;
+
         var journeyId = Guid.NewGuid();
         var codeChallenge = Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes("12345")));
-        var client = TestClients.Client1;
         var fullScope = $"email profile {additionalScopes}".Trim();
         var redirectUri = client.RedirectUris.First().ToString();
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/CompleteTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/CompleteTests.cs
@@ -96,4 +96,42 @@ public class CompleteTests : TestBase
         var doc = await response.GetDocument();
         Assert.NotNull(doc.GetElementByTestId("known-user-content"));
     }
+
+    [Fact]
+    public async Task Get_FirstTimeSignInForEmailWithoutTrnUsingRegisterForNpqClient_RendersExpectedContent()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(hasTrn: false);
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Completed(user, firstTimeSignIn: true), additionalScopes: null, TestClients.RegisterForNpq);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/complete?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Act
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+        Assert.Contains("Continue to register for an NPQ", doc.GetElementByTestId("first-time-user-content")!.InnerHtml);
+        Assert.Contains("Although we could not find your record, you can continue to register for an NPQ.", doc.GetElementByTestId("first-time-user-content")!.InnerHtml);
+    }
+
+    [Fact]
+    public async Task Get_FirstTimeSignInForEmailWithoutTrnUsingDefaultClient_RendersExpectedContent()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(hasTrn: false);
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Completed(user, firstTimeSignIn: true), additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/complete?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Act
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+        Assert.Contains("We’ve finished checking our records", doc.GetElementByTestId("first-time-user-content")!.InnerHtml);
+        Assert.Contains("You can continue anyway and we’ll try to find your record. Someone may be in touch to ask for more information.", doc.GetElementByTestId("first-time-user-content")!.InnerHtml);
+    }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/LandingTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/LandingTests.cs
@@ -1,6 +1,3 @@
-using Flurl;
-using TeacherIdentity.AuthServer.State;
-
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn;
 
 public class LandingTests : TestBase

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/LandingTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/LandingTests.cs
@@ -44,9 +44,7 @@ public class LandingTests : TestBase
     public async Task Get_ValidRequestApplyForQTSClient_RendersClientScopedPartialContent()
     {
         var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null, TestClients.ApplyForQts);
-
-        var fullUrl = new Url("/sign-in/landing").SetQueryParam(AuthenticationStateMiddleware.IdQueryParameterName, authStateHelper.AuthenticationState.JourneyId);
-        var request = new HttpRequestMessage(HttpMethod.Get, fullUrl);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/landing?{authStateHelper.ToQueryParam()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TestBase.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TestBase.cs
@@ -1,3 +1,4 @@
+using TeacherIdentity.AuthServer.Oidc;
 using TeacherIdentity.AuthServer.Services.DqtApi;
 using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
@@ -30,8 +31,9 @@ public abstract partial class TestBase
 
     public Task<AuthenticationStateHelper> CreateAuthenticationStateHelper(
         Func<AuthenticationStateHelper.Configure, Func<AuthenticationState, Task>> configure,
-        string? additionalScopes) =>
-        AuthenticationStateHelper.Create(configure, HostFixture, additionalScopes);
+        string? additionalScopes,
+        TeacherIdentityApplicationDescriptor? client = null) =>
+        AuthenticationStateHelper.Create(configure, HostFixture, additionalScopes, client);
 
     public void ConfigureDqtApiClientToReturnSingleMatch(AuthenticationStateHelper authStateHelper)
     {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnTests.cs
@@ -101,4 +101,42 @@ public class TrnTests : TestBase
         Assert.Equal(handoverEndpoint, form.GetAttribute("action"));
         Assert.Equal("POST", form.GetAttribute("method"));
     }
+
+    [Fact]
+    public async Task Get_WithRegisterForNpqClient_RendersCorrectContent()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified(), CustomScopes.DqtRead, TestClients.RegisterForNpq);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+        Assert.Contains("Your details", doc.GetElementByTestId("trn-panel-content")!.InnerHtml);
+        Assert.Contains("Before you register for an NPQ", doc.GetElementByTestId("trn-panel-content")!.InnerHtml);
+    }
+
+    [Fact]
+    public async Task Get_WithDefaultClient_RendersCorrectContent()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified(), CustomScopes.DqtRead);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+        Assert.Contains("We’ll ask you some questions to check against our records", doc.GetElementByTestId("trn-panel-content")!.InnerHtml);
+        Assert.Contains("We’ll ask for your:", doc.GetElementByTestId("trn-panel-content")!.InnerHtml);
+    }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/TestClients.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/TestClients.cs
@@ -6,11 +6,44 @@ namespace TeacherIdentity.AuthServer.Tests;
 
 public static class TestClients
 {
-    public static OpenIddictApplicationDescriptor[] All => new[] { Client1 };
+    public static OpenIddictApplicationDescriptor[] All => new[] { Client1, ApplyForQts };
 
     public static TeacherIdentityApplicationDescriptor Client1 { get; } = new TeacherIdentityApplicationDescriptor()
     {
         ClientId = "testclient1",
+        ClientSecret = "secret",
+        ConsentType = ConsentTypes.Implicit,
+        DisplayName = "Sample TeacherIdentity.TestClient app",
+        RedirectUris =
+        {
+            new Uri("https://localhost:1234/oidc/callback")
+        },
+        Permissions =
+        {
+            Permissions.Endpoints.Authorization,
+            Permissions.Endpoints.Token,
+            Permissions.GrantTypes.AuthorizationCode,
+            Permissions.GrantTypes.Password,
+            Permissions.ResponseTypes.Code,
+            Permissions.Scopes.Email,
+            Permissions.Scopes.Profile,
+            $"{Permissions.Prefixes.Scope}{CustomScopes.DqtRead}",
+            $"{Permissions.Prefixes.Scope}{CustomScopes.GetAnIdentitySupport}",
+            $"{Permissions.Prefixes.Scope}{CustomScopes.UserRead}",
+            $"{Permissions.Prefixes.Scope}{CustomScopes.UserWrite}",
+#pragma warning disable CS0618 // Type or member is obsolete
+            $"{Permissions.Prefixes.Scope}{CustomScopes.Trn}",
+#pragma warning restore CS0618 // Type or member is obsolete
+        },
+        Requirements =
+        {
+            Requirements.Features.ProofKeyForCodeExchange
+        }
+    };
+
+    public static TeacherIdentityApplicationDescriptor ApplyForQts { get; } = new TeacherIdentityApplicationDescriptor()
+    {
+        ClientId = "apply-for-qts",
         ClientSecret = "secret",
         ConsentType = ConsentTypes.Implicit,
         DisplayName = "Sample TeacherIdentity.TestClient app",

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/TestClients.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/TestClients.cs
@@ -6,7 +6,7 @@ namespace TeacherIdentity.AuthServer.Tests;
 
 public static class TestClients
 {
-    public static OpenIddictApplicationDescriptor[] All => new[] { Client1, ApplyForQts };
+    public static OpenIddictApplicationDescriptor[] All => new[] { Client1, ApplyForQts, RegisterForNpq };
 
     public static TeacherIdentityApplicationDescriptor Client1 { get; } = new TeacherIdentityApplicationDescriptor()
     {
@@ -46,7 +46,7 @@ public static class TestClients
         ClientId = "apply-for-qts",
         ClientSecret = "secret",
         ConsentType = ConsentTypes.Implicit,
-        DisplayName = "Sample TeacherIdentity.TestClient app",
+        DisplayName = "Apply for qualified teacher status (QTS) in England",
         RedirectUris =
         {
             new Uri("https://localhost:1234/oidc/callback")
@@ -56,17 +56,34 @@ public static class TestClients
             Permissions.Endpoints.Authorization,
             Permissions.Endpoints.Token,
             Permissions.GrantTypes.AuthorizationCode,
-            Permissions.GrantTypes.Password,
             Permissions.ResponseTypes.Code,
             Permissions.Scopes.Email,
             Permissions.Scopes.Profile,
-            $"{Permissions.Prefixes.Scope}{CustomScopes.DqtRead}",
-            $"{Permissions.Prefixes.Scope}{CustomScopes.GetAnIdentitySupport}",
-            $"{Permissions.Prefixes.Scope}{CustomScopes.UserRead}",
-            $"{Permissions.Prefixes.Scope}{CustomScopes.UserWrite}",
-#pragma warning disable CS0618 // Type or member is obsolete
-            $"{Permissions.Prefixes.Scope}{CustomScopes.Trn}",
-#pragma warning restore CS0618 // Type or member is obsolete
+        },
+        Requirements =
+        {
+            Requirements.Features.ProofKeyForCodeExchange
+        }
+    };
+
+    public static TeacherIdentityApplicationDescriptor RegisterForNpq { get; } = new TeacherIdentityApplicationDescriptor()
+    {
+        ClientId = "register-for-npq",
+        ClientSecret = "secret",
+        ConsentType = ConsentTypes.Implicit,
+        DisplayName = "Register for an NPQ",
+        RedirectUris =
+        {
+            new Uri("https://localhost:1234/oidc/callback")
+        },
+        Permissions =
+        {
+            Permissions.Endpoints.Authorization,
+            Permissions.Endpoints.Token,
+            Permissions.GrantTypes.AuthorizationCode,
+            Permissions.ResponseTypes.Code,
+            Permissions.Scopes.Email,
+            Permissions.Scopes.Profile,
         },
         Requirements =
         {


### PR DESCRIPTION
### Context

We need a sign in/registration flow that is independent of DQT and TRNs.

### Changes proposed in this pull request

Modify the /sign-in/landing page to match the designs in the prototype.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [x] Reminder created to manually clean any removed app settings post deployment
