### PR TITLE
Use our own journey for the trn scope

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -180,6 +180,12 @@ public class AuthenticationState
         }
     }
 
+    public bool TryGetOAuthState([NotNullWhen(true)] out OAuthAuthorizationState? oAuthState)
+    {
+        oAuthState = OAuthState;
+        return OAuthState is not null;
+    }
+
     public IEnumerable<Claim> GetInternalClaims()
     {
         if (!IsComplete())

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn.cshtml.cs
@@ -1,22 +1,16 @@
 using Flurl;
 using Flurl.Util;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using TeacherIdentity.AuthServer.Oidc;
-using TeacherIdentity.AuthServer.Services.TrnLookup;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn;
 
 [RequireAuthenticationMilestone(AuthenticationState.AuthenticationMilestone.EmailVerified)]
 public class TrnModel : PageModel
 {
-    private readonly FindALostTrnIntegrationHelper _findALostTrnIntegrationHelper;
     private readonly IIdentityLinkGenerator _linkGenerator;
 
-    public TrnModel(
-        FindALostTrnIntegrationHelper findALostTrnIntegrationHelper,
-        IIdentityLinkGenerator linkGenerator)
+    public TrnModel(IIdentityLinkGenerator linkGenerator)
     {
-        _findALostTrnIntegrationHelper = findALostTrnIntegrationHelper;
         _linkGenerator = linkGenerator;
     }
 
@@ -26,23 +20,11 @@ public class TrnModel : PageModel
 
     public string? HandoverMethod { get; set; }
 
-    public async Task OnGet()
+    public void OnGet()
     {
-        var authenticationState = HttpContext.GetAuthenticationState();
-
-        if (authenticationState.OAuthState?.HasScope(CustomScopes.DqtRead) == true)
-        {
-            var nextPage = _linkGenerator.TrnHasTrn();
-            HandoverUrl = new Url(nextPage).RemoveQuery();
-            HandoverParameters = new Url(nextPage).QueryParams.ToKeyValuePairs().ToDictionary(q => q.Key, q => q.Value.ToString()!);
-            HandoverMethod = HttpMethods.Get;
-        }
-        else
-        {
-            var (url, parameters) = await _findALostTrnIntegrationHelper.GetHandoverRequest(authenticationState);
-            HandoverUrl = url;
-            HandoverParameters = parameters.ToDictionary(f => f.Key, f => f.Value.ToString());
-            HandoverMethod = HttpMethods.Post;
-        }
+        var nextPage = _linkGenerator.TrnHasTrn();
+        HandoverUrl = new Url(nextPage).RemoveQuery();
+        HandoverParameters = new Url(nextPage).QueryParams.ToKeyValuePairs().ToDictionary(q => q.Key, q => q.Value.ToString()!);
+        HandoverMethod = HttpMethods.Get;
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/TrnCreateUserPageModel.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/TrnCreateUserPageModel.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Oidc;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 using TeacherIdentity.AuthServer.Services.Zendesk;
 using ZendeskApi.Client.Models;
@@ -101,10 +102,13 @@ public class TrnCreateUserPageModel : PageModel
         authenticationState.OnTrnLookupCompletedAndUserRegistered(user);
         await authenticationState.SignIn(HttpContext);
 
-        if (authenticationState.TrnLookupStatus == TrnLookupStatus.Pending)
+#pragma warning disable CS0618 // Type or member is obsolete
+        if ((!authenticationState.TryGetOAuthState(out var oAuthState) || !oAuthState.HasScope(CustomScopes.Trn)) &&
+            authenticationState.TrnLookupStatus == TrnLookupStatus.Pending)
         {
             await CreateTrnResolutionZendeskTicket(authenticationState);
         }
+#pragma warning restore CS0618 // Type or member is obsolete
 
         return Redirect(authenticationState.GetNextHopUrl(LinkGenerator));
     }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnTests.cs
@@ -1,6 +1,4 @@
-using Microsoft.Extensions.Options;
 using TeacherIdentity.AuthServer.Oidc;
-using TeacherIdentity.AuthServer.Services.TrnLookup;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn;
 
@@ -59,7 +57,7 @@ public class TrnTests : TestBase
     }
 
     [Fact]
-    public async Task Get_WhenDqtReadScopeSpecified_SubmitsToTrnHasTrn()
+    public async Task Get_SubmitsToTrnHasTrn()
     {
         // Arrange
         var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified(), CustomScopes.DqtRead);
@@ -76,30 +74,6 @@ public class TrnTests : TestBase
         var form = doc.GetElementsByTagName("form").Single();
         Assert.StartsWith("/sign-in/trn/has-trn", form.GetAttribute("action"));
         Assert.Equal("GET", form.GetAttribute("method"));
-    }
-
-    [Fact]
-    public async Task Get_WhenDqtReadScopeNotSpecified_SubmitsToHandoverEndpoint()
-    {
-        // Arrange
-#pragma warning disable CS0618 // Type or member is obsolete
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified(), CustomScopes.Trn);
-#pragma warning restore CS0618 // Type or member is obsolete
-
-        var handoverEndpoint = HostFixture.Services.GetRequiredService<IOptions<FindALostTrnIntegrationOptions>>().Value.HandoverEndpoint;
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn?{authStateHelper.ToQueryParam()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
-
-        var doc = await response.GetDocument();
-        var form = doc.GetElementsByTagName("form").Single();
-        Assert.Equal(handoverEndpoint, form.GetAttribute("action"));
-        Assert.Equal("POST", form.GetAttribute("method"));
     }
 
     [Fact]


### PR DESCRIPTION
We're decoupling from Find a lost TRN so that we host the whole UI ourselves. 

Currently to access our Find-less journey, services need to use the `dqt:read` scope, instead of `trn`. In the interests of forcing this separation more quickly, this change means we'll use our journey for `trn` scope too. Raising a Zendesk ticket if a TRN is not found is now guarded by a check for the `dqt:read` scope so that we emulate the current Find behaviour.

Once this has been out in the wild for a bit without issue a further PR will follow to tidy up all the now-redundant Find integration.