### PR TITLE
Add Resend phone confirmation page for register journey

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/BaseEmailPageModel.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/BaseEmailPageModel.cs
@@ -14,17 +14,17 @@ public class BaseEmailPageModel : BaseEmailPinGenerationPageModel
     {
     }
 
-    public async Task<EmailPinGenerationResult> GenerateEmailPinForNewEmail(string email)
+    public async Task<PinGenerationResultAction> GenerateEmailPinForNewEmail(string email)
     {
         var emailPinGenerationFailedReasons = await GenerateEmailPin(email, true);
 
         switch (emailPinGenerationFailedReasons)
         {
             case EmailPinGenerationFailedReason.None:
-                return EmailPinGenerationResult.Succeeded();
+                return PinGenerationResultAction.Succeeded();
 
             case EmailPinGenerationFailedReason.RateLimitExceeded:
-                return EmailPinGenerationResult.Failed(new ViewResult()
+                return PinGenerationResultAction.Failed(new ViewResult()
                 {
                     StatusCode = 429,
                     ViewName = "TooManyRequests"
@@ -32,11 +32,11 @@ public class BaseEmailPageModel : BaseEmailPinGenerationPageModel
 
             case EmailPinGenerationFailedReason.NonPersonalAddress:
                 ModelState.AddModelError(nameof(email), "Enter a personal email address not one from a work or education setting.");
-                return EmailPinGenerationResult.Failed(this.PageWithErrors());
+                return PinGenerationResultAction.Failed(this.PageWithErrors());
 
             case EmailPinGenerationFailedReason.InvalidAddress:
                 ModelState.AddModelError(nameof(email), "Enter a valid email address");
-                return EmailPinGenerationResult.Failed(this.PageWithErrors());
+                return PinGenerationResultAction.Failed(this.PageWithErrors());
 
             default:
                 throw new NotImplementedException($"Unknown {nameof(EmailPinGenerationFailedReason)}: '{emailPinGenerationFailedReasons}'.");

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/BaseExistingEmailPageModel.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/BaseExistingEmailPageModel.cs
@@ -13,17 +13,17 @@ public class BaseExistingEmailPageModel : BaseEmailPinGenerationPageModel
         base(userVerificationService, linkGenerator, dbContext)
     { }
 
-    public async Task<EmailPinGenerationResult> GenerateEmailPinForExistingEmail(string email)
+    public async Task<PinGenerationResultAction> GenerateEmailPinForExistingEmail(string email)
     {
         var emailPinGenerationFailedReasons = await GenerateEmailPin(email, false);
 
         switch (emailPinGenerationFailedReasons)
         {
             case EmailPinGenerationFailedReason.None:
-                return EmailPinGenerationResult.Succeeded();
+                return PinGenerationResultAction.Succeeded();
 
             case EmailPinGenerationFailedReason.RateLimitExceeded:
-                return EmailPinGenerationResult.Failed(new ViewResult()
+                return PinGenerationResultAction.Failed(new ViewResult()
                 {
                     StatusCode = 429,
                     ViewName = "TooManyRequests"

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/BasePhonePageModel.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/BasePhonePageModel.cs
@@ -1,0 +1,48 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeacherIdentity.AuthServer.Helpers;
+using TeacherIdentity.AuthServer.Services.UserVerification;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn;
+
+public class BasePhonePageModel : PageModel
+{
+    private IUserVerificationService _userVerificationService;
+
+    public BasePhonePageModel(IUserVerificationService userVerificationService)
+    {
+        _userVerificationService = userVerificationService;
+    }
+
+    [BindProperty]
+    [Display(Name = "Mobile number", Description = "For international numbers include the country code")]
+    [Required(ErrorMessage = "Enter your mobile phone number")]
+    [Phone(ErrorMessage = "Enter a valid mobile phone number")]
+    public string? MobileNumber { get; set; }
+
+    public async Task<PinGenerationResultAction> GenerateSmsPinForNewPhone(string mobileNumber)
+    {
+        var pinGenerationResult = await _userVerificationService.GenerateSmsPin(PhoneHelper.FormatMobileNumber(mobileNumber));
+
+        switch (pinGenerationResult.FailedReason)
+        {
+            case PinGenerationFailedReason.None:
+                return PinGenerationResultAction.Succeeded();
+
+            case PinGenerationFailedReason.RateLimitExceeded:
+                return PinGenerationResultAction.Failed(new ViewResult()
+                {
+                    StatusCode = 429,
+                    ViewName = "TooManyRequests"
+                });
+
+            case PinGenerationFailedReason.InvalidAddress:
+                ModelState.AddModelError(nameof(mobileNumber), "Enter a valid mobile phone number");
+                return PinGenerationResultAction.Failed(this.PageWithErrors());
+
+            default:
+                throw new NotImplementedException($"Unknown {nameof(PinGenerationFailedReason)}: '{pinGenerationResult.FailedReason}'.");
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Phone.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Phone.cshtml.cs
@@ -1,7 +1,4 @@
-using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.RazorPages;
-using TeacherIdentity.AuthServer.Helpers;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendPhoneConfirmation.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendPhoneConfirmation.cshtml
@@ -1,0 +1,28 @@
+@page "/sign-in/register/resend-phone-confirmation"
+@model TeacherIdentity.AuthServer.Pages.SignIn.Register.ResendPhoneConfirmationModel
+@{
+    ViewBag.Title = "Request a new security code";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.RegisterPhoneConfirmation()" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.RegisterResendPhoneConfirmation()" method="post" asp-antiforgery="true">
+            <h1 class="govuk-heading-xl">Send new text message</h1>
+
+            <p>Text messages sometimes take a few minutes to arrive. If you do not receive the text message, you can request a new one.</p>
+
+            <govuk-details open="@(!ModelState.IsValid)">
+                <govuk-details-summary>Change where the text message is sent</govuk-details-summary>
+                <govuk-details-text>
+                    <govuk-input asp-for="MobileNumber" type="email" autocomplete="email" />
+                </govuk-details-text>
+            </govuk-details>
+
+            <govuk-button type="submit">Request a new code</govuk-button>
+        </form>
+    </div>
+</div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendPhoneConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendPhoneConfirmation.cshtml.cs
@@ -1,7 +1,5 @@
-using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
-using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendPhoneConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendPhoneConfirmation.cshtml.cs
@@ -1,16 +1,16 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.RazorPages;
-using TeacherIdentity.AuthServer.Helpers;
+using Microsoft.AspNetCore.Mvc.Filters;
+using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
 
-public class Phone : BasePhonePageModel
+public class ResendPhoneConfirmationModel : BasePhonePageModel
 {
-    private readonly IIdentityLinkGenerator _linkGenerator;
+    private IIdentityLinkGenerator _linkGenerator;
 
-    public Phone(
+    public ResendPhoneConfirmationModel(
         IUserVerificationService userVerificationService,
         IIdentityLinkGenerator linkGenerator) :
         base(userVerificationService)
@@ -20,6 +20,7 @@ public class Phone : BasePhonePageModel
 
     public void OnGet()
     {
+        MobileNumber = HttpContext.GetAuthenticationState().MobileNumber;
     }
 
     public async Task<IActionResult> OnPost()
@@ -39,5 +40,19 @@ public class Phone : BasePhonePageModel
         HttpContext.GetAuthenticationState().OnMobileNumberSet(MobileNumber!);
 
         return Redirect(_linkGenerator.RegisterPhoneConfirmation());
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var authenticationState = context.HttpContext.GetAuthenticationState();
+
+        if (authenticationState.MobileNumber is null)
+        {
+            context.Result = Redirect(_linkGenerator.RegisterPhone());
+        }
+        else if (authenticationState.MobileNumberVerified)
+        {
+            context.Result = Redirect(_linkGenerator.RegisterName());
+        }
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/UserVerification/PinGenerationResultAction.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/UserVerification/PinGenerationResultAction.cs
@@ -2,12 +2,12 @@ using Microsoft.AspNetCore.Mvc;
 
 namespace TeacherIdentity.AuthServer.Services.UserVerification;
 
-public sealed class EmailPinGenerationResult
+public sealed class PinGenerationResultAction
 {
     public bool Success;
     public IActionResult? Result { get; private set; }
 
-    public static EmailPinGenerationResult Failed(IActionResult result)
+    public static PinGenerationResultAction Failed(IActionResult result)
     {
         return new()
         {
@@ -16,7 +16,7 @@ public sealed class EmailPinGenerationResult
         };
     }
 
-    public static EmailPinGenerationResult Succeeded()
+    public static PinGenerationResultAction Succeeded()
     {
         return new()
         {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ResendPhoneConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ResendPhoneConfirmationTests.cs
@@ -1,0 +1,240 @@
+using TeacherIdentity.AuthServer.Tests.Infrastructure;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
+
+[Collection(nameof(DisableParallelization))]  // Depends on mocks
+public class ResendPhoneConfirmationTests : TestBase
+{
+    public ResendPhoneConfirmationTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register/resend-phone-confirmation");
+    }
+
+    [Fact]
+    public async Task Get_NoAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await MissingAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register/resend-phone-confirmation");
+    }
+
+    [Fact]
+    public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, HttpMethod.Get, "/sign-in/register/resend-phone-confirmation");
+    }
+
+    [Fact]
+    public async Task Get_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, additionalScopes: null, HttpMethod.Get, "/sign-in/register/resend-phone-confirmation");
+    }
+
+    [Fact]
+    public async Task Get_PhoneNotKnown_RedirectsToRegisterPhonePage()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified(), additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/resend-phone-confirmation?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Act
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/sign-in/register/phone?{authStateHelper.ToQueryParam()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_PhoneAlreadyVerified_RedirectsToRegisterName()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.MobileVerified(Faker.Internet.Email()), additionalScopes: null);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/resend-phone-confirmation?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Act
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/sign-in/register/name?{authStateHelper.ToQueryParam()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_RendersExpectedContent()
+    {
+        await ValidRequest_RendersContent(ConfigureValidAuthenticationState, "/sign-in/register/resend-phone-confirmation", additionalScopes: null);
+    }
+
+    [Fact]
+    public async Task Post_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Post, "/sign-in/register/resend-phone-confirmation");
+    }
+
+    [Fact]
+    public async Task Post_MissingAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Post, "/sign-in/register/resend-phone-confirmation");
+    }
+
+    [Fact]
+    public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, HttpMethod.Post, "/sign-in/register/resend-phone-confirmation");
+    }
+
+    [Fact]
+    public async Task Post_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, additionalScopes: null, HttpMethod.Post, "/sign-in/register/resend-phone-confirmation");
+    }
+
+    [Fact]
+    public async Task Post_MobileNumberNotKnown_RedirectsToRegisterPhonePage()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified(), additionalScopes: null);
+        var differentEmail = Faker.Internet.Email();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/resend-phone-confirmation?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "MobileNumber", differentEmail }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Act
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/sign-in/register/phone?{authStateHelper.ToQueryParam()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_PhoneAlreadyVerified_RedirectsToRegisterName()
+    {
+        // Arrange
+        var email = Faker.Internet.Email();
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.MobileVerified(), additionalScopes: null);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/resend-phone-confirmation?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Email", email }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Act
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/sign-in/register/name?{authStateHelper.ToQueryParam()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_EmptyMobileNumber_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/resend-phone-confirmation?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "MobileNumber", "Enter your mobile phone number");
+    }
+
+    [Fact]
+    public async Task Post_ValidMobileNumberWithBlockedClient_ReturnsTooManyRequestsStatusCode()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+
+        HostFixture.RateLimitStore.Setup(x => x.IsClientIpBlockedForPinGeneration(TestRequestClientIpProvider.ClientIpAddress)).ReturnsAsync(true);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/resend-phone-confirmation?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "MobileNumber", Faker.Phone.Number() }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status429TooManyRequests, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_SetsMobileNumberOnAuthenticationStateGeneratesPinAndRedirects()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var mobileNumber = Faker.Phone.Number();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/resend-phone-confirmation?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "MobileNumber", mobileNumber }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/sign-in/register/phone-confirmation?{authStateHelper.ToQueryParam()}", response.Headers.Location?.OriginalString);
+
+        Assert.Equal(mobileNumber, authStateHelper.AuthenticationState.MobileNumber);
+
+        HostFixture.UserVerificationService.Verify(mock => mock.GenerateSmsPin(mobileNumber), Times.Once);
+    }
+
+    [Fact]
+    public async Task Post_NotificationServiceMobileNumber_ReturnsError()
+    {
+        // Arrange
+        HostFixture.NotificationSender
+            .Setup(mock => mock.SendSms(It.IsAny<string>(), It.IsAny<string>()))
+            .Throws(new Exception("ValidationError"));
+
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var mobileNumber = Faker.Phone.Number();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/resend-phone-confirmation?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "MobileNumber", mobileNumber }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "MobileNumber", "Enter a valid mobile phone number");
+    }
+
+    private Func<AuthenticationState, Task> ConfigureValidAuthenticationState(AuthenticationStateHelper.Configure configure) =>
+        configure.MobileNumberSet();
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ResendPhoneConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ResendPhoneConfirmationTests.cs
@@ -1,3 +1,4 @@
+using TeacherIdentity.AuthServer.Helpers;
 using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
@@ -206,7 +207,7 @@ public class ResendPhoneConfirmationTests : TestBase
 
         Assert.Equal(mobileNumber, authStateHelper.AuthenticationState.MobileNumber);
 
-        HostFixture.UserVerificationService.Verify(mock => mock.GenerateSmsPin(mobileNumber), Times.Once);
+        HostFixture.UserVerificationService.Verify(mock => mock.GenerateSmsPin(PhoneHelper.FormatMobileNumber(mobileNumber)), Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
### Context

As an overseas qualified teacher
I want to sign in/register a Teaching services account
So that I can apply for QTS

### Changes proposed in this pull request

Add a new page at /sign-in/register/resend-phone-confirmation following the designs at https://get-an-identity-prototype.herokuapp.com/auth/resend-phone.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
