### PR TITLE
Hide admin links for DQT update if user has TRN

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Users.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Users.cshtml
@@ -92,8 +92,16 @@
                             <tr class="govuk-table__row" data-testid="user-@user.UserId">
                                 <td class="govuk-table__cell"><a asp-page="User" asp-route-userId="@user.UserId">@user.Name</a></td>
                                 <td class="govuk-table__cell">@user.EmailAddress</td>
-                                <td class="govuk-table__cell"><a asp-page="AssignTrn/Trn" asp-route-userId="@user.UserId">Add a DQT record</a></td>
-                                <td class="govuk-table__cell"><a asp-page="AssignTrn/NoTrn" asp-route-userId="@user.UserId">Mark as non DQT</a></td>
+                                @if (user.Trn is null)
+                                {
+                                    <td class="govuk-table__cell"><a asp-page="AssignTrn/Trn" asp-route-userId="@user.UserId">Add a DQT record</a></td>
+                                    <td class="govuk-table__cell"><a asp-page="AssignTrn/NoTrn" asp-route-userId="@user.UserId">Mark as non DQT</a></td>
+                                }
+                                else
+                                {
+                                    <td class="govuk-table__cell"/>
+                                    <td class="govuk-table__cell"/>
+                                }
                             </tr>
                         }
                         </tbody>

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/UsersTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/UsersTests.cs
@@ -177,6 +177,38 @@ public class UsersTests : TestBase, IAsyncLifetime
         }
     }
 
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Get_ValidRequest_ReturnsExpectedContentForUser(bool hasTrn)
+    {
+        // Arrange
+        var user = await TestData.CreateUser(hasTrn: hasTrn);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/users");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+
+        var userRow = doc.GetElementByTestId($"user-{user.UserId}")!;
+
+        if (hasTrn)
+        {
+            Assert.DoesNotContain("Add a DQT record", userRow.InnerHtml);
+            Assert.DoesNotContain("Mark as non DQT", userRow.InnerHtml);
+        }
+        else
+        {
+            Assert.Contains("Add a DQT record", userRow.InnerHtml);
+            Assert.Contains("Mark as non DQT", userRow.InnerHtml);
+        }
+    }
+
     private Dictionary<string, string> GetFilterQueryParams(TrnLookupStatus[] activeFilters)
     {
         var filterParams = new Dictionary<string, string>();


### PR DESCRIPTION
### Context

The user list on the admin page shows ‘Add a DQT record’ and ‘Mark as non DQT' for all users, even if they already have a TRN assigned. We don’t currently support amending a user’s TRN once one has been assigned so navigating to either of these options shows an error.

### Changes proposed in this pull request

Remove the ‘Add a DQT record’ and ‘Mark as non DQT' options if the user already has a TRN.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [x] Reminder created to manually clean any removed app settings post deployment
