### PR TITLE
Simplify Claim creation

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -134,10 +134,10 @@ public class AuthenticationState
         JsonSerializer.Deserialize<AuthenticationState>(serialized, _jsonSerializerOptions) ??
             throw new ArgumentException($"Serialized {nameof(AuthenticationState)} is not valid.", nameof(serialized));
 
-    public static AuthenticationState FromInternalClaims(
+    public static AuthenticationState FromUser(
         Guid journeyId,
         UserRequirements userRequirements,
-        ClaimsPrincipal principal,
+        User? user,
         string postSignInUrl,
         DateTime startedAt,
         string? sessionId = null,
@@ -146,19 +146,19 @@ public class AuthenticationState
     {
         return new AuthenticationState(journeyId, userRequirements, postSignInUrl, startedAt, sessionId, oAuthState)
         {
-            UserId = principal.GetUserId(throwIfMissing: false),
+            UserId = user?.UserId,
             FirstTimeSignInForEmail = firstTimeSignInForEmail,
-            EmailAddress = principal.GetEmailAddress(throwIfMissing: false),
-            EmailAddressVerified = principal.GetEmailAddressVerified(throwIfMissing: false) ?? false,
-            FirstName = principal.GetFirstName(throwIfMissing: false),
-            LastName = principal.GetLastName(throwIfMissing: false),
-            DateOfBirth = principal.GetDateOfBirth(throwIfMissing: false),
-            Trn = principal.GetTrn(throwIfMissing: false),
-            HaveCompletedTrnLookup = principal.GetHaveCompletedTrnLookup(throwIfMissing: false) ?? false,
-            TrnLookup = principal.GetHaveCompletedTrnLookup(throwIfMissing: false) == true ? TrnLookupState.Complete : TrnLookupState.None,
-            UserType = principal.GetUserType(throwIfMissing: false),
-            StaffRoles = principal.GetStaffRoles(),
-            TrnLookupStatus = principal.GetTrnLookupStatus(throwIfMissing: false)
+            EmailAddress = user?.EmailAddress,
+            EmailAddressVerified = user is not null,
+            FirstName = user?.FirstName,
+            LastName = user?.LastName,
+            DateOfBirth = user?.DateOfBirth,
+            Trn = user?.Trn,
+            HaveCompletedTrnLookup = user?.CompletedTrnLookup is not null,
+            TrnLookup = user?.CompletedTrnLookup is not null ? TrnLookupState.Complete : TrnLookupState.None,
+            UserType = user?.UserType,
+            StaffRoles = user?.StaffRoles,
+            TrnLookupStatus = user?.TrnLookupStatus
         };
     }
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/ClaimsPrincipalExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/ClaimsPrincipalExtensions.cs
@@ -1,6 +1,97 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Claims;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Oidc;
+using static OpenIddict.Abstractions.OpenIddictConstants;
+
 namespace TeacherIdentity.AuthServer;
 
 public static class ClaimsPrincipalExtensions
 {
+    public static string? GetEmailAddress(this ClaimsPrincipal principal, bool throwIfMissing = true) =>
+        GetClaim(principal, Claims.Email, throwIfMissing);
 
+    public static string? GetFirstName(this ClaimsPrincipal principal, bool throwIfMissing = true) =>
+        GetClaim(principal, Claims.GivenName, throwIfMissing);
+
+    public static string? GetLastName(this ClaimsPrincipal principal, bool throwIfMissing = true) =>
+        GetClaim(principal, Claims.FamilyName, throwIfMissing);
+
+    public static string[] GetStaffRoles(this ClaimsPrincipal principal) =>
+        principal.Claims.Where(c => c.Type == Claims.Role).Select(c => c.Value).ToArray();
+
+    public static string? GetTrn(this ClaimsPrincipal principal, bool throwIfMissing = true) =>
+        GetClaim(principal, CustomClaims.Trn, throwIfMissing);
+
+    public static Guid? GetUserId(this ClaimsPrincipal principal, bool throwIfMissing = true)
+    {
+        // Subject here can either be a GUID (which is our User ID) or it could be the client ID
+        // (in cases where client credentials grant is being used)
+
+        var value = principal.FindFirstValue(Claims.Subject);
+
+        if (string.IsNullOrEmpty(value))
+        {
+            if (throwIfMissing)
+            {
+                ThrowClaimMissingException(Claims.Subject);
+            }
+
+            return null;
+        }
+
+        if (!Guid.TryParse(value, out var userId))
+        {
+            if (throwIfMissing)
+            {
+                throw new InvalidOperationException($"The '{Claims.Subject}' claim does not contain a user ID.");
+            }
+
+            return null;
+        }
+
+        return userId;
+    }
+
+    public static UserType? GetUserType(this ClaimsPrincipal principal, bool throwIfMissing = true) =>
+        GetClaim(principal, CustomClaims.UserType, throwIfMissing, Enum.Parse<UserType>);
+
+    private static string? GetClaim(ClaimsPrincipal principal, string claimType, bool throwIfMissing)
+    {
+        var value = principal.FindFirstValue(claimType);
+
+        if (string.IsNullOrEmpty(value))
+        {
+            if (throwIfMissing)
+            {
+                ThrowClaimMissingException(claimType);
+            }
+
+            return null;
+        }
+
+        return value;
+    }
+
+    private static T? GetClaim<T>(ClaimsPrincipal principal, string claimType, bool throwIfMissing, Func<string, T> convertValue)
+        where T : struct
+    {
+        var value = principal.FindFirstValue(claimType);
+
+        if (string.IsNullOrEmpty(value))
+        {
+            if (throwIfMissing)
+            {
+                ThrowClaimMissingException(claimType);
+            }
+
+            return null;
+        }
+
+        return convertValue(value);
+    }
+
+    [DoesNotReturn]
+    private static void ThrowClaimMissingException(string claimType) =>
+        throw new InvalidOperationException($"No '{claimType}' claim was found.");
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
@@ -450,7 +450,8 @@ public class Program
             .AddSingleton<ProtectedStringFactory>()
             .AddTransient<ClientScopedViewHelper>()
             .AddTransient<IActionContextAccessor, ActionContextAccessor>()
-            .AddTransient<TrnLookupHelper>();
+            .AddTransient<TrnLookupHelper>()
+            .AddTransient<UserClaimHelper>();
 
         builder.Services.AddNotifications(builder.Environment, builder.Configuration);
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/UserClaimHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/UserClaimHelper.cs
@@ -1,89 +1,21 @@
-using System.Diagnostics.CodeAnalysis;
 using System.Security.Claims;
+using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Oidc;
 using static OpenIddict.Abstractions.OpenIddictConstants;
 
 namespace TeacherIdentity.AuthServer;
 
-public static class UserClaimHelper
+public class UserClaimHelper
 {
-    public static DateOnly? GetDateOfBirth(this ClaimsPrincipal principal, bool throwIfMissing = true) =>
-        GetClaim(principal, Claims.Birthdate, throwIfMissing, value => DateOnly.ParseExact(value, CustomClaims.DateFormat));
+    private readonly TeacherIdentityServerDbContext _dbContext;
 
-    public static string? GetEmailAddress(this ClaimsPrincipal principal, bool throwIfMissing = true) =>
-        GetClaim(principal, Claims.Email, throwIfMissing);
-
-    public static bool? GetEmailAddressVerified(this ClaimsPrincipal principal, bool throwIfMissing = true) =>
-        GetClaim(principal, Claims.EmailVerified, throwIfMissing, value => bool.Parse(value));
-
-    public static string? GetFirstName(this ClaimsPrincipal principal, bool throwIfMissing = true) =>
-        GetClaim(principal, Claims.GivenName, throwIfMissing);
-
-    public static bool? GetHaveCompletedTrnLookup(this ClaimsPrincipal principal, bool throwIfMissing = true) =>
-        GetClaim(principal, CustomClaims.HaveCompletedTrnLookup, throwIfMissing, value => bool.Parse(value));
-
-    public static string? GetLastName(this ClaimsPrincipal principal, bool throwIfMissing = true) =>
-        GetClaim(principal, Claims.FamilyName, throwIfMissing);
-
-    public static string[] GetStaffRoles(this ClaimsPrincipal principal) =>
-        principal.Claims.Where(c => c.Type == Claims.Role).Select(c => c.Value).ToArray();
-
-    public static string? GetTrn(this ClaimsPrincipal principal, bool throwIfMissing = true) =>
-        GetClaim(principal, CustomClaims.Trn, throwIfMissing);
-
-    public static Guid? GetUserId(this ClaimsPrincipal principal, bool throwIfMissing = true)
+    public UserClaimHelper(TeacherIdentityServerDbContext dbContext)
     {
-        // Subject here can either be a GUID (which is our User ID) or it could be the client ID
-        // (in cases where client credentials grant is being used)
-
-        var value = principal.FindFirstValue(Claims.Subject);
-
-        if (string.IsNullOrEmpty(value))
-        {
-            if (throwIfMissing)
-            {
-                ThrowClaimMissingException(Claims.Subject);
-            }
-
-            return null;
-        }
-
-        if (!Guid.TryParse(value, out var userId))
-        {
-            if (throwIfMissing)
-            {
-                throw new InvalidOperationException($"The '{Claims.Subject}' claim does not contain a user ID.");
-            }
-
-            return null;
-        }
-
-        return userId;
+        _dbContext = dbContext;
     }
 
-    public static UserType? GetUserType(this ClaimsPrincipal principal, bool throwIfMissing = true) =>
-        GetClaim(principal, CustomClaims.UserType, throwIfMissing, value => Enum.Parse<UserType>(value));
-
-    public static TrnLookupStatus? GetTrnLookupStatus(this ClaimsPrincipal principal, bool throwIfMissing = true) =>
-        GetClaim(principal, CustomClaims.TrnLookupStatus, throwIfMissing, value => Enum.Parse<TrnLookupStatus>(value));
-
-    public static IEnumerable<Claim> GetInternalClaims(User user)
-    {
-        return GetInternalClaims(
-            user.UserId,
-            user.EmailAddress,
-            user.FirstName,
-            user.LastName,
-            user.DateOfBirth,
-            user.Trn,
-            user.CompletedTrnLookup.HasValue,
-            user.UserType,
-            user.StaffRoles,
-            user.TrnLookupStatus);
-    }
-
-    public static IEnumerable<Claim> GetInternalClaims(AuthenticationState authenticationState)
+    public static IReadOnlyCollection<Claim> GetInternalClaims(AuthenticationState authenticationState)
     {
         if (!authenticationState.IsComplete())
         {
@@ -95,160 +27,93 @@ public static class UserClaimHelper
             authenticationState.EmailAddress!,
             authenticationState.FirstName!,
             authenticationState.LastName!,
-            authenticationState.DateOfBirth,
             authenticationState.Trn,
-            authenticationState.HaveCompletedTrnLookup,
             authenticationState.UserType!.Value,
-            authenticationState.StaffRoles,
-            authenticationState.TrnLookupStatus);
+            authenticationState.StaffRoles);
     }
 
-    public static IEnumerable<Claim> GetPublicClaims(User user, Func<string, bool> hasScope)
+    public static IReadOnlyCollection<Claim> GetInternalClaims(User user)
     {
-        return GetPublicClaims(
-            hasScope,
+        return GetInternalClaims(
             user.UserId,
             user.EmailAddress,
             user.FirstName,
             user.LastName,
-            user.DateOfBirth,
             user.Trn,
-            user.TrnLookupStatus);
-    }
-
-    public static IEnumerable<Claim> GetPublicClaims(AuthenticationState authenticationState, Func<string, bool> hasScope)
-    {
-        if (!authenticationState.IsComplete())
-        {
-            throw new InvalidOperationException("Cannot retrieve claims until authentication is complete.");
-        }
-
-        return GetPublicClaims(
-            hasScope,
-            authenticationState.UserId!.Value,
-            authenticationState.EmailAddress!,
-            authenticationState.FirstName!,
-            authenticationState.LastName!,
-            authenticationState.DateOfBirth,
-            authenticationState.Trn,
-            authenticationState.TrnLookupStatus);
+            user.UserType,
+            user.StaffRoles);
     }
 
     public static string MapUserTypeToClaimValue(UserType userType) => userType.ToString();
 
-    private static string? GetClaim(ClaimsPrincipal principal, string claimType, bool throwIfMissing)
+    public async Task<IReadOnlyCollection<Claim>> GetPublicClaims(Guid userId, Func<string, bool> hasScope)
     {
-        var value = principal.FindFirstValue(claimType);
+        var user = await _dbContext.Users.SingleOrDefaultAsync(u => u.UserId == userId);
 
-        if (string.IsNullOrEmpty(value))
+        if (user is null)
         {
-            if (throwIfMissing)
-            {
-                ThrowClaimMissingException(claimType);
-            }
-
-            return null;
+            return Array.Empty<Claim>();
         }
 
-        return value;
-    }
-
-    private static T? GetClaim<T>(ClaimsPrincipal principal, string claimType, bool throwIfMissing, Func<string, T> convertValue)
-        where T : struct
-    {
-        var value = principal.FindFirstValue(claimType);
-
-        if (string.IsNullOrEmpty(value))
+        var claims = new List<Claim>()
         {
-            if (throwIfMissing)
-            {
-                ThrowClaimMissingException(claimType);
-            }
+            new Claim(Claims.Subject, userId.ToString()!),
+            new Claim(Claims.Email, user.EmailAddress),
+            new Claim(Claims.EmailVerified, bool.TrueString),
+            new Claim(Claims.Name, $"{user.FirstName} {user.LastName}"),
+            new Claim(Claims.GivenName, user.FirstName),
+            new Claim(Claims.FamilyName, user.LastName),
+        };
 
-            return null;
-        }
-
-        return convertValue(value);
-    }
-
-    [DoesNotReturn]
-    private static void ThrowClaimMissingException(string claimType) =>
-        throw new InvalidOperationException($"No '{claimType}' claim was found.");
-
-    private static IEnumerable<Claim> GetInternalClaims(
-        Guid userId,
-        string email,
-        string firstName,
-        string lastName,
-        DateOnly? dateOfBirth,
-        string? trn,
-        bool haveCompletedTrnLookup,
-        UserType userType,
-        string[]? staffRoles,
-        TrnLookupStatus? trnLookupStatus)
-    {
-        yield return new Claim(Claims.Subject, userId.ToString()!);
-        yield return new Claim(Claims.Email, email);
-        yield return new Claim(Claims.EmailVerified, bool.TrueString);
-        yield return new Claim(Claims.Name, firstName + " " + lastName);
-        yield return new Claim(Claims.GivenName, firstName);
-        yield return new Claim(Claims.FamilyName, lastName);
-        yield return new Claim(CustomClaims.HaveCompletedTrnLookup, haveCompletedTrnLookup.ToString());
-        yield return new Claim(CustomClaims.UserType, MapUserTypeToClaimValue(userType));
-
-        if (dateOfBirth.HasValue)
+        if (user.DateOfBirth is DateOnly dateOfBirth)
         {
-            yield return new Claim(Claims.Birthdate, dateOfBirth!.Value.ToString(CustomClaims.DateFormat));
-        }
-
-        if (trn is not null)
-        {
-            yield return new Claim(CustomClaims.Trn, trn);
-        }
-
-        foreach (var role in staffRoles ?? Array.Empty<string>())
-        {
-            yield return new Claim(Claims.Role, role);
-        }
-
-        if (trnLookupStatus is TrnLookupStatus trs)
-        {
-            yield return new Claim(CustomClaims.TrnLookupStatus, trs.ToString());
-        }
-    }
-
-    private static IEnumerable<Claim> GetPublicClaims(
-        Func<string, bool> hasScope,
-        Guid userId,
-        string email,
-        string firstName,
-        string lastName,
-        DateOnly? dateOfBirth,
-        string? trn,
-        TrnLookupStatus? trnLookupStatus)
-    {
-        yield return new Claim(Claims.Subject, userId.ToString()!);
-        yield return new Claim(Claims.Email, email);
-        yield return new Claim(Claims.EmailVerified, bool.TrueString);
-        yield return new Claim(Claims.Name, firstName + " " + lastName);
-        yield return new Claim(Claims.GivenName, firstName);
-        yield return new Claim(Claims.FamilyName, lastName);
-
-        if (dateOfBirth.HasValue)
-        {
-            yield return new Claim(Claims.Birthdate, dateOfBirth!.Value.ToString(CustomClaims.DateFormat));
+            claims.Add(new Claim(Claims.Birthdate, dateOfBirth.ToString(CustomClaims.DateFormat)));
         }
 
 #pragma warning disable CS0618 // Type or member is obsolete
         if (hasScope(CustomScopes.Trn) || hasScope(CustomScopes.DqtRead))
         {
-            yield return new Claim(CustomClaims.TrnLookupStatus, trnLookupStatus!.Value.ToString());
+            claims.Add(new Claim(CustomClaims.TrnLookupStatus, user.TrnLookupStatus!.Value.ToString()));
 
-            if (trn is not null)
+            if (user.Trn is not null)
             {
-                yield return new Claim(CustomClaims.Trn, trn);
+                claims.Add(new Claim(CustomClaims.Trn, user.Trn));
             }
         }
 #pragma warning restore CS0618 // Type or member is obsolete
+
+        return claims;
+    }
+
+    private static IReadOnlyCollection<Claim> GetInternalClaims(
+        Guid userId,
+        string email,
+        string firstName,
+        string lastName,
+        string? trn,
+        UserType userType,
+        string[]? staffRoles)
+    {
+        var claims = new List<Claim>()
+        {
+            new Claim(Claims.Subject, userId.ToString()!),
+            new Claim(Claims.Email, email),
+            new Claim(Claims.Name, firstName + " " + lastName),
+            new Claim(Claims.GivenName, firstName),
+            new Claim(Claims.FamilyName, lastName),
+            new Claim(CustomClaims.UserType, MapUserTypeToClaimValue(userType))
+        };
+
+        if (trn is not null)
+        {
+            claims.Add(new Claim(CustomClaims.Trn, trn));
+        }
+
+        foreach (var role in staffRoles ?? Array.Empty<string>())
+        {
+            claims.Add(new Claim(Claims.Role, role));
+        }
+
+        return claims;
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.TestClient/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.TestClient/Program.cs
@@ -44,6 +44,7 @@ public class Program
                 options.Scope.Add("openid");
                 options.Scope.Add("profile");
 
+                options.GetClaimsFromUserInfoEndpoint = true;
                 options.SaveTokens = true;
 
                 // Log the access token to the console for debugging

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateTests.cs
@@ -9,129 +9,108 @@ namespace TeacherIdentity.AuthServer.Tests;
 public partial class AuthenticationStateTests
 {
     [Fact]
-    public void FromInternalClaims_DefaultUser()
+    public void FromUser_DefaultUser_MapsDataOnCorrectly()
     {
         // Arrange
-        var dateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
-        var email = Faker.Internet.Email();
-        var emailVerified = true;
-        var firstName = Faker.Name.First();
-        var lastName = Faker.Name.Last();
-        var firstTimeSignInForEmail = true;
-        var haveCompletedTrnLookup = true;
-        var trn = "2345678";
-        var userId = Guid.NewGuid();
-        var userType = UserType.Default;
-
-        var claims = new[]
+        var user = new User()
         {
-            new Claim(Claims.Subject, userId.ToString()!),
-            new Claim(Claims.Email, email),
-            new Claim(Claims.EmailVerified, emailVerified.ToString()),
-            new Claim(Claims.Name, firstName + " " + lastName),
-            new Claim(Claims.GivenName, firstName),
-            new Claim(Claims.FamilyName, lastName),
-            new Claim(Claims.Birthdate, dateOfBirth.ToString("yyyy-MM-dd")),
-            new Claim(CustomClaims.HaveCompletedTrnLookup, haveCompletedTrnLookup.ToString()),
-            new Claim(CustomClaims.Trn, trn),
-            new Claim(CustomClaims.UserType, userType.ToString()),
-            new Claim(CustomClaims.TrnLookupStatus, TrnLookupStatus.Found.ToString())
+            CompletedTrnLookup = new(2023, 2, 16, 18, 44, 17),
+            Created = DateTime.UtcNow,
+            DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
+            EmailAddress = Faker.Internet.Email(),
+            FirstName = Faker.Name.First(),
+            LastName = Faker.Name.Last(),
+            Trn = "2345678",
+            TrnAssociationSource = TrnAssociationSource.Lookup,
+            TrnLookupStatus = TrnLookupStatus.Found,
+            Updated = DateTime.UtcNow,
+            UserId = Guid.NewGuid(),
+            UserType = UserType.Default
         };
-        var principal = new ClaimsPrincipal(new ClaimsIdentity(claims));
+
+        var firstTimeSignInForEmail = true;
 
         var journeyId = Guid.NewGuid();
         var userRequirements = UserRequirements.DefaultUserType | UserRequirements.TrnHolder;
 
         // Act
-        var authenticationState = AuthenticationState.FromInternalClaims(
+        var authenticationState = AuthenticationState.FromUser(
             journeyId,
             userRequirements,
-            principal,
+            user,
             postSignInUrl: "/",
             startedAt: DateTime.UtcNow,
             oAuthState: null,
             firstTimeSignInForEmail: firstTimeSignInForEmail);
 
         // Assert
-        Assert.Equal(dateOfBirth, authenticationState.DateOfBirth);
-        Assert.Equal(email, authenticationState.EmailAddress);
-        Assert.Equal(emailVerified, authenticationState.EmailAddressVerified);
-        Assert.Equal(firstName, authenticationState.FirstName);
-        Assert.Equal(lastName, authenticationState.LastName);
+        Assert.Equal(user.DateOfBirth, authenticationState.DateOfBirth);
+        Assert.Equal(user.EmailAddress, authenticationState.EmailAddress);
+        Assert.True(authenticationState.EmailAddressVerified);
+        Assert.Equal(user.FirstName, authenticationState.FirstName);
+        Assert.Equal(user.LastName, authenticationState.LastName);
         Assert.Equal(firstTimeSignInForEmail, authenticationState.FirstTimeSignInForEmail);
-        Assert.Equal(haveCompletedTrnLookup, authenticationState.HaveCompletedTrnLookup);
-        Assert.Equal(trn, authenticationState.Trn);
-        Assert.Equal(userId, authenticationState.UserId);
+        Assert.True(authenticationState.HaveCompletedTrnLookup);
+        Assert.Equal(user.Trn, authenticationState.Trn);
+        Assert.Equal(user.UserId, authenticationState.UserId);
         Assert.Equal(AuthenticationState.TrnLookupState.Complete, authenticationState.TrnLookup);
-        Assert.Equal(userType, authenticationState.UserType);
+        Assert.Equal(user.UserType, authenticationState.UserType);
         Assert.Equal(TrnLookupStatus.Found, authenticationState.TrnLookupStatus);
     }
 
     [Fact]
-    public void FromInternalClaims_StaffUser()
+    public void FromUser_StaffUser_MapsDataOnCorrectly()
     {
         // Arrange
-        var dateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
-        var email = Faker.Internet.Email();
-        var emailVerified = true;
-        var firstName = Faker.Name.First();
-        var lastName = Faker.Name.Last();
-        var firstTimeSignInForEmail = true;
-        var userId = Guid.NewGuid();
-        var userType = UserType.Staff;
-        var staffRoles = new[] { StaffRoles.GetAnIdentityAdmin, StaffRoles.GetAnIdentitySupport };
-
-        var claims = new[]
+        var user = new User()
         {
-            new Claim(Claims.Subject, userId.ToString()!),
-            new Claim(Claims.Email, email),
-            new Claim(Claims.EmailVerified, emailVerified.ToString()),
-            new Claim(Claims.Name, firstName + " " + lastName),
-            new Claim(Claims.GivenName, firstName),
-            new Claim(Claims.FamilyName, lastName),
-            new Claim(Claims.Birthdate, dateOfBirth.ToString("yyyy-MM-dd")),
-            new Claim(Claims.Role, StaffRoles.GetAnIdentityAdmin),
-            new Claim(Claims.Role, StaffRoles.GetAnIdentitySupport),
-            new Claim(CustomClaims.UserType, userType.ToString())
+            CompletedTrnLookup = new(2023, 2, 16, 18, 44, 17),
+            Created = DateTime.UtcNow,
+            EmailAddress = Faker.Internet.Email(),
+            FirstName = Faker.Name.First(),
+            LastName = Faker.Name.Last(),
+            StaffRoles = new[] { StaffRoles.GetAnIdentityAdmin, StaffRoles.GetAnIdentitySupport },
+            Updated = DateTime.UtcNow,
+            UserId = Guid.NewGuid(),
+            UserType = UserType.Default
         };
-        var principal = new ClaimsPrincipal(new ClaimsIdentity(claims));
+
+        var firstTimeSignInForEmail = true;
 
         var journeyId = Guid.NewGuid();
         var userRequirements = UserRequirements.DefaultUserType | UserRequirements.TrnHolder;
 
         // Act
-        var authenticationState = AuthenticationState.FromInternalClaims(
+        var authenticationState = AuthenticationState.FromUser(
             journeyId,
             userRequirements,
-            principal,
+            user,
             postSignInUrl: "/",
             startedAt: DateTime.UtcNow,
             oAuthState: null,
             firstTimeSignInForEmail: firstTimeSignInForEmail);
 
         // Assert
-        Assert.Equal(dateOfBirth, authenticationState.DateOfBirth);
-        Assert.Equal(email, authenticationState.EmailAddress);
-        Assert.Equal(emailVerified, authenticationState.EmailAddressVerified);
-        Assert.Equal(firstName, authenticationState.FirstName);
-        Assert.Equal(lastName, authenticationState.LastName);
+        Assert.Equal(user.DateOfBirth, authenticationState.DateOfBirth);
+        Assert.Equal(user.EmailAddress, authenticationState.EmailAddress);
+        Assert.True(authenticationState.EmailAddressVerified);
+        Assert.Equal(user.FirstName, authenticationState.FirstName);
+        Assert.Equal(user.LastName, authenticationState.LastName);
         Assert.Equal(firstTimeSignInForEmail, authenticationState.FirstTimeSignInForEmail);
-        Assert.Equal(staffRoles, authenticationState.StaffRoles);
-        Assert.Equal(userId, authenticationState.UserId);
-        Assert.Equal(userType, authenticationState.UserType);
+        Assert.Equal(user.StaffRoles, authenticationState.StaffRoles);
+        Assert.Equal(user.UserId, authenticationState.UserId);
+        Assert.Equal(user.UserType, authenticationState.UserType);
         Assert.Null(authenticationState.TrnLookupStatus);
     }
 
     [Fact]
-    public void GetInternalClaims_DefaultUser()
+    public void GetInternalClaims_DefaultUser_ReturnsExpectedClaims()
     {
         // Arrange
         var dateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
         var email = Faker.Internet.Email();
-        var emailVerified = true;
         var firstName = Faker.Name.First();
         var lastName = Faker.Name.Last();
-        var haveCompletedTrnLookup = true;
         var trn = "2345678";
         var userId = Guid.NewGuid();
         var userType = UserType.Default;
@@ -172,26 +151,21 @@ public partial class AuthenticationStateTests
         {
             new Claim(Claims.Subject, userId.ToString()!),
             new Claim(Claims.Email, email),
-            new Claim(Claims.EmailVerified, emailVerified.ToString()),
             new Claim(Claims.Name, firstName + " " + lastName),
             new Claim(Claims.GivenName, firstName),
             new Claim(Claims.FamilyName, lastName),
-            new Claim(Claims.Birthdate, dateOfBirth.ToString("yyyy-MM-dd")),
-            new Claim(CustomClaims.HaveCompletedTrnLookup, haveCompletedTrnLookup.ToString()),
             new Claim(CustomClaims.Trn, trn),
-            new Claim(CustomClaims.UserType, userType.ToString()),
-            new Claim(CustomClaims.TrnLookupStatus, trnLookupStatus.ToString())
+            new Claim(CustomClaims.UserType, userType.ToString())
         };
         Assert.Equal(expectedClaims.OrderBy(c => c.Type), claims.OrderBy(c => c.Type), new ClaimTypeAndValueEqualityComparer());
     }
 
     [Fact]
-    public void GetInternalClaims_StaffUser()
+    public void GetInternalClaims_StaffUser_ReturnsExpectedClaims()
     {
         // Arrange
         var dateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
         var email = Faker.Internet.Email();
-        var emailVerified = true;
         var firstName = Faker.Name.First();
         var lastName = Faker.Name.Last();
         var userId = Guid.NewGuid();
@@ -231,14 +205,11 @@ public partial class AuthenticationStateTests
         {
             new Claim(Claims.Subject, userId.ToString()!),
             new Claim(Claims.Email, email),
-            new Claim(Claims.EmailVerified, emailVerified.ToString()),
             new Claim(Claims.Name, firstName + " " + lastName),
             new Claim(Claims.GivenName, firstName),
             new Claim(Claims.FamilyName, lastName),
-            new Claim(Claims.Birthdate, dateOfBirth.ToString("yyyy-MM-dd")),
             new Claim(Claims.Role, StaffRoles.GetAnIdentityAdmin),
             new Claim(Claims.Role, StaffRoles.GetAnIdentitySupport),
-            new Claim(CustomClaims.HaveCompletedTrnLookup, bool.FalseString),
             new Claim(CustomClaims.UserType, userType.ToString())
         };
         Assert.Equal(expectedClaims.OrderBy(c => c.Type), claims.OrderBy(c => c.Type), new ClaimTypeAndValueEqualityComparer());
@@ -871,14 +842,14 @@ public partial class AuthenticationStateTests
 
                 // User requesting authorization with admin scopes or trn scope
                 {
-                    S(AuthenticationState.FromInternalClaims(journeyId, UserRequirements.DefaultUserType, new ClaimsPrincipal(), postSignInUrl, startedAt: DateTime.UtcNow, oAuthState: new OAuthAuthorizationState(clientId, "user:read", null))),
+                    S(AuthenticationState.FromUser(journeyId, UserRequirements.DefaultUserType, user: null, postSignInUrl, startedAt: DateTime.UtcNow, oAuthState: new OAuthAuthorizationState(clientId, "user:read", null))),
                     $"/sign-in/email?asid={journeyId}",
                     AuthenticationState.AuthenticationMilestone.None
                 },
 
                 // User requesting authorization without admin scopes or trn scope
                 {
-                    S(AuthenticationState.FromInternalClaims(journeyId, UserRequirements.DefaultUserType, new ClaimsPrincipal(), postSignInUrl, startedAt: DateTime.UtcNow, oAuthState: new OAuthAuthorizationState(clientId, "foo", null))),
+                    S(AuthenticationState.FromUser(journeyId, UserRequirements.DefaultUserType, user: null, postSignInUrl, startedAt: DateTime.UtcNow, oAuthState: new OAuthAuthorizationState(clientId, "foo", null))),
                     $"/sign-in/landing?asid={journeyId}",
                     AuthenticationState.AuthenticationMilestone.None
                 },

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/UserClaimHelperTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/UserClaimHelperTests.cs
@@ -1,36 +1,33 @@
 using System.Security.Claims;
-using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Oidc;
 using static OpenIddict.Abstractions.OpenIddictConstants;
 
 namespace TeacherIdentity.AuthServer.Tests;
 
-public class UserClaimHelperTests
+public class UserClaimHelperTests : IClassFixture<DbFixture>
 {
+    private readonly DbFixture _dbFixture;
+
+    public UserClaimHelperTests(DbFixture dbFixture)
+    {
+        _dbFixture = dbFixture;
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public void GetPublicClaims_FromUser_ReturnsExpectedClaims(bool haveTrnScope)
+    public async Task GetPublicClaims_FromUser_ReturnsExpectedClaims(bool haveTrnScope)
     {
         // Arrange
-        var user = new User()
-        {
-            UserId = Guid.NewGuid(),
-            EmailAddress = Faker.Internet.Email(),
-            FirstName = Faker.Name.First(),
-            LastName = Faker.Name.Last(),
-            DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
-            Trn = "1234567",
-            Created = DateTime.UtcNow,
-            UserType = UserType.Default,
-            Updated = DateTime.UtcNow,
-            TrnLookupStatus = TrnLookupStatus.Found
-        };
+        var user = await _dbFixture.TestData.CreateUser(hasTrn: haveTrnScope);
+
+        using var dbContext = _dbFixture.GetDbContext();
+        var userClaimHelper = new UserClaimHelper(dbContext);
 
         // Act
 #pragma warning disable CS0618 // Type or member is obsolete
-        var result = UserClaimHelper.GetPublicClaims(
-            user,
+        var result = await userClaimHelper.GetPublicClaims(
+            user.UserId,
             hasScope: scope => scope == CustomScopes.Trn && haveTrnScope);
 #pragma warning restore CS0618 // Type or member is obsolete
 
@@ -43,77 +40,13 @@ public class UserClaimHelperTests
             new Claim(Claims.Name, user.FirstName + " " + user.LastName),
             new Claim(Claims.GivenName, user.FirstName),
             new Claim(Claims.FamilyName, user.LastName),
-            new Claim(Claims.Birthdate, user.DateOfBirth.Value.ToString("yyyy-MM-dd")),
+            new Claim(Claims.Birthdate, user.DateOfBirth!.Value.ToString("yyyy-MM-dd")),
         };
 
         if (haveTrnScope)
         {
-            expectedClaims.Add(new Claim(CustomClaims.Trn, user.Trn));
+            expectedClaims.Add(new Claim(CustomClaims.Trn, user.Trn!));
             expectedClaims.Add(new Claim(CustomClaims.TrnLookupStatus, user.TrnLookupStatus!.Value.ToString()));
-        }
-
-        Assert.Equal(expectedClaims.OrderBy(c => c.Type), result.OrderBy(c => c.Type), new ClaimTypeAndValueEqualityComparer());
-    }
-
-    [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public void GetPublicClaims_FromAuthenticationState_ReturnsExpectedClaims(bool haveTrnScope)
-    {
-        // Arrange
-        var user = new User()
-        {
-            UserId = Guid.NewGuid(),
-            EmailAddress = Faker.Internet.Email(),
-            FirstName = Faker.Name.First(),
-            LastName = Faker.Name.Last(),
-            DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
-            Trn = "1234567",
-            CompletedTrnLookup = DateTime.UtcNow,
-            Created = DateTime.UtcNow,
-            UserType = UserType.Default,
-            Updated = DateTime.UtcNow,
-            TrnLookupStatus = TrnLookupStatus.Found
-        };
-
-#pragma warning disable CS0618 // Type or member is obsolete
-        Func<string, bool> hasScope = s => s == CustomScopes.Trn && haveTrnScope;
-#pragma warning restore CS0618 // Type or member is obsolete
-
-        var userRequirements = UserRequirementsExtensions.GetUserRequirementsForScopes(hasScope);
-
-        var authenticationState = new AuthenticationState(
-            journeyId: Guid.NewGuid(),
-            userRequirements,
-            postSignInUrl: "",
-            startedAt: DateTime.UtcNow,
-            oAuthState: new OAuthAuthorizationState(
-                clientId: "",
-                scope: "email profile" + (haveTrnScope ? " trn" : ""),
-                redirectUri: ""));
-
-        authenticationState.OnEmailSet(user.EmailAddress);
-        authenticationState.OnEmailVerified(user);
-
-        // Act
-        var result = UserClaimHelper.GetPublicClaims(authenticationState, hasScope);
-
-        // Assert
-        var expectedClaims = new List<Claim>()
-        {
-            new Claim(Claims.Subject, authenticationState.UserId.ToString()!),
-            new Claim(Claims.Email, authenticationState.EmailAddress!),
-            new Claim(Claims.EmailVerified, authenticationState.EmailAddressVerified.ToString()),
-            new Claim(Claims.Name, authenticationState.FirstName + " " + authenticationState.LastName),
-            new Claim(Claims.GivenName, authenticationState.FirstName!),
-            new Claim(Claims.FamilyName, authenticationState.LastName!),
-            new Claim(Claims.Birthdate, authenticationState.DateOfBirth!.Value.ToString("yyyy-MM-dd")),
-        };
-
-        if (haveTrnScope)
-        {
-            expectedClaims.Add(new Claim(CustomClaims.Trn, authenticationState.Trn!));
-            expectedClaims.Add(new Claim(CustomClaims.TrnLookupStatus, authenticationState.TrnLookupStatus!.Value.ToString()));
         }
 
         Assert.Equal(expectedClaims.OrderBy(c => c.Type), result.OrderBy(c => c.Type), new ClaimTypeAndValueEqualityComparer());


### PR DESCRIPTION
Until now we've kept track of user information in potentially up to three places; AuthenticationState, the DB and the Cookies Principal. This is becoming more and more complicated and expensive to maintain and is problematic when we want to add additional public claims without storing them in the auth cookie.

This change simplifies things; we keep a minimal set of claims in the auth cookie and always go to the DB to get the full set of 'public' claims (i.e. those that go into ID and access tokens). The factory method on AuthenticationState to create a new instance from an already-signed in user is also changed to take a User object instead of ClaimsPrincipal.