### PR TITLE
Add confirm existing account phone page

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -121,6 +121,8 @@ public static class IdentityLinkGeneratorExtensions
 
     public static string RegisterSendConfirmExistingAccountPhone(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Register/SendConfirmExistingAccountPhone");
 
+    public static string RegisterResendConfirmExistingAccountPhone(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Register/ResendConfirmExistingAccountPhone");
+
     public static string RegisterConfirmExistingAccountPhone(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Register/ConfirmExistingAccountPhone");
 
     public static string RegisterProveYourIdentity(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Register/ProveYourIdentity");

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/BasePhoneConfirmationPageModel.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/BasePhoneConfirmationPageModel.cs
@@ -11,7 +11,7 @@ public abstract class BasePhoneConfirmationPageModel : BasePinVerificationPageMo
     {
     }
 
-    public string? MobileNumber => HttpContext.GetAuthenticationState().MobileNumber;
+    public virtual string? MobileNumber => HttpContext.GetAuthenticationState().MobileNumber;
 
     protected override Task<PinGenerationResult> GeneratePin()
     {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ConfirmExistingAccountPhone.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ConfirmExistingAccountPhone.cshtml
@@ -1,0 +1,28 @@
+@page "/sign-in/register/confirm-existing-account-phone"
+@model TeacherIdentity.AuthServer.Pages.SignIn.Register.ConfirmExistingAccountPhone
+@{
+    ViewBag.Title = "Check your phone";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.RegisterSendConfirmExistingAccountPhone()" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.RegisterConfirmExistingAccountPhone()" method="post" asp-antiforgery="true">
+            <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
+
+            <p>We’ve sent you a text message with a security code to <b data-testid="mobileNumber">@Redactor.RedactMobileNumber(Model.MobileNumber!)</b></p>
+
+            <govuk-input asp-for="Code" input-class="govuk-!-width-one-quarter" pattern="[0-9]*" inputmode="numeric" autocomplete="one-time-code">
+                <govuk-input-label class="govuk-label--s" />
+            </govuk-input>
+
+            <p><a href="@LinkGenerator.RegisterResendConfirmExistingAccountPhone()">I have not received a text message</a></p>
+            <p><a href="@LinkGenerator.RegisterResendPhoneConfirmation()">I can’t access this mobile number</a></p>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ConfirmExistingAccountPhone.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ConfirmExistingAccountPhone.cshtml.cs
@@ -1,0 +1,89 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Helpers;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Services.UserVerification;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
+
+public class ConfirmExistingAccountPhone : BasePhoneConfirmationPageModel
+{
+    private readonly IIdentityLinkGenerator _linkGenerator;
+    private readonly TeacherIdentityServerDbContext _dbContext;
+
+    public ConfirmExistingAccountPhone(
+        IUserVerificationService userVerificationService,
+        PinValidator pinValidator,
+        IIdentityLinkGenerator linkGenerator,
+        TeacherIdentityServerDbContext dbContext)
+        : base(userVerificationService, pinValidator)
+    {
+        _linkGenerator = linkGenerator;
+        _dbContext = dbContext;
+    }
+
+    public override string? MobileNumber => HttpContext.GetAuthenticationState().ExistingAccountMobileNumber;
+    public new User? User { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Security code")]
+    public override string? Code { get; set; }
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        Code = Code?.Trim();
+        ValidateCode();
+
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        var pinVerificationFailedReasons = await UserVerificationService.VerifySmsPin(MobileNumber!, Code!);
+
+        if (pinVerificationFailedReasons != PinVerificationFailedReasons.None)
+        {
+            return await HandlePinVerificationFailed(pinVerificationFailedReasons);
+        }
+
+        var authenticationState = HttpContext.GetAuthenticationState();
+
+        authenticationState.OnExistingAccountVerified(User!);
+        await authenticationState.SignIn(HttpContext);
+
+        return Redirect(authenticationState.GetNextHopUrl(_linkGenerator));
+    }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        var authenticationState = context.HttpContext.GetAuthenticationState();
+
+        if (MobileNumber is null || authenticationState.ExistingAccountChosen != true)
+        {
+            context.Result = new RedirectResult(_linkGenerator.RegisterCheckAccount());
+            return;
+        }
+
+        User = await _dbContext.Users.Where(u => u.UserType == UserType.Default && u.MobileNumber == MobileNumber).SingleOrDefaultAsync();
+
+        if (User is null)
+        {
+            context.Result = NotFound();
+            return;
+        }
+
+        if (!authenticationState.GetPermittedUserTypes().Contains(User.UserType))
+        {
+            context.Result = new ForbidResult();
+            return;
+        }
+
+        await next();
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ConfirmExistingAccountPhone.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ConfirmExistingAccountPhone.cshtml.cs
@@ -2,7 +2,6 @@ using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.EntityFrameworkCore;
-using TeacherIdentity.AuthServer.Helpers;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/SendConfirmExistingAccountPhone.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/SendConfirmExistingAccountPhone.cshtml.cs
@@ -37,8 +37,10 @@ public class SendConfirmExistingAccountPhone : BaseExistingPhonePageModel
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (HttpContext.GetAuthenticationState().ExistingAccountMobileNumber is null ||
-            HttpContext.GetAuthenticationState().ExistingAccountChosen != true)
+        var authenticationState = context.HttpContext.GetAuthenticationState();
+
+        if (authenticationState.ExistingAccountMobileNumber is null ||
+            authenticationState.ExistingAccountChosen != true)
         {
             context.Result = new RedirectResult(_linkGenerator.RegisterCheckAccount());
         }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ConfirmExistingAccountPhoneTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ConfirmExistingAccountPhoneTests.cs
@@ -1,0 +1,388 @@
+using Microsoft.Extensions.Options;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Oidc;
+using TeacherIdentity.AuthServer.Services;
+using TeacherIdentity.AuthServer.Services.UserVerification;
+using TeacherIdentity.AuthServer.Tests.Infrastructure;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
+
+[Collection(nameof(DisableParallelization))]  // Depends on mocks and changes the clock
+public class ConfirmExistingAccountPhoneTests : TestBase, IAsyncLifetime
+{
+    private User? _existingUserAccount;
+
+    public ConfirmExistingAccountPhoneTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+        HostFixture.RateLimitStore.Setup(x => x.IsClientIpBlockedForPinVerification(TestRequestClientIpProvider.ClientIpAddress)).ReturnsAsync(false);
+    }
+
+    public async Task InitializeAsync()
+    {
+        _existingUserAccount = await TestData.CreateUser();
+    }
+
+    public Task DisposeAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task Get_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register/confirm-existing-account-phone");
+    }
+
+    [Fact]
+    public async Task Get_NoAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await MissingAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register/confirm-existing-account-phone");
+    }
+
+    [Fact]
+    public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, HttpMethod.Get, "/sign-in/register/confirm-existing-account-phone");
+    }
+
+    [Fact]
+    public async Task Get_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, additionalScopes: null, HttpMethod.Get, "/sign-in/register/confirm-existing-account-phone");
+    }
+
+    [Fact]
+    public async Task Get_ExistingAccountChosenNotSet_RedirectsToCheckAccount()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.RegisterExistingUserAccountMatch(), additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/confirm-existing-account-phone?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Act
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/register/check-account", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_ExistingAccountMobileNumberNull_RedirectsToCheckAccount()
+    {
+        // Arrange
+        _existingUserAccount!.MobileNumber = null;
+
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.RegisterExistingUserAccountMatch(), additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/confirm-existing-account-phone?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Act
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/register/check-account", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_RendersExpectedContent()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/confirm-existing-account-phone?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Act
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+        Assert.Equal(new Redactor().RedactMobileNumber(authStateHelper.AuthenticationState.ExistingAccountMobileNumber!), doc.GetElementByTestId("mobileNumber")?.TextContent);
+    }
+
+    [Fact]
+    public async Task Post_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Post, "/sign-in/register/confirm-existing-account-phone");
+    }
+
+    [Fact]
+    public async Task Post_NoAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await MissingAuthenticationState_ReturnsBadRequest(HttpMethod.Post, "/sign-in/register/confirm-existing-account-phone");
+    }
+
+    [Fact]
+    public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, HttpMethod.Post, "/sign-in/register/confirm-existing-account-phone");
+    }
+
+    [Fact]
+    public async Task Post_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, additionalScopes: null, HttpMethod.Post, "/sign-in/register/confirm-existing-account-phone");
+    }
+
+    [Fact]
+    public async Task Post_UnknownPin_ReturnsError()
+    {
+        // The real PIN generation service never generates pins that start with a '0'
+        var pin = "01234";
+
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/confirm-existing-account-phone?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pin }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Code", "Enter a correct security code");
+    }
+
+    [Fact]
+    public async Task Post_PinTooShort_ReturnsError()
+    {
+        // Arrange
+        var pin = "0";
+
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/confirm-existing-account-phone?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pin }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Code", "You’ve not entered enough numbers, the code must be 5 numbers");
+    }
+
+    [Fact]
+    public async Task Post_PinTooLong_ReturnsError()
+    {
+        // Arrange
+        var pin = "0123345678";
+
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/confirm-existing-account-phone?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pin }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Code", "You’ve entered too many numbers, the code must be 5 numbers");
+    }
+
+    [Fact]
+    public async Task Post_NonNumericPin_ReturnsError()
+    {
+        // Arrange
+        var pin = "abc";
+
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/confirm-existing-account-phone?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pin }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Code", "The code must be 5 numbers");
+    }
+
+    [Fact]
+    public async Task Post_PinExpiredLessThanTwoHoursAgo_ReturnsErrorAndSendsANewPin()
+    {
+        // Arrange
+        var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
+        var pinResult = await userVerificationService.GenerateSmsPin(_existingUserAccount!.MobileNumber!);
+        Clock.AdvanceBy(TimeSpan.FromHours(1));
+        Spy.Get<IUserVerificationService>().Reset();
+
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/confirm-existing-account-phone?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pinResult.Pin! }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Code", "The security code has expired. New code sent.");
+
+        HostFixture.UserVerificationService.Verify(mock => mock.GenerateSmsPin(_existingUserAccount!.MobileNumber!), Times.Once);
+    }
+
+    [Fact]
+    public async Task Post_PinExpiredMoreThanTwoHoursAgo_ReturnsErrorAndDoesNotSendANewPin()
+    {
+        // Arrange
+        var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
+        var userVerificationOptions = HostFixture.Services.GetRequiredService<IOptions<UserVerificationOptions>>();
+        var pinResult = await userVerificationService.GenerateSmsPin(_existingUserAccount!.MobileNumber!);
+        Clock.AdvanceBy(TimeSpan.FromHours(2) + TimeSpan.FromSeconds(userVerificationOptions.Value.PinLifetimeSeconds));
+        Spy.Get<IUserVerificationService>().Reset();
+
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/confirm-existing-account-phone?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pinResult.Pin! }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Code", "Enter a correct security code");
+
+        HostFixture.UserVerificationService.Verify(mock => mock.GenerateSmsPin(_existingUserAccount!.MobileNumber!), Times.Never);
+    }
+
+    [Fact]
+    public async Task Post_ValidPin_UpdatesAuthenticationState()
+    {
+        // Arrange
+        var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
+        var pinResult = await userVerificationService.GenerateSmsPin(_existingUserAccount!.MobileNumber!);
+
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/confirm-existing-account-phone?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pinResult.Pin! }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        Assert.True(authStateHelper.AuthenticationState.MobileNumberVerified);
+    }
+
+    [Fact]
+    public async Task Post_BlockedClient_ReturnsTooManyRequestsStatusCode()
+    {
+        // Arrange
+        HostFixture.RateLimitStore.Setup(x => x.IsClientIpBlockedForPinVerification(TestRequestClientIpProvider.ClientIpAddress)).ReturnsAsync(true);
+
+        var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
+        var pinResult = await userVerificationService.GenerateSmsPin(_existingUserAccount!.MobileNumber!);
+
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/confirm-existing-account-phone?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pinResult.Pin! }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status429TooManyRequests, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_ValidPinForNonAdminScopeWithNonAdminUser_ReturnsForbidden()
+    {
+        // Arrange
+        var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
+        var pinResult = await userVerificationService.GenerateSmsPin(_existingUserAccount!.MobileNumber!);
+
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: CustomScopes.StaffUserTypeScopes.First());
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/confirm-existing-account-phone?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pinResult.Pin! }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_ValidPinForNonAdminScopeWithNonAdminUser_UpdatesAuthenticationStateSignsInAndRedirects()
+    {
+        // Arrange
+        var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
+        var pinResult = await userVerificationService.GenerateSmsPin(_existingUserAccount!.MobileNumber!);
+
+        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: CustomScopes.DefaultUserTypesScopes.First());
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/confirm-existing-account-phone?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pinResult.Pin! }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal(authStateHelper.AuthenticationState.PostSignInUrl, response.Headers.Location?.OriginalString);
+
+        AssertAuthenticationStateUpdated(_existingUserAccount, authStateHelper);
+    }
+
+    private void AssertAuthenticationStateUpdated(User existingUser, AuthenticationStateHelper authStateHelper)
+    {
+        Assert.Equal(authStateHelper.AuthenticationState.UserId, existingUser.UserId);
+        Assert.Equal(authStateHelper.AuthenticationState.EmailAddress, existingUser.EmailAddress);
+        Assert.Equal(authStateHelper.AuthenticationState.MobileNumber, existingUser.MobileNumber);
+        Assert.Equal(authStateHelper.AuthenticationState.FirstName, existingUser.FirstName);
+        Assert.Equal(authStateHelper.AuthenticationState.LastName, existingUser.LastName);
+        Assert.Equal(authStateHelper.AuthenticationState.DateOfBirth, existingUser.DateOfBirth);
+        Assert.Equal(authStateHelper.AuthenticationState.Trn, existingUser.Trn);
+        Assert.Equal(authStateHelper.AuthenticationState.UserType, existingUser.UserType);
+        Assert.Equal(authStateHelper.AuthenticationState.StaffRoles, existingUser.StaffRoles);
+        Assert.Equal(authStateHelper.AuthenticationState.TrnLookupStatus, existingUser.TrnLookupStatus);
+
+        Assert.True(authStateHelper.AuthenticationState.MobileNumberVerified);
+    }
+
+    private Func<AuthenticationState, Task> ConfigureValidAuthenticationState(AuthenticationStateHelper.Configure configure) =>
+        configure.RegisterExistingUserAccountChosen(existingUserAccount: _existingUserAccount);
+}


### PR DESCRIPTION
### Context

As an overseas qualified teacher
I want to sign in/register a Teaching services account
So that I can apply for QTS

### Changes proposed in this pull request

Add a new page at /sign-in/register/confirm-existing-account-phone following the designs at https://get-an-identity-prototype.herokuapp.com/sign-in/phone-code.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [x] Reminder created to manually clean any removed app settings post deployment
