### PR TITLE
Fix final bookend content for NPQ for TRN Optional

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Complete.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Complete.cshtml
@@ -20,6 +20,8 @@
                 Uri.EscapeDataString(value);
         }
     }
+
+    ViewData.Add("Scope", Model.Scope);
 }
 
 <form action="@action" method="@method" asp-antiforgery="false">

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Complete.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Complete.cshtml.cs
@@ -29,6 +29,8 @@ public class CompleteModel : PageModel
 
     public UserType UserType { get; set; }
 
+    public string? Scope { get; set; }
+
     public void OnGet()
     {
         var authenticationState = HttpContext.GetAuthenticationState();
@@ -44,6 +46,7 @@ public class CompleteModel : PageModel
         Trn = authenticationState.Trn;
         AlreadyCompleted = authenticationState.HaveResumedCompletedJourney;
         UserType = authenticationState.UserType!.Value;
+        Scope = authenticationState.OAuthState?.Scope;
 
         HttpContext.Features.Get<WebRequestEventFeature>()?.Event.AddTag(FirstTimeSignInForEmail ? "FirstTimeUser" : "ReturningUser");
     }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/_TrnLookup.EndBookend.FirstTimeSignInWithoutTrn.RegisterForNpq.Content.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/_TrnLookup.EndBookend.FirstTimeSignInWithoutTrn.RegisterForNpq.Content.cshtml
@@ -1,2 +1,10 @@
-<p>Although we could not find your record, you can continue to register for an NPQ.</p>
-<p>You’ll need to enter some of your details again.</p>
+@if (ViewData.TryGetValue("Scope", out var scopeObj) && scopeObj is string scope && scope.Split(' ').Contains("trn"))
+{
+    <p>Although we could not find your record, you can continue to register for an NPQ.</p>
+    <p>You’ll need to enter some of your details again.</p>
+}
+else
+{
+    <p>You can continue anyway and we’ll try to find your record. Someone may be in touch to ask for more information.</p>
+    <p>If you need to come back to this service later you’ll only need to give us your email address <strong>(@Model.Email)</strong>.</p>
+}


### PR DESCRIPTION
The final bookend content should be different for the 'TRN Optional' journey than the current Find-based journey. Unfortunately we don't have a great way to know which journey we're in on the Complete page other than looking at scope so that's what this change does.

I've added a note to the ticket for removing Find integration to tidy this up.