### PR TITLE
Add name page to register journey

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -105,6 +105,8 @@ public static class IdentityLinkGeneratorExtensions
 
     public static string RegisterName(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Register/Name");
 
+    public static string RegisterDateOfBirth(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Register/DateOfBirthPage");
+
     public static string UpdateEmail(this IIdentityLinkGenerator linkGenerator, string? returnUrl, string? cancelUrl) =>
         linkGenerator.PageWithAuthenticationJourneyId("/Authenticated/UpdateEmail/Index", authenticationJourneyRequired: false)
             .SetQueryParam("returnUrl", returnUrl)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Name.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Name.cshtml
@@ -1,0 +1,28 @@
+@page "/sign-in/register/name"
+@model TeacherIdentity.AuthServer.Pages.SignIn.Register.Name
+@{
+    ViewBag.Title = "Your name";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.RegisterPhoneConfirmation()" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.RegisterName()" method="post" asp-antiforgery="true">
+            <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
+
+            <govuk-input asp-for="FirstName" spellcheck="false" autocomplete="given-name">
+                <govuk-input-label class="govuk-label--s" />
+            </govuk-input>
+
+            <govuk-input asp-for="LastName" spellcheck="false" autocomplete="family-name">
+                <govuk-input-label class="govuk-label--s"/>
+            </govuk-input>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>
+

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Name.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Name.cshtml.cs
@@ -1,8 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using TeacherIdentity.AuthServer.Pages.SignIn.Trn;
 using static TeacherIdentity.AuthServer.AuthenticationState;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Name.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Name.cshtml.cs
@@ -1,0 +1,46 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeacherIdentity.AuthServer.Pages.SignIn.Trn;
+using static TeacherIdentity.AuthServer.AuthenticationState;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
+
+[BindProperties]
+[RequireAuthenticationMilestone(AuthenticationMilestone.EmailVerified)]
+public class Name : PageModel
+{
+    private IIdentityLinkGenerator _linkGenerator;
+
+    public Name(IIdentityLinkGenerator linkGenerator)
+    {
+        _linkGenerator = linkGenerator;
+    }
+
+    [Display(Name = "First name")]
+    [Required(ErrorMessage = "Enter your first name")]
+    [StringLength(200, ErrorMessage = "First name must be 200 characters or less")]
+    public string? FirstName { get; set; }
+
+    [Display(Name = "Last name")]
+    [Required(ErrorMessage = "Enter your last name")]
+    [StringLength(200, ErrorMessage = "Last name must be 200 characters or less")]
+    public string? LastName { get; set; }
+
+    public void OnGet()
+    {
+    }
+
+    public IActionResult OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        HttpContext.GetAuthenticationState().OnNameSet(FirstName!, LastName!);
+
+        return Redirect(_linkGenerator.RegisterDateOfBirth());
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/NameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/NameTests.cs
@@ -1,0 +1,180 @@
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
+
+[Collection(nameof(DisableParallelization))]  // Relies on mocks
+public class NameTests : TestBase
+{
+    public NameTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, $"/sign-in/register/name");
+    }
+
+    [Fact]
+    public async Task Get_NoAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await MissingAuthenticationState_ReturnsBadRequest(HttpMethod.Get, $"/sign-in/register/name");
+    }
+
+    [Fact]
+    public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, HttpMethod.Get, "/sign-in/register/name");
+    }
+
+    [Fact]
+    public async Task Get_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, additionalScopes: null, HttpMethod.Get, "/sign-in/register/name");
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_RendersContent()
+    {
+        await ValidRequest_RendersContent("/sign-in/register/name", ConfigureValidAuthenticationState, additionalScopes: null);
+    }
+
+    [Fact]
+    public async Task Post_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Post, $"/sign-in/register/name");
+    }
+
+    [Fact]
+    public async Task Post_NoAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await MissingAuthenticationState_ReturnsBadRequest(HttpMethod.Post, $"/sign-in/register/name");
+    }
+
+    [Fact]
+    public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, HttpMethod.Post, "/sign-in/register/name");
+    }
+
+    [Fact]
+    public async Task Post_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, additionalScopes: null, HttpMethod.Post, "/sign-in/register/name");
+    }
+
+    [Fact]
+    public async Task Post_EmptyFirstName_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/name?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "LastName", Faker.Name.Last() },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "FirstName", "Enter your first name");
+    }
+
+    [Fact]
+    public async Task Post_EmptyLastName_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/name?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "FirstName", Faker.Name.First() },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "LastName", "Enter your last name");
+    }
+
+    [Fact]
+    public async Task Post_TooLongFirstName_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/name?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "FirstName", new string('a', 201) },
+                { "LastName", Faker.Name.Last() },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "FirstName", "First name must be 200 characters or less");
+    }
+
+    [Fact]
+    public async Task Post_TooLongLastName_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/name?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "FirstName", Faker.Name.First() },
+                { "LastName", new string('a', 201) },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "LastName", "Last name must be 200 characters or less");
+    }
+
+    [Fact]
+    public async Task Post_ValidName_SetsNameOnAuthenticationState()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var firstName = Faker.Name.First();
+        var lastName = Faker.Name.Last();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/name?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "FirstName", firstName },
+                { "LastName", lastName },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        Assert.Equal(firstName, authStateHelper.AuthenticationState.FirstName);
+        Assert.Equal(lastName, authStateHelper.AuthenticationState.LastName);
+    }
+
+    private Func<AuthenticationState, Task> ConfigureValidAuthenticationState(AuthenticationStateHelper.Configure configure) =>
+        configure.MobileNumberSet();
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/NameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/NameTests.cs
@@ -1,6 +1,5 @@
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
 
-[Collection(nameof(DisableParallelization))]  // Relies on mocks
 public class NameTests : TestBase
 {
     public NameTests(HostFixture hostFixture)


### PR DESCRIPTION
### Context

As an overseas qualified teacher
I want to sign in/register a Teaching services account
So that I can apply for QTS

### Changes proposed in this pull request

Create a new page at /sign-in/register/name following the designs in the prototype.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
