### PR TITLE
Add new previous user ID claim to access and identity tokens

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
@@ -380,6 +380,10 @@ public class AuthorizationController : Controller
 
                 yield break;
 
+            case CustomClaims.PreviousUserId:
+                yield return Destinations.IdentityToken;
+                yield break;
+
             default:
                 yield break;
         }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Oidc/CustomClaims.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Oidc/CustomClaims.cs
@@ -8,4 +8,5 @@ public static class CustomClaims
     public const string TrnLookupStatus = "trn-lookup-status";
     public const string HaveCompletedTrnLookup = "completed-trn-lookup";
     public const string UserType = "user-type";
+    public const string PreviousUserId = "previous-user-id";
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/UserClaimHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/UserClaimHelper.cs
@@ -1,4 +1,5 @@
 using System.Security.Claims;
+using LinqKit;
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Oidc;
@@ -82,12 +83,9 @@ public class UserClaimHelper
         }
 #pragma warning restore CS0618 // Type or member is obsolete
 
-        var mergedUserIds = await _dbContext.Users.IgnoreQueryFilters()
+        await _dbContext.Users.IgnoreQueryFilters()
             .Where(u => u.MergedWithUserId == userId)
-            .Select(u => u.UserId)
-            .ToListAsync();
-
-        claims.Add(new Claim(CustomClaims.PreviousUserId, String.Join(",", mergedUserIds)));
+            .ForEachAsync(u => claims.Add(new Claim(CustomClaims.PreviousUserId, u.UserId.ToString())));
 
         return claims;
     }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/UserClaimHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/UserClaimHelper.cs
@@ -82,6 +82,13 @@ public class UserClaimHelper
         }
 #pragma warning restore CS0618 // Type or member is obsolete
 
+        var mergedUserIds = await _dbContext.Users.IgnoreQueryFilters()
+            .Where(u => u.MergedWithUserId == userId)
+            .Select(u => u.UserId)
+            .ToListAsync();
+
+        claims.Add(new Claim(CustomClaims.PreviousUserId, String.Join(",", mergedUserIds)));
+
         return claims;
     }
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/UserClaimHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/UserClaimHelper.cs
@@ -1,5 +1,4 @@
 using System.Security.Claims;
-using LinqKit;
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Oidc;

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/UserClaimHelperTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/UserClaimHelperTests.cs
@@ -94,7 +94,7 @@ public class UserClaimHelperTests : IClassFixture<DbFixture>
         }
         else
         {
-           Assert.DoesNotContain(result, c => c.Type == CustomClaims.PreviousUserId);
+            Assert.DoesNotContain(result, c => c.Type == CustomClaims.PreviousUserId);
         }
     }
 }


### PR DESCRIPTION
### Context

We now support merging user accounts. When that happens one account is deleted and the other is retained (the ‘master’) with a link to the deleted record.

We send out a web hook with the ID of the deleted account and its new master so that consuming services can update their records and replace the old ID with the new. However, there’s a chance that services may not have processed the web hook by the time the user signs in again. If that happens, the consuming service may see a new ID and will incorrectly create a new user record.

### Changes proposed in this pull request

Add an additional claim - previous_user_id - to the ID and access tokens that contains the IDs of merged accounts, if any

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
