### PR TITLE
Fix TrnLookupStatus for users not found in Find

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230216161649_TrnLookupStatusCheckConstraint.Designer.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230216161649_TrnLookupStatusCheckConstraint.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeacherIdentity.AuthServer.Models;
@@ -12,9 +13,11 @@ using TeacherIdentity.AuthServer.Models;
 namespace TeacherIdentity.AuthServer.Migrations
 {
     [DbContext(typeof(TeacherIdentityServerDbContext))]
-    partial class TeacherIdentityServerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230216161649_TrnLookupStatusCheckConstraint")]
+    partial class TrnLookupStatusCheckConstraint
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230216161649_TrnLookupStatusCheckConstraint.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230216161649_TrnLookupStatusCheckConstraint.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeacherIdentity.AuthServer.Migrations
+{
+    /// <inheritdoc />
+    public partial class TrnLookupStatusCheckConstraint : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("""
+                update users set trn_lookup_status = 1
+                where trn_lookup_status = 0 and completed_trn_lookup is not null;
+                """);
+
+            migrationBuilder.AddCheckConstraint(
+                name: "ck_trn_lookup_status",
+                table: "users",
+                sql: "(completed_trn_lookup is null and trn is null) or trn_lookup_status is not null");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "ck_trn_lookup_status",
+                table: "users");
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/Mappings/UserMapping.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/Mappings/UserMapping.cs
@@ -7,7 +7,9 @@ public class UserMapping : IEntityTypeConfiguration<User>
 {
     public void Configure(EntityTypeBuilder<User> builder)
     {
-        builder.ToTable("users");
+        builder.ToTable(
+            "users",
+            t => t.HasCheckConstraint("ck_trn_lookup_status", "(completed_trn_lookup is null and trn is null) or trn_lookup_status is not null"));
         builder.HasKey(u => u.UserId);
         builder.Property(u => u.EmailAddress).HasMaxLength(User.EmailAddressMaxLength).IsRequired().UseCollation("case_insensitive");
         builder.HasIndex(u => u.EmailAddress).IsUnique().HasDatabaseName(User.EmailAddressUniqueIndexName).HasFilter("is_deleted = false");

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnCallback.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnCallback.cshtml.cs
@@ -68,9 +68,7 @@ public class TrnCallbackModel : PageModel
             TrnAssociationSource = !string.IsNullOrEmpty(lookupState.Trn) ? TrnAssociationSource.Lookup : null,
             LastSignedIn = _clock.UtcNow,
             RegisteredWithClientId = authenticationState.OAuthState?.ClientId,
-            TrnLookupStatus = lookupState.Trn is not null ? TrnLookupStatus.Found :
-                lookupState.SupportTicketCreated ? TrnLookupStatus.Pending :
-                TrnLookupStatus.None
+            TrnLookupStatus = lookupState.Trn is not null ? TrnLookupStatus.Found : TrnLookupStatus.Pending
         };
 
         _dbContext.Users.Add(user);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnCallbackTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnCallbackTests.cs
@@ -119,12 +119,10 @@ public class TrnCallbackTests : TestBase
     }
 
     [Theory]
-    [InlineData(true, false, TrnLookupStatus.Found)]
-    [InlineData(false, false, TrnLookupStatus.None)]
-    [InlineData(false, true, TrnLookupStatus.Pending)]
+    [InlineData(true, TrnLookupStatus.Found)]
+    [InlineData(false, TrnLookupStatus.Pending)]
     public async Task Get_ValidCallback_CreatesUserLocksLookupStateAndRedirectsToNextPage(
         bool hasTrn,
-        bool supportTicketCreated,
         TrnLookupStatus expectedTrnLookupStatus)
     {
         // Arrange
@@ -135,7 +133,7 @@ public class TrnCallbackTests : TestBase
         var trn = hasTrn ? TestData.GenerateTrn() : null;
 
         var authStateHelper = await CreateAuthenticationStateHelper(
-            c => c.TrnLookupCallbackCompleted(email, trn, dateOfBirth, firstName, lastName, supportTicketCreated),
+            c => c.TrnLookupCallbackCompleted(email, trn, dateOfBirth, firstName, lastName),
             CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/callback?{authStateHelper.ToQueryParam()}");


### PR DESCRIPTION
When we introduced `TrnLookupStatus` we set all existing users without a TRN to `Pending`, since NPQ expects all users to have a TRN.

For 'TRN Optional', the Find integration API endpoint was updated to add an additional property - `SupportTicketCreated` - so that for new users without a found TRN we would use `Pending` if a Zendesk support ticket were raised (since we expect the user to have a TRN based on their answers) or `None`, if the answers suggest they don't in fact have a TRN. Find never actually populated this property on the API however so the property was the default - `false` -  meaning we've marked all new users without a TRN `TrnLookupStatus.None`.

This change fixes up all users with `TrnLookupStatus.None` to make them `TrnLookupStatus.Pending` (I've checked and this is safe to do with the current production data). It also modifies the behaviour for new users to make them all `TrnLookupStatus.Pending`. 

When 'TRN Optional' rolls out proper we'll be using our own journey, not integrating with Find, so we will correctly derive `TrnLookupStatus` from then on.

I've also added a check constraint to ensure we're setting `TrnLookupStatus` when we need to.