### PR TITLE
Add resend confirm existing account phone page for register journey

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/EmailConfirmation.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/EmailConfirmation.cshtml
@@ -20,7 +20,7 @@
             </govuk-input>
 
             <p>
-                <a href="@LinkGenerator.RegisterResendEmailConfirmation()">I have not received a text message</a>
+                <a href="@LinkGenerator.RegisterResendEmailConfirmation()">I have not received an email</a>
             </p>
 
             <govuk-button type="submit">Continue</govuk-button>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendConfirmExistingAccountPhone.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendConfirmExistingAccountPhone.cshtml
@@ -1,0 +1,23 @@
+@page "/sign-in/register/resend-confirm-existing-account-phone"
+@model TeacherIdentity.AuthServer.Pages.SignIn.Register.ResendConfirmExistingAccountPhone
+@{
+    ViewBag.Title = "Request a mobile security code";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.RegisterConfirmExistingAccountPhone()" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.RegisterResendConfirmExistingAccountPhone()" method="post" asp-antiforgery="true">
+            <h1 class="govuk-heading-xl">Request security code to your mobile phone</h1>
+
+            <p>We’ll send text message to <b>@Redactor.RedactMobileNumber(Model.ExistingMobileNumber!)</b> which contains a security code</p>
+
+            <p><a href="@LinkGenerator.RegisterProveYourIdentity()">I can’t access this mobile number</a></p>
+
+            <govuk-button type="submit">Request security code</govuk-button>
+        </form>
+    </div>
+</div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendConfirmExistingAccountPhone.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendConfirmExistingAccountPhone.cshtml.cs
@@ -1,0 +1,48 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using TeacherIdentity.AuthServer.Services.UserVerification;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
+
+public class ResendConfirmExistingAccountPhone : BaseExistingPhonePageModel
+{
+    private IIdentityLinkGenerator _linkGenerator;
+
+    public ResendConfirmExistingAccountPhone(
+        IUserVerificationService userVerificationService,
+        IIdentityLinkGenerator linkGenerator) :
+        base(userVerificationService)
+    {
+        _linkGenerator = linkGenerator;
+    }
+
+    public string? ExistingMobileNumber => HttpContext.GetAuthenticationState().ExistingAccountMobileNumber;
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        var pinGenerationResult = await GenerateSmsPinForExistingMobileNumber(ExistingMobileNumber!);
+
+        if (!pinGenerationResult.Success)
+        {
+            return pinGenerationResult.Result!;
+        }
+
+        return Redirect(_linkGenerator.RegisterConfirmExistingAccountPhone());
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var authenticationState = context.HttpContext.GetAuthenticationState();
+
+        if (authenticationState.ExistingAccountMobileNumber is null ||
+            authenticationState.ExistingAccountChosen != true)
+        {
+            context.Result = new RedirectResult(_linkGenerator.RegisterCheckAccount());
+        }
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ResendConfirmExistingAccountPhoneTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ResendConfirmExistingAccountPhoneTests.cs
@@ -4,11 +4,11 @@ using TeacherIdentity.AuthServer.Tests.Infrastructure;
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
 
 [Collection(nameof(DisableParallelization))]  // Depends on mocks
-public class ResendConfirmExistingAccountEmailTests : TestBase, IAsyncLifetime
+public class ResendConfirmExistingAccountPhoneTests : TestBase, IAsyncLifetime
 {
     private User? _existingUserAccount;
 
-    public ResendConfirmExistingAccountEmailTests(HostFixture hostFixture)
+    public ResendConfirmExistingAccountPhoneTests(HostFixture hostFixture)
         : base(hostFixture)
     {
     }
@@ -26,25 +26,25 @@ public class ResendConfirmExistingAccountEmailTests : TestBase, IAsyncLifetime
     [Fact]
     public async Task Get_InvalidAuthenticationStateProvided_ReturnsBadRequest()
     {
-        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register/resend-confirm-existing-account-email");
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register/resend-confirm-existing-account-phone");
     }
 
     [Fact]
     public async Task Get_NoAuthenticationStateProvided_ReturnsBadRequest()
     {
-        await MissingAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register/resend-confirm-existing-account-email");
+        await MissingAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register/resend-confirm-existing-account-phone");
     }
 
     [Fact]
     public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, HttpMethod.Get, "/sign-in/register/resend-confirm-existing-account-email");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, HttpMethod.Get, "/sign-in/register/resend-confirm-existing-account-phone");
     }
 
     [Fact]
     public async Task Get_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, additionalScopes: null, HttpMethod.Get, "/sign-in/register/resend-confirm-existing-account-email");
