### PR TITLE
Add email exists page for register journey

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -97,6 +97,8 @@ public static class IdentityLinkGeneratorExtensions
 
     public static string RegisterEmailConfirmation(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Register/EmailConfirmation");
 
+    public static string RegisterEmailExists(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Register/EmailExists");
+
     public static string RegisterPhone(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Register/Phone");
 
     public static string RegisterPhoneConfirmation(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Register/PhoneConfirmation");

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/EmailConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/EmailConfirmation.cshtml.cs
@@ -1,6 +1,9 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Helpers;
+using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
@@ -8,14 +11,17 @@ namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
 public class EmailConfirmationModel : BaseEmailConfirmationPageModel
 {
     private readonly IIdentityLinkGenerator _linkGenerator;
+    private readonly TeacherIdentityServerDbContext _dbContext;
 
     public EmailConfirmationModel(
         IUserVerificationService userVerificationService,
         PinValidator pinValidator,
-        IIdentityLinkGenerator linkGenerator)
+        IIdentityLinkGenerator linkGenerator,
+        TeacherIdentityServerDbContext dbContext)
         : base(userVerificationService, pinValidator)
     {
         _linkGenerator = linkGenerator;
+        _dbContext = dbContext;
     }
 
     [BindProperty]
@@ -43,7 +49,23 @@ public class EmailConfirmationModel : BaseEmailConfirmationPageModel
             return await HandlePinVerificationFailed(pinVerificationFailedReasons);
         }
 
-        HttpContext.GetAuthenticationState().OnEmailVerified();
+        var authenticationState = HttpContext.GetAuthenticationState();
+        var permittedUserTypes = authenticationState.GetPermittedUserTypes();
+
+        var user = await _dbContext.Users.Where(u => u.EmailAddress == Email).SingleOrDefaultAsync();
+
+        if (user is not null && !permittedUserTypes.Contains(user.UserType))
+        {
+            return new ForbidResult();
+        }
+
+        HttpContext.GetAuthenticationState().OnEmailVerified(user);
+
+        if (user is not null)
+        {
+            await authenticationState.SignIn(HttpContext);
+            return Redirect(_linkGenerator.RegisterEmailExists());
+        }
 
         return Redirect(_linkGenerator.RegisterPhone());
     }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/EmailConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/EmailConfirmation.cshtml.cs
@@ -2,7 +2,6 @@ using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.EntityFrameworkCore;
-using TeacherIdentity.AuthServer.Helpers;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/EmailExists.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/EmailExists.cshtml
@@ -1,0 +1,19 @@
+@page "/sign-in/register/email-exists"
+@model TeacherIdentity.AuthServer.Pages.SignIn.Register.EmailExists
+@{
+    ViewBag.Title = "Sign in to your Teaching services account";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.RegisterEmailConfirmation()" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
+
+        <p>We’ve found a Teaching services account for email (@Model.Email)</p>
+
+        <govuk-button-link href="@HttpContext.GetAuthenticationState().GetNextHopUrl(LinkGenerator)">Sign in</govuk-button-link>
+    </div>
+</div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/EmailExists.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/EmailExists.cshtml.cs
@@ -1,0 +1,11 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeacherIdentity.AuthServer.State;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
+
+[AllowCompletedAuthenticationJourney]
+[RequireAuthenticationMilestone(AuthenticationState.AuthenticationMilestone.Complete)]
+public class EmailExists : PageModel
+{
+    public string? Email => HttpContext.GetAuthenticationState().EmailAddress;
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailConfirmationTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Options;
+using TeacherIdentity.AuthServer.Oidc;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
@@ -297,5 +298,59 @@ public class EmailConfirmationTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status429TooManyRequests, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_ValidPinForNonAdminScopeWithNonAdminUser_UpdatesAuthenticationStateSignsInAndRedirects()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: Models.UserType.Default);
+
+        var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
+        var pinResult = await userVerificationService.GenerateEmailPin(user.EmailAddress);
+
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(user.EmailAddress), additionalScopes: CustomScopes.DefaultUserTypesScopes.First());
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email-confirmation?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pinResult.Pin! }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/register/email-exists", response.Headers.Location?.OriginalString);
+
+        Assert.True(authStateHelper.AuthenticationState.EmailAddressVerified);
+        Assert.NotNull(authStateHelper.AuthenticationState.UserId);
+    }
+
+    [Fact]
+    public async Task Post_ValidPinForAdminScopeWithNonAdminUser_ReturnsForbidden()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: Models.UserType.Default);
+
+        var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
+        var pinResult = await userVerificationService.GenerateEmailPin(user.EmailAddress);
+
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(user.EmailAddress), additionalScopes: CustomScopes.StaffUserTypeScopes.First());
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email-confirmation?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pinResult.Pin! }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailExistsTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailExistsTests.cs
@@ -1,8 +1,8 @@
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
 
-public class PhoneExistsTests : TestBase
+public class EmailExistsTests : TestBase
 {
-    public PhoneExistsTests(HostFixture hostFixture)
+    public EmailExistsTests(HostFixture hostFixture)
         : base(hostFixture)
     {
     }
@@ -10,20 +10,20 @@ public class PhoneExistsTests : TestBase
     [Fact]
     public async Task Get_InvalidAuthenticationStateProvided_ReturnsBadRequest()
     {
-        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register/phone-exists");
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register/email-exists");
     }
 
     [Fact]
     public async Task Get_MissingAuthenticationStateProvided_ReturnsBadRequest()
     {
-        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register/phone-exists");
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register/email-exists");
     }
 
     [Fact]
     public async Task Get_JourneyHasExpired_RendersErrorPage()
     {
         var user = await TestData.CreateUser();
-        await JourneyHasExpired_RendersErrorPage(c => c.Completed(user), additionalScopes: null, HttpMethod.Get, "/sign-in/register/phone-exists");
+        await JourneyHasExpired_RendersErrorPage(c => c.Completed(user), additionalScopes: null, HttpMethod.Get, "/sign-in/register/email-exists");
     }
 
     [Fact]
@@ -36,6 +36,6 @@ public class PhoneExistsTests : TestBase
     public async Task Get_ValidRequest_RendersContent()
     {
         var user = await TestData.CreateUser();
-        await ValidRequest_RendersContent(c => c.Completed(user), "/sign-in/register/phone-exists", additionalScopes: null);
+        await ValidRequest_RendersContent(c => c.Completed(user), "/sign-in/register/email-exists", additionalScopes: null);
     }
 }


### PR DESCRIPTION
### Context

As an overseas qualified teacher
I want to sign in/register a Teaching services account
So that I can apply for QTS

### Changes proposed in this pull request

Add a new page at /sign-in/register/email-exists following the designs in the prototype.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [x] Reminder created to manually clean any removed app settings post deployment
