### PR TITLE
Add send confirm existing account phone page for register journey

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -111,6 +111,8 @@ public class AuthenticationState
     [JsonInclude]
     public string? ExistingAccountEmail { get; private set; }
     [JsonInclude]
+    public string? ExistingAccountMobileNumber { get; private set; }
+    [JsonInclude]
     public bool? ExistingAccountChosen { get; private set; }
 
     /// <summary>
@@ -618,6 +620,7 @@ public class AuthenticationState
     {
         ExistingAccountUserId = existingUserAccount.UserId;
         ExistingAccountEmail = existingUserAccount.EmailAddress;
+        ExistingAccountMobileNumber = existingUserAccount.MobileNumber;
     }
 
     public void OnExistingAccountChosen(bool isUsersAccount)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -119,6 +119,12 @@ public static class IdentityLinkGeneratorExtensions
 
     public static string RegisterResendConfirmExistingAccountEmail(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Register/ResendConfirmExistingAccountEmail");
 
+    public static string RegisterSendConfirmExistingAccountPhone(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Register/SendConfirmExistingAccountPhone");
+
+    public static string RegisterConfirmExistingAccountPhone(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Register/ConfirmExistingAccountPhone");
+
+    public static string RegisterProveYourIdentity(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Register/ProveYourIdentity");
+
     public static string UpdateEmail(this IIdentityLinkGenerator linkGenerator, string? returnUrl, string? cancelUrl) =>
         linkGenerator.PageWithAuthenticationJourneyId("/Authenticated/UpdateEmail/Index", authenticationJourneyRequired: false)
             .SetQueryParam("returnUrl", returnUrl)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/BaseExistingPhonePageModel.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/BaseExistingPhonePageModel.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Services.UserVerification;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn;
+
+public class BaseExistingPhonePageModel : PageModel
+{
+    private IUserVerificationService _userVerificationService;
+
+    public BaseExistingPhonePageModel(IUserVerificationService userVerificationService)
+    {
+        _userVerificationService = userVerificationService;
+    }
+
+    public async Task<PinGenerationResultAction> GenerateSmsPinForExistingMobileNumber(string mobileNumber)
+    {
+        var pinGenerationResult = await _userVerificationService.GenerateSmsPin(mobileNumber);
+
+        switch (pinGenerationResult.FailedReason)
+        {
+            case PinGenerationFailedReason.None:
+                return PinGenerationResultAction.Succeeded();
+
+            case PinGenerationFailedReason.RateLimitExceeded:
+                return PinGenerationResultAction.Failed(new ViewResult()
+                {
+                    StatusCode = 429,
+                    ViewName = "TooManyRequests"
+                });
+
+            default:
+                throw new NotImplementedException($"Unknown {nameof(PinGenerationFailedReason)}: '{pinGenerationResult.FailedReason}'.");
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/BaseExistingPhonePageModel.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/BaseExistingPhonePageModel.cs
@@ -1,6 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ConfirmExistingAccount.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ConfirmExistingAccount.cshtml
@@ -20,7 +20,7 @@
             </govuk-input>
 
             <p><a href="@LinkGenerator.RegisterResendConfirmExistingAccountEmail()">I have not received an email</a></p>
-            <p><a href="@LinkGenerator.RegisterResendPhoneConfirmation()">I can’t access this email address</a></p>
+            <p><a href="@LinkGenerator.RegisterSendConfirmExistingAccountPhone()">I can’t access this email address</a></p>
 
             <govuk-button type="submit">Continue</govuk-button>
         </form>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/SendConfirmExistingAccountPhone.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/SendConfirmExistingAccountPhone.cshtml
@@ -1,0 +1,23 @@
+@page "/sign-in/register/send-confirm-existing-account-phone"
+@model TeacherIdentity.AuthServer.Pages.SignIn.Register.SendConfirmExistingAccountPhone
+@{
+    ViewBag.Title = "Request a new security code";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.RegisterConfirmExistingAccount()" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.RegisterSendConfirmExistingAccountPhone()" method="post" asp-antiforgery="true">
+            <h1 class="govuk-heading-xl">Request security code to your mobile phone</h1>
+
+            <p>We’ll send text message to <b>@Redactor.RedactMobileNumber(Model.ExistingMobileNumber!)</b> which contains a security code</p>
+
+            <govuk-button type="submit">Request security code</govuk-button>
+
+            <p><a href="@LinkGenerator.RegisterProveYourIdentity()">I can’t access this mobile number</a></p>
+        </form>
+    </div>
+</div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/SendConfirmExistingAccountPhone.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/SendConfirmExistingAccountPhone.cshtml.cs
@@ -1,0 +1,46 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using TeacherIdentity.AuthServer.Services.UserVerification;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
+
+public class SendConfirmExistingAccountPhone : BaseExistingPhonePageModel
+{
+    private IIdentityLinkGenerator _linkGenerator;
+
+    public SendConfirmExistingAccountPhone(
+        IUserVerificationService userVerificationService,
+        IIdentityLinkGenerator linkGenerator) :
+        base(userVerificationService)
+    {
+        _linkGenerator = linkGenerator;
+    }
+
+    public string? ExistingMobileNumber => HttpContext.GetAuthenticationState().ExistingAccountMobileNumber;
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        var pinGenerationResult = await GenerateSmsPinForExistingMobileNumber(ExistingMobileNumber!);
+
+        if (!pinGenerationResult.Success)
+        {
+            return pinGenerationResult.Result!;
+        }
+
+        return Redirect(_linkGenerator.RegisterConfirmExistingAccountPhone());
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        if (HttpContext.GetAuthenticationState().ExistingAccountMobileNumber is null ||
+            HttpContext.GetAuthenticationState().ExistingAccountChosen != true)
+        {
+            context.Result = new RedirectResult(_linkGenerator.RegisterCheckAccount());
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/Redactor.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/Redactor.cs
@@ -63,6 +63,11 @@ public class Redactor
             return string.Empty;
         }
 
+        if (mobileNumber.Length <= 4)
+        {
+            return "***" + mobileNumber[^1];
+        }
+
         return new string('*', mobileNumber.Length - 4) + mobileNumber.Substring(mobileNumber.Length - 4);
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/Redactor.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/Redactor.cs
@@ -55,4 +55,14 @@ public class Redactor
 
         return builder.ToString();
     }
+
+    public string? RedactMobileNumber(string mobileNumber)
+    {
+        if (string.IsNullOrEmpty(mobileNumber))
+        {
+            return string.Empty;
+        }
+
+        return new string('*', mobileNumber.Length - 4) + mobileNumber.Substring(mobileNumber.Length - 4);
+    }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ResendPhoneConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ResendPhoneConfirmationTests.cs
@@ -97,7 +97,7 @@ public class ResendPhoneConfirmationTests : TestBase
     }
 
     [Fact]
-    public async Task Post_MobileNumberNotKnown_RedirectsToRegisterPhonePage()
+    public async Task Post_PhoneNotKnown_RedirectsToRegisterPhonePage()
     {
         // Arrange
         var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified(), additionalScopes: null);
@@ -211,7 +211,7 @@ public class ResendPhoneConfirmationTests : TestBase
     }
 
     [Fact]
-    public async Task Post_NotificationServiceMobileNumber_ReturnsError()
+    public async Task Post_InvalidNotificationServiceMobileNumber_ReturnsError()
     {
         // Arrange
         HostFixture.NotificationSender

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/SendConfirmExistingAccountPhoneTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/SendConfirmExistingAccountPhoneTests.cs
@@ -1,0 +1,170 @@
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
+
+[Collection(nameof(DisableParallelization))]  // Depends on mocks
+public class SendConfirmExistingAccountPhoneTests : TestBase, IAsyncLifetime
+{
+    private User? _existingUserAccount;
+
+    public SendConfirmExistingAccountPhoneTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    public async Task InitializeAsync()
+    {
+        _existingUserAccount = await TestData.CreateUser();
+    }
+
+    public Task DisposeAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Get_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register/send-confirm-existing-account-phone");
+    }
+
+    [Fact]
+    public async Task Get_NoAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await MissingAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register/send-confirm-existing-account-phone");
+    }
+
+    [Fact]
+    public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, HttpMethod.Get, "/sign-in/register/send-confirm-existing-account-phone");
+    }
+
+    [Fact]
+    public async Task Get_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, additionalScopes: null, HttpMethod.Get, "/sign-in/register/send-confirm-existing-account-phone");
+    }
+
+    [Fact]
+    public async Task Get_PhoneNotKnown_RedirectsToCheckAccount()
+    {
+        // Arrange
+        _existingUserAccount!.MobileNumber = null;
+
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/send-confirm-existing-account-phone?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Act
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/sign-in/register/check-account?{authStateHelper.ToQueryParam()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_ExistingAccountChosenNotSet_RedirectsToCheckAccount()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.RegisterExistingUserAccountMatch(), additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/resend-confirm-existing-account-email?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Act
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/register/check-account", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_RendersExpectedContent()
+    {
+        await ValidRequest_RendersContent(ConfigureValidAuthenticationState, "/sign-in/register/send-confirm-existing-account-phone", additionalScopes: null);
+    }
+
+    [Fact]
+    public async Task Post_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Post, "/sign-in/register/send-confirm-existing-account-phone");
+    }
+
+    [Fact]
+    public async Task Post_MissingAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Post, "/sign-in/register/send-confirm-existing-account-phone");
+    }
+
+    [Fact]
+    public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, HttpMethod.Post, "/sign-in/register/send-confirm-existing-account-phone");
+    }
+
+    [Fact]
+    public async Task Post_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, additionalScopes: null, HttpMethod.Post, "/sign-in/register/send-confirm-existing-account-phone");
+    }
+
+    [Fact]
+    public async Task Post_PhoneNotKnown_RedirectsToCheckAccount()
+    {
+        // Arrange
+        _existingUserAccount!.MobileNumber = null;
+
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/send-confirm-existing-account-phone?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Act
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/sign-in/register/check-account?{authStateHelper.ToQueryParam()}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_ExistingAccountChosenNotSet_RedirectsToCheckAccount()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.RegisterExistingUserAccountMatch(), additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/resend-confirm-existing-account-email?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Act
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/register/check-account", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_GeneratesPinAndRedirects()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/send-confirm-existing-account-phone?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        HostFixture.UserVerificationService.Verify(mock => mock.GenerateSmsPin(_existingUserAccount!.MobileNumber!), Times.Once);
+    }
+
+    private Func<AuthenticationState, Task> ConfigureValidAuthenticationState(AuthenticationStateHelper.Configure configure) =>
+        configure.RegisterExistingUserAccountChosen(_existingUserAccount);
+}


### PR DESCRIPTION
### Context

As an overseas qualified teacher
I want to sign in/register a Teaching services account
So that I can apply for QTS

### Changes proposed in this pull request

Add a new page at /sign-in/register/send-confirm-existing-account-phone

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [x] Reminder created to manually clean any removed app settings post deployment
