### PR TITLE
Fix 'TRN in use' email selection for new TRN journey

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnInUseChooseEmail.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnInUseChooseEmail.cshtml.cs
@@ -54,14 +54,18 @@ public class TrnInUseChooseEmailModel : PageModel
         var authenticationState = HttpContext.GetAuthenticationState();
 
         var lookupState = await _dbContext.JourneyTrnLookupStates
-            .SingleAsync(s => s.JourneyId == authenticationState.JourneyId);
+            .SingleOrDefaultAsync(s => s.JourneyId == authenticationState.JourneyId);
         var user = await _dbContext.Users.SingleAsync(u => u.EmailAddress == authenticationState.TrnOwnerEmailAddress);
 
         var emailChanged = user.EmailAddress != Email;
 
         user.EmailAddress = Email;
-        lookupState.Locked = _clock.UtcNow;
-        lookupState.UserId = user.UserId;
+
+        if (lookupState is not null)
+        {
+            lookupState.Locked = _clock.UtcNow;
+            lookupState.UserId = user.UserId;
+        }
 
         if (emailChanged)
         {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignIn.StaffUser.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignIn.StaffUser.cs
@@ -1,0 +1,113 @@
+using Microsoft.Playwright;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Oidc;
+
+namespace TeacherIdentity.AuthServer.EndToEndTests;
+
+public partial class SignIn
+{
+    [Fact]
+    public async Task StaffUser_CanSignInSuccessfullyWithEmailAndPin()
+    {
+        await using var context = await _hostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await SignInExistingStaffUserWithTestClient(page);
+    }
+
+    [Fact]
+    public async Task StaffUser_CanSignInToAdminPageSuccessfullyWithEmailAndPin()
+    {
+        var staffUser = await _hostFixture.TestData.CreateUser(userType: UserType.Staff, staffRoles: StaffRoles.All);
+
+        await using var context = await _hostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        // Try to access protected admin area on auth server
+
+        await page.GotoAsync($"{HostFixture.AuthServerBaseUrl}/admin/staff");
+
+        // Fill in the sign in form (email + PIN)
+
+        await page.FillAsync("text=Enter your email address", staffUser.EmailAddress);
+        await page.ClickAsync("button:text-is('Continue')");
+
+        var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
+        await page.FillAsync("text=Enter your code", pin);
+        await page.ClickAsync("button:text-is('Continue')");
+
+        // Should now be on the originally request URL, /admin/staff
+
+        var clientAppHost = new Uri(HostFixture.ClientBaseUrl).Host;
+        Assert.EndsWith("/admin/staff", page.Url);
+
+        // Check events have been emitted
+
+        _hostFixture.EventObserver.AssertEventsSaved(e => AssertEventIsUserSignedIn(e, staffUser.UserId, expectOAuthProperties: false));
+    }
+
+    [Fact]
+    public async Task StaffUser_MissingPermission_GetsForbiddenError()
+    {
+        var staffUser = await _hostFixture.TestData.CreateUser(userType: UserType.Staff, staffRoles: Array.Empty<string>());
+
+        await using var context = await _hostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        // Start on the client app and try to access a protected area with admin scope
+
+        await page.GotoAsync($"/profile?scope={CustomScopes.UserRead}");
+
+        // Fill in the sign in form (email + PIN)
+
+        await page.FillAsync("text=Enter your email address", staffUser.EmailAddress);
+        await page.ClickAsync("button:text-is('Continue')");
+
+        var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
+        await page.FillAsync("text=Enter your code", pin);
+        await page.ClickAsync("button:text-is('Continue')");
+
+        // Should get a Forbidden error
+
+        await page.WaitForSelectorAsync("h1:text-is('Forbidden')");
+    }
+
+    private async Task<Guid> SignInExistingStaffUserWithTestClient(IPage page)
+    {
+        var user = await _hostFixture.TestData.CreateUser(userType: UserType.Staff, staffRoles: StaffRoles.All);
+
+        // Start on the client app and try to access a protected area with admin scope
+
+        await page.GotoAsync($"/profile?scope=email+openid+profile+{CustomScopes.UserRead}");
+
+        // Fill in the sign in form (email + PIN)
+
+        await page.FillAsync("text=Enter your email address", user.EmailAddress);
+        await page.ClickAsync("button:text-is('Continue')");
+
+        var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
+        await page.FillAsync("text=Enter your code", pin);
+        await page.ClickAsync("button:text-is('Continue')");
+
+        // Should now be on the confirmation page
+
+        Assert.Equal(1, await page.Locator("data-testid=known-user-content").CountAsync());
+        await page.ClickAsync("button:text-is('Continue')");
+
+        // Should now be back at the client, signed in
+
+        var clientAppHost = new Uri(HostFixture.ClientBaseUrl).Host;
+        var pageUrlHost = new Uri(page.Url).Host;
+        Assert.Equal(clientAppHost, pageUrlHost);
+
+        var signedInEmail = await page.InnerTextAsync("data-testid=email");
+        Assert.Equal(string.Empty, await page.InnerTextAsync("data-testid=trn"));
+        Assert.Equal(user.EmailAddress, signedInEmail);
+
+        // Check events have been emitted
+
+        _hostFixture.EventObserver.AssertEventsSaved(e => AssertEventIsUserSignedIn(e, user.UserId));
+
+        return user.UserId;
+    }
+}


### PR DESCRIPTION
We are missing an e2e test that covers 'TRN in use' for the new TRN journey. Adding it showed a bug; we were assuming we have a `JourneyTrnLookupState` around but we don't in this new journey. This change fixes that bug and adds an e2e test.

Once the new TRN journey is out of the door we can remove all the `JourneyTrnLookupState`-related bits and simplify things significantly.