### PR TITLE
Add register confirm account page

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -631,6 +631,13 @@ public class AuthenticationState
         ExistingAccountChosen = isUsersAccount;
     }
 
+    public void OnExistingAccountVerified(User user)
+    {
+        EmailAddressVerified = true;
+
+        UpdateAuthenticationStateWithUserDetails(user);
+    }
+
     public string? GetOfficialName()
     {
         return GetFullName(OfficialFirstName, OfficialLastName);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -115,6 +115,8 @@ public static class IdentityLinkGeneratorExtensions
 
     public static string RegisterConfirmExistingAccount(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Register/ConfirmExistingAccount");
 
+    public static string RegisterResendEmailConfirmation(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Register/ResendEmailConfirmation");
+
     public static string UpdateEmail(this IIdentityLinkGenerator linkGenerator, string? returnUrl, string? cancelUrl) =>
         linkGenerator.PageWithAuthenticationJourneyId("/Authenticated/UpdateEmail/Index", authenticationJourneyRequired: false)
             .SetQueryParam("returnUrl", returnUrl)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/CheckAccount.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/CheckAccount.cshtml
@@ -17,13 +17,13 @@
 
             <h2>Is this your account?</h2>
 
-            <govuk-inset-text>@Redactor.RedactEmail(Model.ExistingEmail!)</govuk-inset-text>
+            <govuk-inset-text>@Redactor.RedactEmail(Model.ExistingAccountEmail!)</govuk-inset-text>
 
             <govuk-radios asp-for="IsUsersAccount">
                 <govuk-radios-fieldset>
                     <govuk-radios-item value="True">
                         Yes, sign into this account
-                        <govuk-radios-item-hint>We’ll send a security code to @Redactor.RedactEmail(Model.ExistingEmail!)</govuk-radios-item-hint>
+                        <govuk-radios-item-hint>We’ll send a security code to @Redactor.RedactEmail(Model.ExistingAccountEmail!)</govuk-radios-item-hint>
                     </govuk-radios-item>
                     <govuk-radios-item value="False">
                         No, this is not my account

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/CheckAccount.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/CheckAccount.cshtml.cs
@@ -26,7 +26,7 @@ public class CheckAccount : PageModel
     }
 
     public string? Email => HttpContext.GetAuthenticationState().EmailAddress;
-    public string? ExistingEmail => HttpContext.GetAuthenticationState().ExistingAccountEmail;
+    public string? ExistingAccountEmail => HttpContext.GetAuthenticationState().ExistingAccountEmail;
 
     [BindProperty]
     [Display(Name = " ")]
@@ -49,7 +49,7 @@ public class CheckAccount : PageModel
 
         if (IsUsersAccount == true)
         {
-            return await GenerateEmailPinForEmail(ExistingEmail!);
+            return await GenerateEmailPinForEmail(ExistingAccountEmail!);
         }
 
         var user = await CreateUser();

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ConfirmExistingAccount.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ConfirmExistingAccount.cshtml
@@ -1,0 +1,28 @@
+@page "/sign-in/register/confirm-existing-account"
+@model TeacherIdentity.AuthServer.Pages.SignIn.Register.ConfirmExistingAccount
+@{
+    ViewBag.Title = "Confirm your email address";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.RegisterCheckAccount()" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.RegisterConfirmExistingAccount()" method="post" asp-antiforgery="true">
+            <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
+
+            <p>A confirmation code has been sent to <b data-testid="email">@Redactor.RedactEmail(Model.Email!)</b></p>
+
+            <govuk-input asp-for="Code" input-class="govuk-!-width-one-quarter" pattern="[0-9]*" inputmode="numeric" autocomplete="one-time-code">
+                <govuk-input-label class="govuk-label--s" />
+            </govuk-input>
+
+            <p><a href="@LinkGenerator.RegisterResendEmailConfirmation()">I have not received an email</a></p>
+            <p><a href="@LinkGenerator.RegisterResendPhoneConfirmation()">I can’t access this email address</a></p>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ConfirmExistingAccount.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ConfirmExistingAccount.cshtml.cs
@@ -1,0 +1,88 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Services.UserVerification;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
+
+public class ConfirmExistingAccount : BaseEmailConfirmationPageModel
+{
+    private readonly IIdentityLinkGenerator _linkGenerator;
+    private readonly TeacherIdentityServerDbContext _dbContext;
+
+    public ConfirmExistingAccount(
+        IUserVerificationService userVerificationService,
+        PinValidator pinValidator,
+        IIdentityLinkGenerator linkGenerator,
+        TeacherIdentityServerDbContext dbContext)
+        : base(userVerificationService, pinValidator)
+    {
+        _linkGenerator = linkGenerator;
+        _dbContext = dbContext;
+    }
+
+    public override string? Email => HttpContext.GetAuthenticationState().ExistingAccountEmail;
+    public new User? User { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Confirmation code")]
+    public override string? Code { get; set; }
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        Code = Code?.Trim();
+        ValidateCode();
+
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        var pinVerificationFailedReasons = await UserVerificationService.VerifyEmailPin(Email!, Code!);
+
+        if (pinVerificationFailedReasons != PinVerificationFailedReasons.None)
+        {
+            return await HandlePinVerificationFailed(pinVerificationFailedReasons);
+        }
+
+        var authenticationState = HttpContext.GetAuthenticationState();
+
+        authenticationState.OnExistingAccountVerified(User!);
+        await authenticationState.SignIn(HttpContext);
+
+        return Redirect(authenticationState.GetNextHopUrl(_linkGenerator));
+    }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        var authenticationState = HttpContext.GetAuthenticationState();
+
+        if (HttpContext.GetAuthenticationState().ExistingAccountChosen != true)
+        {
+            context.Result = new RedirectResult(_linkGenerator.RegisterCheckAccount());
+            return;
+        }
+
+        User = await _dbContext.Users.Where(u => u.UserType == UserType.Default && u.EmailAddress == Email).SingleOrDefaultAsync();
+
+        if (User is null)
+        {
+            context.Result = NotFound();
+            return;
+        }
+
+        if (!authenticationState.GetPermittedUserTypes().Contains(User.UserType))
+        {
+            context.Result = new ForbidResult();
+            return;
+        }
+
+        await next();
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
@@ -179,6 +179,19 @@ public sealed class AuthenticationStateHelper
                 s.OnExistingAccountFound(existingUserAccount ?? await TestData.CreateUser());
             };
 
+        public Func<AuthenticationState, Task>  RegisterExistingUserAccountChosen(
+            User? existingUserAccount = null,
+            DateOnly? dateOfBirth = null,
+            string? firstName = null,
+            string? lastName = null,
+            string? mobileNumber = null,
+            string? email = null) =>
+            async s =>
+            {
+                await RegisterExistingUserAccountMatch(existingUserAccount, dateOfBirth, firstName, lastName, mobileNumber, email)(s);
+                s.OnExistingAccountChosen(true);
+            };
+
         public Func<AuthenticationState, Task> TrnLookupCallbackCompleted(
             string email,
             string? trn,

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
@@ -179,7 +179,7 @@ public sealed class AuthenticationStateHelper
                 s.OnExistingAccountFound(existingUserAccount ?? await TestData.CreateUser());
             };
 
-        public Func<AuthenticationState, Task>  RegisterExistingUserAccountChosen(
+        public Func<AuthenticationState, Task> RegisterExistingUserAccountChosen(
             User? existingUserAccount = null,
             DateOnly? dateOfBirth = null,
             string? firstName = null,

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ConfirmExistingAccountTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ConfirmExistingAccountTests.cs
@@ -1,0 +1,371 @@
+using Microsoft.Extensions.Options;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Oidc;
+using TeacherIdentity.AuthServer.Services;
+using TeacherIdentity.AuthServer.Services.UserVerification;
+using TeacherIdentity.AuthServer.Tests.Infrastructure;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
+
+[Collection(nameof(DisableParallelization))]  // Depends on mocks and changes the clock
+public class ConfirmExistingAccountTests : TestBase, IAsyncLifetime
+{
+    private User? _existingUserAccount;
+
+    public ConfirmExistingAccountTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+        HostFixture.RateLimitStore.Setup(x => x.IsClientIpBlockedForPinVerification(TestRequestClientIpProvider.ClientIpAddress)).ReturnsAsync(false);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _existingUserAccount = await TestData.CreateUser();
+    }
+
+    public Task DisposeAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Get_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register/confirm-existing-account");
+    }
+
+    [Fact]
+    public async Task Get_NoAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await MissingAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register/confirm-existing-account");
+    }
+
+    [Fact]
+    public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, HttpMethod.Get, "/sign-in/register/confirm-existing-account");
+    }
+
+    [Fact]
+    public async Task Get_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, additionalScopes: null, HttpMethod.Get, "/sign-in/register/confirm-existing-account");
+    }
+
+    [Fact]
+    public async Task Get_ExistingAccountChosenNotSet_RedirectsToCheckAccount()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.RegisterExistingUserAccountMatch(), additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/confirm-existing-account?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Act
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/register/check-account", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_RendersExpectedContent()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/confirm-existing-account?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Act
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+        Assert.Equal(new Redactor().RedactEmail(authStateHelper.AuthenticationState.ExistingAccountEmail!), doc.GetElementByTestId("email")?.TextContent);
+    }
+
+    [Fact]
+    public async Task Post_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Post, "/sign-in/register/confirm-existing-account");
+    }
+
+    [Fact]
+    public async Task Post_NoAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await MissingAuthenticationState_ReturnsBadRequest(HttpMethod.Post, "/sign-in/register/confirm-existing-account");
+    }
+
+    [Fact]
+    public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, HttpMethod.Post, "/sign-in/register/confirm-existing-account");
+    }
+
+    [Fact]
+    public async Task Post_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, additionalScopes: null, HttpMethod.Post, "/sign-in/register/confirm-existing-account");
+    }
+
+    [Fact]
+    public async Task Post_UnknownPin_ReturnsError()
+    {
+        // The real PIN generation service never generates pins that start with a '0'
+        var pin = "01234";
+
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/confirm-existing-account?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pin }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Code", "Enter a correct security code");
+    }
+
+    [Fact]
+    public async Task Post_PinTooShort_ReturnsError()
+    {
+        // Arrange
+        var pin = "0";
+
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/confirm-existing-account?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pin }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Code", "You’ve not entered enough numbers, the code must be 5 numbers");
+    }
+
+    [Fact]
+    public async Task Post_PinTooLong_ReturnsError()
+    {
+        // Arrange
+        var pin = "0123345678";
+
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/confirm-existing-account?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pin }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Code", "You’ve entered too many numbers, the code must be 5 numbers");
+    }
+
+    [Fact]
+    public async Task Post_NonNumericPin_ReturnsError()
+    {
+        // Arrange
+        var pin = "abc";
+
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/confirm-existing-account?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pin }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Code", "The code must be 5 numbers");
+    }
+
+    [Fact]
+    public async Task Post_PinExpiredLessThanTwoHoursAgo_ReturnsErrorAndSendsANewPin()
+    {
+        // Arrange
+        var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
+        var pinResult = await userVerificationService.GenerateEmailPin(_existingUserAccount!.EmailAddress);
+        Clock.AdvanceBy(TimeSpan.FromHours(1));
+        Spy.Get<IUserVerificationService>().Reset();
+
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/confirm-existing-account?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pinResult.Pin! }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Code", "The security code has expired. New code sent.");
+
+        HostFixture.UserVerificationService.Verify(mock => mock.GenerateEmailPin(_existingUserAccount!.EmailAddress), Times.Once);
+    }
+
+    [Fact]
+    public async Task Post_PinExpiredMoreThanTwoHoursAgo_ReturnsErrorAndDoesNotSendANewPin()
+    {
+        // Arrange
+        var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
+        var userVerificationOptions = HostFixture.Services.GetRequiredService<IOptions<UserVerificationOptions>>();
+        var pinResult = await userVerificationService.GenerateEmailPin(_existingUserAccount!.EmailAddress);
+        Clock.AdvanceBy(TimeSpan.FromHours(2) + TimeSpan.FromSeconds(userVerificationOptions.Value.PinLifetimeSeconds));
+        Spy.Get<IUserVerificationService>().Reset();
+
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/confirm-existing-account?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pinResult.Pin! }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Code", "Enter a correct security code");
+
+        HostFixture.UserVerificationService.Verify(mock => mock.GenerateEmailPin(_existingUserAccount!.EmailAddress), Times.Never);
+    }
+
+    [Fact]
+    public async Task Post_ValidPin_UpdatesAuthenticationState()
+    {
+        // Arrange
+        var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
+        var pinResult = await userVerificationService.GenerateEmailPin(_existingUserAccount!.EmailAddress);
+
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/confirm-existing-account?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pinResult.Pin! }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        Assert.True(authStateHelper.AuthenticationState.EmailAddressVerified);
+    }
+
+    [Fact]
+    public async Task Post_BlockedClient_ReturnsTooManyRequestsStatusCode()
+    {
+        // Arrange
+        HostFixture.RateLimitStore.Setup(x => x.IsClientIpBlockedForPinVerification(TestRequestClientIpProvider.ClientIpAddress)).ReturnsAsync(true);
+
+        var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
+        var pinResult = await userVerificationService.GenerateEmailPin(_existingUserAccount!.EmailAddress);
+
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/confirm-existing-account?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pinResult.Pin! }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status429TooManyRequests, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_ValidPinForNonAdminScopeWithNonAdminUser_ReturnsForbidden()
+    {
+        // Arrange
+        var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
+        var pinResult = await userVerificationService.GenerateEmailPin(_existingUserAccount!.EmailAddress);
+
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: CustomScopes.StaffUserTypeScopes.First());
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/confirm-existing-account?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pinResult.Pin! }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_ValidPinForNonAdminScopeWithNonAdminUser_UpdatesAuthenticationStateSignsInAndRedirects()
+    {
+        // Arrange
+        var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
+        var pinResult = await userVerificationService.GenerateEmailPin(_existingUserAccount!.EmailAddress);
+
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: CustomScopes.DefaultUserTypesScopes.First());
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/confirm-existing-account?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pinResult.Pin! }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal(authStateHelper.AuthenticationState.PostSignInUrl, response.Headers.Location?.OriginalString);
+
+        AssertAuthenticationStateUpdated(_existingUserAccount, authStateHelper);
+    }
+
+    private void AssertAuthenticationStateUpdated(User existingUser, AuthenticationStateHelper authStateHelper)
+    {
+        Assert.Equal(authStateHelper.AuthenticationState.UserId, existingUser.UserId);
+        Assert.Equal(authStateHelper.AuthenticationState.EmailAddress, existingUser.EmailAddress);
+        Assert.Equal(authStateHelper.AuthenticationState.MobileNumber, existingUser.MobileNumber);
+        Assert.Equal(authStateHelper.AuthenticationState.FirstName, existingUser.FirstName);
+        Assert.Equal(authStateHelper.AuthenticationState.LastName, existingUser.LastName);
+        Assert.Equal(authStateHelper.AuthenticationState.DateOfBirth, existingUser.DateOfBirth);
+        Assert.Equal(authStateHelper.AuthenticationState.Trn, existingUser.Trn);
+        Assert.Equal(authStateHelper.AuthenticationState.UserType, existingUser.UserType);
+        Assert.Equal(authStateHelper.AuthenticationState.StaffRoles, existingUser.StaffRoles);
+        Assert.Equal(authStateHelper.AuthenticationState.TrnLookupStatus, existingUser.TrnLookupStatus);
+
+        Assert.True(authStateHelper.AuthenticationState.EmailAddressVerified);
+    }
+
+    private Func<AuthenticationState, Task> ConfigureValidAuthenticationState(AuthenticationStateHelper.Configure configure) =>
+        configure.RegisterExistingUserAccountChosen(existingUserAccount: _existingUserAccount);
+}


### PR DESCRIPTION
### Context

I want to sign in/register a Teaching services account
So that I can apply for QTS

### Changes proposed in this pull request

Create a new page at /sign-in/register/confirm-existing-account  following the [designs in the prototype](https://get-an-identity-prototype.herokuapp.com/sign-in/email-code).

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [x] Reminder created to manually clean any removed app settings post deployment
