### PR TITLE
Add change email request page

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -125,7 +125,7 @@ public static class IdentityLinkGeneratorExtensions
 
     public static string RegisterExistingAccountPhoneConfirmation(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Register/ExistingAccountPhoneConfirmation");
 
-    public static string RegisterProveYourIdentity(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Register/ProveYourIdentity");
+    public static string RegisterChangeEmailRequest(this IIdentityLinkGenerator linkGenerator) => linkGenerator.PageWithAuthenticationJourneyId("/SignIn/Register/ChangeEmailRequest");
 
     public static string UpdateEmail(this IIdentityLinkGenerator linkGenerator, string? returnUrl, string? cancelUrl) =>
         linkGenerator.PageWithAuthenticationJourneyId("/Authenticated/UpdateEmail/Index", authenticationJourneyRequired: false)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ChangeEmailRequest.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ChangeEmailRequest.cshtml
@@ -1,0 +1,55 @@
+@page "/sign-in/register/change-email-request"
+@{
+    ViewBag.Title = "You need to prove your identity to change your email address";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.RegisterExistingAccountPhone()" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
+
+        <p>Call the Teaching Regulation Agency (TRA) for support.</p>
+
+        <p>Telephone: 020 7593 5394</p>
+        <p>Lines are open Monday to Thursday, 9am to 5pm, and on Friday from 9am to 4:30pm (except public holidays)</p>
+
+        <h2 class="govuk-heading-m">Send a secure email using Galaxkey</h2>
+
+        <p>To send a secure email to the Teaching Regulation Agency (TRA) you need to use the Galaxkey site:</p>
+        <p><a href="https://manager.galaxkey.com/services/registerme">https://manager.galaxkey.com/services/registerme</a></p>
+
+        <p>Use your new email address, jane.doe@example.com.</p>
+        <p>After you activate your account you can then send secure emails to TRA using Galaxkey.</p>
+
+        <h2 class="govuk-heading-m">Send your ID documents securely</h2>
+
+        <p>Follow these steps to send your documents through Galaxkey:</p>
+
+        <ul class="govuk-list govuk-list--bullet">
+            <li>select ‘Compose’ to create a new secure email</li>
+            <li>enter ‘qts.enquiries@education.gov.uk’ as the recipient</li>
+            <li>enter ‘Change of details’ as the subject line</li>
+            <li>in your email include:</li>
+            <ul class="govuk-list govuk-list--bullet">
+                <li>your full legal name</li>
+                <li>your date of birth</li>
+                <li>your email address</li>
+            </ul>
+            <li>attach a scanned copy or photo of one of the following types of ID:</li>
+            <ul class="govuk-list govuk-list--bullet">
+                <li>passport</li>
+                <li>driving licence (full or provisional)</li>
+                <li>certificate of residence</li>
+                <li>birth certificate</li>
+            </ul>
+        </ul>
+
+        <h2 class="govuk-heading-m">What happens next</h2>
+
+        <p>TRA will confirm your identity and update your email address.</p>
+        <p>Your ID documents will be deleted once your request is processed.</p>
+    </div>
+</div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ExistingAccountPhone.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ExistingAccountPhone.cshtml
@@ -17,7 +17,7 @@
 
             <govuk-button type="submit">Request security code</govuk-button>
 
-            <p><a href="@LinkGenerator.RegisterProveYourIdentity()">I can’t access this mobile number</a></p>
+            <p><a href="@LinkGenerator.RegisterChangeEmailRequest()">I can’t access this mobile number</a></p>
         </form>
     </div>
 </div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendExistingAccountPhone.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendExistingAccountPhone.cshtml
@@ -15,7 +15,7 @@
 
             <p>We’ll send text message to <b>@Redactor.RedactMobileNumber(Model.ExistingMobileNumber!)</b> which contains a security code</p>
 
-            <p><a href="@LinkGenerator.RegisterProveYourIdentity()">I can’t access this mobile number</a></p>
+            <p><a href="@LinkGenerator.RegisterChangeEmailRequest()">I can’t access this mobile number</a></p>
 
             <govuk-button type="submit">Request security code</govuk-button>
         </form>


### PR DESCRIPTION
### Context

As an overseas qualified teacher
I want to sign in/register a Teaching services account
So that I can apply for QTS

### Changes proposed in this pull request

Add a new page at /sign-in/register/change-email-requestfollowing the designs at https://get-an-identity-prototype.herokuapp.com/auth/change-email-request

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [x] Reminder created to manually clean any removed app settings post deployment
