### PR TITLE
Add resend email confirmation page for register journey

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/EmailConfirmation.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/EmailConfirmation.cshtml
@@ -19,6 +19,10 @@
                 <govuk-input-label class="govuk-label--s" />
             </govuk-input>
 
+            <p>
+                <a href="@LinkGenerator.RegisterResendPhoneConfirmation()">I have not received a text message</a>
+            </p>
+
             <govuk-button type="submit">Continue</govuk-button>
         </form>
     </div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/EmailConfirmation.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/EmailConfirmation.cshtml
@@ -20,7 +20,7 @@
             </govuk-input>
 
             <p>
-                <a href="@LinkGenerator.RegisterResendPhoneConfirmation()">I have not received a text message</a>
+                <a href="@LinkGenerator.RegisterResendEmailConfirmation()">I have not received a text message</a>
             </p>
 
             <govuk-button type="submit">Continue</govuk-button>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendEmailConfirmation.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendEmailConfirmation.cshtml
@@ -1,0 +1,28 @@
+@page "/sign-in/register/resend-email-confirmation"
+@model TeacherIdentity.AuthServer.Pages.SignIn.Register.ResendEmailConfirmationModel
+@{
+    ViewBag.Title = "Request a new security code";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.RegisterEmailConfirmation()" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.RegisterResendEmailConfirmation()" method="post" asp-antiforgery="true">
+            <h1 class="govuk-heading-xl">Request a new email code</h1>
+
+            <p>Emails sometimes take a few minutes to arrive. If you do not receive the email, you can request a new one.</p>
+
+            <govuk-details open="@(!ModelState.IsValid)">
+                <govuk-details-summary>Change where the email is sent</govuk-details-summary>
+                <govuk-details-text>
+                    <govuk-input asp-for="Email" type="email" autocomplete="email" />
+                </govuk-details-text>
+            </govuk-details>
+
+            <govuk-button type="submit">Request a new code</govuk-button>
+        </form>
+    </div>
+</div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendEmailConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendEmailConfirmation.cshtml.cs
@@ -1,0 +1,62 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Services.UserVerification;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
+
+[BindProperties]
+public class ResendEmailConfirmationModel : BaseEmailPageModel
+{
+    public ResendEmailConfirmationModel(
+        IUserVerificationService userVerificationService,
+        IIdentityLinkGenerator linkGenerator,
+        TeacherIdentityServerDbContext dbContext) :
+        base(userVerificationService, linkGenerator, dbContext)
+    {
+    }
+
+    [Display(Name = "Email address")]
+    [Required(ErrorMessage = "Enter your email address")]
+    [EmailAddress(ErrorMessage = "Enter a valid email address")]
+    public string? Email { get; set; }
+
+    public void OnGet()
+    {
+        Email = HttpContext.GetAuthenticationState().EmailAddress;
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        var validateEmailResult = await ValidateEmail(Email!);
+
+        if (!validateEmailResult.IsValid)
+        {
+            return validateEmailResult.Result!;
+        }
+
+        HttpContext.GetAuthenticationState().OnEmailSet(Email!);
+
+        return Redirect(LinkGenerator.RegisterEmailConfirmation());
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var authenticationState = context.HttpContext.GetAuthenticationState();
+
+        if (authenticationState.EmailAddress is null)
+        {
+            context.Result = Redirect(LinkGenerator.RegisterEmail());
+        }
+        else if (authenticationState.EmailAddressVerified)
+        {
+            context.Result = Redirect(LinkGenerator.RegisterPhone());
+        }
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ResendEmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ResendEmailConfirmationTests.cs
@@ -266,7 +266,7 @@ public class ResendEmailConfirmationTests : TestBase
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        await AssertEx.HtmlResponseHasError(response, "Email", "Enter a personal email address. It cannot be one that other people may get access to.");
+        await AssertEx.HtmlResponseHasError(response, "Email", "Enter a personal email address not one from a work or education setting.");
     }
 
     [Fact]

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ResendEmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ResendEmailConfirmationTests.cs
@@ -1,0 +1,320 @@
+using TeacherIdentity.AuthServer.Tests.Infrastructure;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
+
+[Collection(nameof(DisableParallelization))]  // Depends on mocks
+public class ResendEmailConfirmationTests : TestBase
+{
+    public ResendEmailConfirmationTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register/resend-email-confirmation");
+    }
+
+    [Fact]
+    public async Task Get_NoAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await MissingAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register/resend-email-confirmation");
+    }
+
+    [Fact]
+    public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, HttpMethod.Get, "/sign-in/register/resend-email-confirmation");
+    }
+
+    [Fact]
+    public async Task Get_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(c => c.EmailVerified(), additionalScopes: null, HttpMethod.Get, "/sign-in/register/resend-email-confirmation");
+    }
+
+    [Fact]
+    public async Task Get_EmailNotKnown_RedirectsToRegisterEmailPage()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/resend-email-confirmation?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Act
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/sign-in/register/email?{authStateHelper.ToQueryParam()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_EmailAlreadyVerified_RedirectsToRegisterPhone()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified(Faker.Internet.Email()), additionalScopes: null);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/resend-email-confirmation?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Act
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/sign-in/register/phone?{authStateHelper.ToQueryParam()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_RendersExpectedContent()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(), additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/resend-email-confirmation?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Act
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+        Assert.Equal(authStateHelper.AuthenticationState.EmailAddress, doc.GetElementById("Email")?.GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task Post_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Post, "/sign-in/register/resend-email-confirmation");
+    }
+
+    [Fact]
+    public async Task Post_MissingAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Post, "/sign-in/register/resend-email-confirmation");
+    }
+
+    [Fact]
+    public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, HttpMethod.Post, "/sign-in/register/resend-email-confirmation");
+    }
+
+    [Fact]
+    public async Task Post_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(c => c.EmailVerified(), additionalScopes: null, HttpMethod.Post, "/sign-in/register/resend-email-confirmation");
+    }
+
+    [Fact]
+    public async Task Post_EmailNotKnown_RedirectsToRegisterEmailPage()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null);
+        var differentEmail = Faker.Internet.Email();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/resend-email-confirmation?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Email", differentEmail }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Act
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/sign-in/register/email?{authStateHelper.ToQueryParam()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_EmailAlreadyVerified_RedirectsToRegisterPhone()
+    {
+        // Arrange
+        var email = Faker.Internet.Email();
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified(), additionalScopes: null);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/resend-email-confirmation?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Email", email }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Act
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/sign-in/register/phone?{authStateHelper.ToQueryParam()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_EmptyEmail_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(), additionalScopes: null);
+        var differentEmail = "";
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/resend-email-confirmation?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Email", differentEmail }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Email", "Enter your email address");
+    }
+
+    [Fact]
+    public async Task Post_InvalidEmail_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(), additionalScopes: null);
+        var differentEmail = "xx";
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/resend-email-confirmation?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Email", differentEmail }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Email", "Enter a valid email address");
+    }
+
+    [Fact]
+    public async Task Post_ValidEmailWithBlockedClient_ReturnsTooManyRequestsStatusCode()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(), additionalScopes: null);
+        var differentEmail = "valid@email.com";
+
+        HostFixture.RateLimitStore.Setup(x => x.IsClientIpBlockedForPinGeneration(TestRequestClientIpProvider.ClientIpAddress)).ReturnsAsync(true);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/resend-email-confirmation?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Email", differentEmail }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status429TooManyRequests, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_SetsEmailOnAuthenticationStateGeneratesPinAndRedirects()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(), additionalScopes: null);
+        var differentEmail = Faker.Internet.Email();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/resend-email-confirmation?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Email", differentEmail }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/sign-in/register/email-confirmation?{authStateHelper.ToQueryParam()}", response.Headers.Location?.OriginalString);
+
+        Assert.Equal(differentEmail, authStateHelper.AuthenticationState.EmailAddress);
+
+        HostFixture.UserVerificationService.Verify(mock => mock.GenerateEmailPin(differentEmail), Times.Once);
+    }
+
+    [Theory]
+    [InlineData("admin")]
+    [InlineData("academy")]
+    public async Task Post_EmailWithInvalidPrefix_ReturnsError(string emailPrefix)
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(), additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/resend-email-confirmation?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Email", TestData.GenerateUniqueEmail(emailPrefix) }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Email", "Enter a personal email address. It cannot be one that other people may get access to.");
+    }
+
+    [Fact]
+    public async Task Post_EmailWithInvalidPrefixAlreadyExists_DoNotReturnError()
+    {
+        // Arrange
+        var invalidPrefix = "headteacher";
+        var user = await TestData.CreateUser(email: TestData.GenerateUniqueEmail(invalidPrefix));
+
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(), additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/resend-email-confirmation?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Email", user.EmailAddress }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_NotificationServiceInvalidEmail_ReturnsError()
+    {
+        // Arrange
+        HostFixture.NotificationSender
+            .Setup(mock => mock.SendEmail(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Throws(new Exception("ValidationError"));
+
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(), additionalScopes: null);
+        var email = Faker.Internet.Email();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/resend-email-confirmation?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Email", email }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Email", "Enter a valid email address");
+    }
+}


### PR DESCRIPTION
### Context

As an overseas qualified teacher
I want to sign in/register a Teaching services account
So that I can apply for QTS

### Changes proposed in this pull request

Add a new page at /sign-in/register/resend-email-confirmation following the designs at https://get-an-identity-prototype.herokuapp.com/sign-in/resend-email

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