+        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, additionalScopes: null, HttpMethod.Get, "/sign-in/register/resend-confirm-existing-account-phone");
     }
 
     [Fact]
@@ -52,7 +52,7 @@ public class ResendConfirmExistingAccountEmailTests : TestBase, IAsyncLifetime
     {
         // Arrange
         var authStateHelper = await CreateAuthenticationStateHelper(c => c.RegisterExistingUserAccountMatch(), additionalScopes: null);
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/resend-confirm-existing-account-email?{authStateHelper.ToQueryParam()}");
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/resend-confirm-existing-account-phone?{authStateHelper.ToQueryParam()}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -65,42 +65,42 @@ public class ResendConfirmExistingAccountEmailTests : TestBase, IAsyncLifetime
     [Fact]
     public async Task Get_ValidRequest_RendersExpectedContent()
     {
-        await ValidRequest_RendersContent(ConfigureValidAuthenticationState, "/sign-in/register/resend-confirm-existing-account-email", additionalScopes: null);
+        await ValidRequest_RendersContent(ConfigureValidAuthenticationState, "/sign-in/register/resend-confirm-existing-account-phone", additionalScopes: null);
     }
 
     [Fact]
     public async Task Post_InvalidAuthenticationStateProvided_ReturnsBadRequest()
     {
-        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Post, "/sign-in/register/resend-confirm-existing-account-email");
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Post, "/sign-in/register/resend-confirm-existing-account-phone");
     }
 
     [Fact]
     public async Task Post_MissingAuthenticationStateProvided_ReturnsBadRequest()
     {
-        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Post, "/sign-in/register/resend-confirm-existing-account-email");
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Post, "/sign-in/register/resend-confirm-existing-account-phone");
     }
 
     [Fact]
     public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
     {
-        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, HttpMethod.Post, "/sign-in/register/resend-confirm-existing-account-email");
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, HttpMethod.Post, "/sign-in/register/resend-confirm-existing-account-phone");
     }
 
     [Fact]
     public async Task Post_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, additionalScopes: null, HttpMethod.Post, "/sign-in/register/resend-confirm-existing-account-email");
+        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, additionalScopes: null, HttpMethod.Post, "/sign-in/register/resend-confirm-existing-account-phone");
     }
 
     [Fact]
-    public async Task Post_ValidEmailWithBlockedClient_ReturnsTooManyRequestsStatusCode()
+    public async Task Post_ValidMobileNumberWithBlockedClient_ReturnsTooManyRequestsStatusCode()
     {
         // Arrange
         var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
 
         HostFixture.RateLimitStore.Setup(x => x.IsClientIpBlockedForPinGeneration(TestRequestClientIpProvider.ClientIpAddress)).ReturnsAsync(true);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/resend-confirm-existing-account-email?{authStateHelper.ToQueryParam()}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/resend-confirm-existing-account-phone?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
         };
@@ -118,7 +118,7 @@ public class ResendConfirmExistingAccountEmailTests : TestBase, IAsyncLifetime
         // Arrange
         var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/resend-confirm-existing-account-email?{authStateHelper.ToQueryParam()}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/resend-confirm-existing-account-phone?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
         };
@@ -128,9 +128,9 @@ public class ResendConfirmExistingAccountEmailTests : TestBase, IAsyncLifetime
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal($"/sign-in/register/confirm-existing-account?{authStateHelper.ToQueryParam()}", response.Headers.Location?.OriginalString);
+        Assert.Equal($"/sign-in/register/confirm-existing-account-phone?{authStateHelper.ToQueryParam()}", response.Headers.Location?.OriginalString);
 
-        HostFixture.UserVerificationService.Verify(mock => mock.GenerateEmailPin(_existingUserAccount!.EmailAddress), Times.Once);
+        HostFixture.UserVerificationService.Verify(mock => mock.GenerateSmsPin(_existingUserAccount!.MobileNumber!), Times.Once);
     }
 
     private Func<AuthenticationState, Task> ConfigureValidAuthenticationState(AuthenticationStateHelper.Configure configure) =>


### PR DESCRIPTION
### Context

As an overseas qualified teacher
I want to sign in/register a Teaching services account
So that I can apply for QTS

### Changes proposed in this pull request

Add a new page at /sign-in/register/resend-confirm-existing-account-phonefollowing the designs at https://get-an-identity-prototype.herokuapp.com/sign-in/resend-phone

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [x] Reminder created to manually clean any removed app settings post deployment
