### PR TITLE
Add test-scoped services

### DIFF
--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AddUserImportTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AddUserImportTests.cs
@@ -3,7 +3,6 @@ using Microsoft.EntityFrameworkCore;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Admin;
 
-[Collection(nameof(DisableParallelization))]  // Relies on mocks
 public class AddUserImportTests : TestBase
 {
     public AddUserImportTests(HostFixture hostFixture)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AssignTrn/ConfirmTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AssignTrn/ConfirmTests.cs
@@ -5,7 +5,6 @@ using TeacherIdentity.AuthServer.Services.DqtApi;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Admin.AssignTrn;
 
-[Collection(nameof(DisableParallelization))]  // Relies on mocks
 public class ConfirmTests : TestBase
 {
     public ConfirmTests(HostFixture hostFixture)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AssignTrn/TrnTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AssignTrn/TrnTests.cs
@@ -2,7 +2,6 @@ using TeacherIdentity.AuthServer.Services.DqtApi;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Admin.AssignTrn;
 
-[Collection(nameof(DisableParallelization))]  // Relies on mocks
 public class TrnTests : TestBase
 {
     public TrnTests(HostFixture hostFixture)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/UserTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/UserTests.cs
@@ -1,6 +1,5 @@
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Admin;
 
-[Collection(nameof(DisableParallelization))]  // Relies on mocks
 public class UserTests : TestBase
 {
     public UserTests(HostFixture hostFixture)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/UpdateUserTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/UpdateUserTests.cs
@@ -4,7 +4,6 @@ using TeacherIdentity.AuthServer.Oidc;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Api.V1;
 
-[Collection(nameof(DisableParallelization))]  // Changes the clock
 public class UpdateUserTests : TestBase
 {
     public UpdateUserTests(HostFixture hostFixture)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Authenticated/TestBase.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Authenticated/TestBase.cs
@@ -24,6 +24,8 @@ public partial class TestBase
 
     public HostFixture HostFixture { get; }
 
+    public SpyRegistry SpyRegistry => HostFixture.SpyRegistry;
+
     public TestData TestData => HostFixture.Services.GetRequiredService<TestData>();
 
     public HttpClient HttpClient { get; }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Authenticated/UpdateEmail/ConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Authenticated/UpdateEmail/ConfirmationTests.cs
@@ -7,7 +7,6 @@ using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Authenticated.UpdateEmail;
 
-[Collection(nameof(DisableParallelization))]  // Depends on mocks and changes the clock
 public class ConfirmationTests : TestBase
 {
     public ConfirmationTests(HostFixture hostFixture)
@@ -228,7 +227,7 @@ public class ConfirmationTests : TestBase
         var pinResult = await userVerificationService.GenerateEmailPin(newEmail);
         Assert.True(pinResult.Succeeded);
         Clock.AdvanceBy(TimeSpan.FromHours(1));
-        Spy.Get<IUserVerificationService>().Reset();
+        SpyRegistry.Get<IUserVerificationService>().Reset();
 
         var protectedEmail = HostFixture.Services.GetRequiredService<ProtectedStringFactory>().CreateFromPlainValue(newEmail);
 
@@ -266,7 +265,7 @@ public class ConfirmationTests : TestBase
         var pinResult = await userVerificationService.GenerateEmailPin(newEmail);
         Assert.True(pinResult.Succeeded);
         Clock.AdvanceBy(TimeSpan.FromHours(2) + TimeSpan.FromSeconds(userVerificationOptions.Value.PinLifetimeSeconds));
-        Spy.Get<IUserVerificationService>().Reset();
+        SpyRegistry.Get<IUserVerificationService>().Reset();
 
         var protectedEmail = HostFixture.Services.GetRequiredService<ProtectedStringFactory>().CreateFromPlainValue(newEmail);
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Authenticated/UpdateEmail/IndexTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Authenticated/UpdateEmail/IndexTests.cs
@@ -5,7 +5,6 @@ using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Authenticated.UpdateEmail;
 
-[Collection(nameof(DisableParallelization))]  // Relies on mocks
 public class IndexTests : TestBase
 {
     public IndexTests(HostFixture hostFixture)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Authenticated/UpdateEmail/ResendConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Authenticated/UpdateEmail/ResendConfirmationTests.cs
@@ -5,7 +5,6 @@ using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Authenticated.UpdateEmail;
 
-[Collection(nameof(DisableParallelization))]  // Relies on mocks
 public class ResendConfirmationTests : TestBase
 {
     public ResendConfirmationTests(HostFixture hostFixture)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/CompleteTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/CompleteTests.cs
@@ -2,7 +2,6 @@ using TeacherIdentity.AuthServer.Oidc;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn;
 
-[Collection(nameof(DisableParallelization))]  // Relies on mocks
 public class CompleteTests : TestBase
 {
     public CompleteTests(HostFixture hostFixture)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
@@ -5,7 +5,6 @@ using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn;
 
-[Collection(nameof(DisableParallelization))]  // Depends on mocks and changes the clock
 public class EmailConfirmationTests : TestBase
 {
     public EmailConfirmationTests(HostFixture hostFixture)
@@ -228,7 +227,7 @@ public class EmailConfirmationTests : TestBase
         var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
         var pinResult = await userVerificationService.GenerateEmailPin(email);
         Clock.AdvanceBy(TimeSpan.FromHours(1));
-        Spy.Get<IUserVerificationService>().Reset();
+        SpyRegistry.Get<IUserVerificationService>().Reset();
 
         var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
@@ -258,7 +257,7 @@ public class EmailConfirmationTests : TestBase
         var userVerificationOptions = HostFixture.Services.GetRequiredService<IOptions<UserVerificationOptions>>();
         var pinResult = await userVerificationService.GenerateEmailPin(email);
         Clock.AdvanceBy(TimeSpan.FromHours(2) + TimeSpan.FromSeconds(userVerificationOptions.Value.PinLifetimeSeconds));
-        Spy.Get<IUserVerificationService>().Reset();
+        SpyRegistry.Get<IUserVerificationService>().Reset();
 
         var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailTests.cs
@@ -3,7 +3,6 @@ using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn;
 
-[Collection(nameof(DisableParallelization))]  // Depends on mocks
 public class EmailTests : TestBase
 {
     public EmailTests(HostFixture hostFixture)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailConfirmationTests.cs
@@ -5,7 +5,6 @@ using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
 
-[Collection(nameof(DisableParallelization))]  // Depends on mocks and changes the clock
 public class EmailConfirmationTests : TestBase
 {
     public EmailConfirmationTests(HostFixture hostFixture)
@@ -197,7 +196,7 @@ public class EmailConfirmationTests : TestBase
         var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
         var pinResult = await userVerificationService.GenerateEmailPin(email);
         Clock.AdvanceBy(TimeSpan.FromHours(1));
-        Spy.Get<IUserVerificationService>().Reset();
+        SpyRegistry.Get<IUserVerificationService>().Reset();
 
         var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email-confirmation?{authStateHelper.ToQueryParam()}")
@@ -227,7 +226,7 @@ public class EmailConfirmationTests : TestBase
         var userVerificationOptions = HostFixture.Services.GetRequiredService<IOptions<UserVerificationOptions>>();
         var pinResult = await userVerificationService.GenerateEmailPin(email);
         Clock.AdvanceBy(TimeSpan.FromHours(2) + TimeSpan.FromSeconds(userVerificationOptions.Value.PinLifetimeSeconds));
-        Spy.Get<IUserVerificationService>().Reset();
+        SpyRegistry.Get<IUserVerificationService>().Reset();
 
         var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(email), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email-confirmation?{authStateHelper.ToQueryParam()}")

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailTests.cs
@@ -3,7 +3,6 @@ using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
 
-[Collection(nameof(DisableParallelization))]  // Depends on mocks
 public class EmailTests : TestBase
 {
     public EmailTests(HostFixture hostFixture)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ExistingAccountEmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ExistingAccountEmailConfirmationTests.cs
@@ -7,7 +7,6 @@ using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
 
-[Collection(nameof(DisableParallelization))]  // Depends on mocks and changes the clock
 public class ExistingAccountEmailConfirmationTests : TestBase, IAsyncLifetime
 {
     private User? _existingUserAccount;
@@ -203,7 +202,7 @@ public class ExistingAccountEmailConfirmationTests : TestBase, IAsyncLifetime
         var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
         var pinResult = await userVerificationService.GenerateEmailPin(_existingUserAccount!.EmailAddress);
         Clock.AdvanceBy(TimeSpan.FromHours(1));
-        Spy.Get<IUserVerificationService>().Reset();
+        SpyRegistry.Get<IUserVerificationService>().Reset();
 
         var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/existing-account-email-confirmation?{authStateHelper.ToQueryParam()}")
@@ -231,7 +230,7 @@ public class ExistingAccountEmailConfirmationTests : TestBase, IAsyncLifetime
         var userVerificationOptions = HostFixture.Services.GetRequiredService<IOptions<UserVerificationOptions>>();
         var pinResult = await userVerificationService.GenerateEmailPin(_existingUserAccount!.EmailAddress);
         Clock.AdvanceBy(TimeSpan.FromHours(2) + TimeSpan.FromSeconds(userVerificationOptions.Value.PinLifetimeSeconds));
-        Spy.Get<IUserVerificationService>().Reset();
+        SpyRegistry.Get<IUserVerificationService>().Reset();
 
         var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/existing-account-email-confirmation?{authStateHelper.ToQueryParam()}")

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ExistingAccountPhoneConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ExistingAccountPhoneConfirmationTests.cs
@@ -7,7 +7,6 @@ using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
 
-[Collection(nameof(DisableParallelization))]  // Depends on mocks and changes the clock
 public class ExistingAccountPhoneConfirmationTests : TestBase, IAsyncLifetime
 {
     private User? _existingUserAccount;
@@ -220,7 +219,7 @@ public class ExistingAccountPhoneConfirmationTests : TestBase, IAsyncLifetime
         var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
         var pinResult = await userVerificationService.GenerateSmsPin(_existingUserAccount!.MobileNumber!);
         Clock.AdvanceBy(TimeSpan.FromHours(1));
-        Spy.Get<IUserVerificationService>().Reset();
+        SpyRegistry.Get<IUserVerificationService>().Reset();
 
         var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/existing-account-phone-confirmation?{authStateHelper.ToQueryParam()}")
@@ -248,7 +247,7 @@ public class ExistingAccountPhoneConfirmationTests : TestBase, IAsyncLifetime
         var userVerificationOptions = HostFixture.Services.GetRequiredService<IOptions<UserVerificationOptions>>();
         var pinResult = await userVerificationService.GenerateSmsPin(_existingUserAccount!.MobileNumber!);
         Clock.AdvanceBy(TimeSpan.FromHours(2) + TimeSpan.FromSeconds(userVerificationOptions.Value.PinLifetimeSeconds));
-        Spy.Get<IUserVerificationService>().Reset();
+        SpyRegistry.Get<IUserVerificationService>().Reset();
 
         var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/existing-account-phone-confirmation?{authStateHelper.ToQueryParam()}")

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ExistingAccountPhoneTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ExistingAccountPhoneTests.cs
@@ -2,7 +2,6 @@ using TeacherIdentity.AuthServer.Models;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
 
-[Collection(nameof(DisableParallelization))]  // Depends on mocks
 public class ExistingAccountPhoneTests : TestBase, IAsyncLifetime
 {
     private User? _existingUserAccount;

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/PhoneConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/PhoneConfirmationTests.cs
@@ -5,7 +5,6 @@ using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
 
-[Collection(nameof(DisableParallelization))]  // Depends on mocks and changes the clock
 public class PhoneConfirmationTests : TestBase
 {
     public PhoneConfirmationTests(HostFixture hostFixture)
@@ -197,7 +196,7 @@ public class PhoneConfirmationTests : TestBase
         var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
         var pinResult = await userVerificationService.GenerateSmsPin(mobileNumber);
         Clock.AdvanceBy(TimeSpan.FromHours(1));
-        Spy.Get<IUserVerificationService>().Reset();
+        SpyRegistry.Get<IUserVerificationService>().Reset();
 
         var authStateHelper = await CreateAuthenticationStateHelper(c => c.MobileNumberSet(mobileNumber), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/phone-confirmation?{authStateHelper.ToQueryParam()}")
@@ -227,7 +226,7 @@ public class PhoneConfirmationTests : TestBase
         var userVerificationOptions = HostFixture.Services.GetRequiredService<IOptions<UserVerificationOptions>>();
         var pinResult = await userVerificationService.GenerateSmsPin(mobileNumber);
         Clock.AdvanceBy(TimeSpan.FromHours(2) + TimeSpan.FromSeconds(userVerificationOptions.Value.PinLifetimeSeconds));
-        Spy.Get<IUserVerificationService>().Reset();
+        SpyRegistry.Get<IUserVerificationService>().Reset();
 
         var authStateHelper = await CreateAuthenticationStateHelper(c => c.MobileNumberSet(mobileNumber), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/phone-confirmation?{authStateHelper.ToQueryParam()}")

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/PhoneTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/PhoneTests.cs
@@ -3,7 +3,6 @@ using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
 
-[Collection(nameof(DisableParallelization))]  // Depends on mocks
 public class PhoneTests : TestBase
 {
     public PhoneTests(HostFixture hostFixture)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ResendEmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ResendEmailConfirmationTests.cs
@@ -2,7 +2,6 @@ using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
 
-[Collection(nameof(DisableParallelization))]  // Depends on mocks
 public class ResendEmailConfirmationTests : TestBase
 {
     public ResendEmailConfirmationTests(HostFixture hostFixture)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ResendExistingAccountEmailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ResendExistingAccountEmailTests.cs
@@ -3,7 +3,6 @@ using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
 
-[Collection(nameof(DisableParallelization))]  // Depends on mocks
 public class ResendExistingAccountEmailTests : TestBase, IAsyncLifetime
 {
     private User? _existingUserAccount;

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ResendExistingAccountPhoneTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ResendExistingAccountPhoneTests.cs
@@ -3,7 +3,6 @@ using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
 
-[Collection(nameof(DisableParallelization))]  // Depends on mocks
 public class ResendExistingAccountPhoneTests : TestBase, IAsyncLifetime
 {
     private User? _existingUserAccount;

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ResendPhoneConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ResendPhoneConfirmationTests.cs
@@ -3,7 +3,6 @@ using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
 
-[Collection(nameof(DisableParallelization))]  // Depends on mocks
 public class ResendPhoneConfirmationTests : TestBase
 {
     public ResendPhoneConfirmationTests(HostFixture hostFixture)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/ResendEmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/ResendEmailConfirmationTests.cs
@@ -3,7 +3,6 @@ using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn;
 
-[Collection(nameof(DisableParallelization))]  // Depends on mocks
 public class ResendEmailConfirmationTests : TestBase
 {
     public ResendEmailConfirmationTests(HostFixture hostFixture)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/ResendTrnOwnerEmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/ResendTrnOwnerEmailConfirmationTests.cs
@@ -2,7 +2,6 @@ using TeacherIdentity.AuthServer.Oidc;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn;
 
-[Collection(nameof(DisableParallelization))]  // Depends on mocks
 public class ResendTrnOwnerEmailConfirmationTests : TestBase
 {
     public ResendTrnOwnerEmailConfirmationTests(HostFixture hostFixture)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TestBase.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TestBase.cs
@@ -27,6 +27,8 @@ public abstract partial class TestBase
 
     public HttpClient HttpClient { get; }
 
+    public SpyRegistry SpyRegistry => HostFixture.SpyRegistry;
+
     public TestData TestData => HostFixture.Services.GetRequiredService<TestData>();
 
     public Task<AuthenticationStateHelper> CreateAuthenticationStateHelper(

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/AwardedQtsPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/AwardedQtsPageTests.cs
@@ -2,7 +2,6 @@ using TeacherIdentity.AuthServer.Oidc;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Trn;
 
-[Collection(nameof(DisableParallelization))]  // Relies on mocks
 public class AwardedQtsPageTests : TestBase
 {
     public AwardedQtsPageTests(HostFixture hostFixture)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/DateOfBirthPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/DateOfBirthPageTests.cs
@@ -2,7 +2,6 @@ using TeacherIdentity.AuthServer.Oidc;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Trn;
 
-[Collection(nameof(DisableParallelization))]  // Relies on mocks
 public class DateOfBirthPageTests : TestBase
 {
     public DateOfBirthPageTests(HostFixture hostFixture)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/HasNiNumberPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/HasNiNumberPageTests.cs
@@ -2,7 +2,6 @@ using TeacherIdentity.AuthServer.Oidc;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Trn;
 
-[Collection(nameof(DisableParallelization))]  // Relies on mocks
 public class HasNiNumberPageTests : TestBase
 {
     public HasNiNumberPageTests(HostFixture hostFixture)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/HasTrnPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/HasTrnPageTests.cs
@@ -2,7 +2,6 @@ using TeacherIdentity.AuthServer.Oidc;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Trn;
 
-[Collection(nameof(DisableParallelization))]  // Relies on mocks
 public class HasTrnPageTests : TestBase
 {
     public HasTrnPageTests(HostFixture hostFixture)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/IttProviderTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/IttProviderTests.cs
@@ -4,7 +4,6 @@ using TeacherIdentity.AuthServer.Services.DqtApi;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Trn;
 
-[Collection(nameof(DisableParallelization))]  // Relies on mocks
 public class IttProviderTests : TestBase
 {
     public IttProviderTests(HostFixture hostFixture)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/NiNumberPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/NiNumberPageTests.cs
@@ -2,7 +2,6 @@ using TeacherIdentity.AuthServer.Oidc;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Trn;
 
-[Collection(nameof(DisableParallelization))]  // Relies on mocks
 public class NiNumberPageTests : TestBase
 {
     public NiNumberPageTests(HostFixture hostFixture)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/NoMatchTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/NoMatchTests.cs
@@ -5,7 +5,6 @@ using static TeacherIdentity.AuthServer.Tests.AuthenticationStateHelper;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Trn;
 
-[Collection(nameof(DisableParallelization))]  // Relies on mocks
 public class NoMatchTests : TestBase
 {
     public NoMatchTests(HostFixture hostFixture)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/OfficialNameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/OfficialNameTests.cs
@@ -2,7 +2,6 @@ using TeacherIdentity.AuthServer.Oidc;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Trn;
 
-[Collection(nameof(DisableParallelization))]  // Relies on mocks
 public class OfficialNameTests : TestBase
 {
     public OfficialNameTests(HostFixture hostFixture)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/PreferredNameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/PreferredNameTests.cs
@@ -2,7 +2,6 @@ using TeacherIdentity.AuthServer.Oidc;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Trn;
 
-[Collection(nameof(DisableParallelization))]  // Relies on mocks
 public class PreferredNameTests : TestBase
 {
     public PreferredNameTests(HostFixture hostFixture)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnCallbackTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnCallbackTests.cs
@@ -5,7 +5,6 @@ using TeacherIdentity.AuthServer.Oidc;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn;
 
-[Collection(nameof(DisableParallelization))] // relies on mocks
 public class TrnCallbackTests : TestBase
 {
     public TrnCallbackTests(HostFixture hostFixture)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnInUseTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnInUseTests.cs
@@ -5,7 +5,6 @@ using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn;
 
-[Collection(nameof(DisableParallelization))]  // Relies on mocks and changes the clock
 public class TrnInUseTests : TestBase
 {
     public TrnInUseTests(HostFixture hostFixture)
@@ -272,7 +271,7 @@ public class TrnInUseTests : TestBase
         var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
         var pinResult = await userVerificationService.GenerateEmailPin(existingTrnOwner.EmailAddress);
         Clock.AdvanceBy(TimeSpan.FromHours(1));
-        Spy.Get<IUserVerificationService>().Reset();
+        SpyRegistry.Get<IUserVerificationService>().Reset();
 
         var authStateHelper = await CreateAuthenticationStateHelper(
             c => c.TrnLookupCompletedForExistingTrn(email, existingTrnOwner),
@@ -306,7 +305,7 @@ public class TrnInUseTests : TestBase
         var userVerificationOptions = HostFixture.Services.GetRequiredService<IOptions<UserVerificationOptions>>();
         var pinResult = await userVerificationService.GenerateEmailPin(existingTrnOwner.EmailAddress);
         Clock.AdvanceBy(TimeSpan.FromHours(2) + TimeSpan.FromSeconds(userVerificationOptions.Value.PinLifetimeSeconds));
-        Spy.Get<IUserVerificationService>().Reset();
+        SpyRegistry.Get<IUserVerificationService>().Reset();
 
         var authStateHelper = await CreateAuthenticationStateHelper(
             c => c.TrnLookupCompletedForExistingTrn(email, existingTrnOwner),

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Services/UserVerificationServiceTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Services/UserVerificationServiceTests.cs
@@ -9,7 +9,6 @@ using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
 namespace TeacherIdentity.AuthServer.Tests.Services;
 
-[Collection(nameof(DisableParallelization))]  // Changes the clock
 public class UserVerificationServiceTests : IClassFixture<DbFixture>
 {
     private static readonly TimeSpan _pinLifetime = TimeSpan.FromSeconds(120);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Spy.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Spy.cs
@@ -3,11 +3,11 @@ using Castle.DynamicProxy;
 
 namespace TeacherIdentity.AuthServer.Tests;
 
-public static class Spy
+public class SpyRegistry
 {
-    private static readonly Dictionary<Type, object> _allSpies = new();
+    private readonly Dictionary<Type, object> _allSpies = new();
 
-    public static Spy<T> Get<T>()
+    public Spy<T> Get<T>()
         where T : class
     {
         lock (_allSpies)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/TestScopedServices.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/TestScopedServices.cs
@@ -1,0 +1,42 @@
+using TeacherIdentity.AuthServer.Services.DqtApi;
+using TeacherIdentity.AuthServer.Services.Notification;
+using TeacherIdentity.AuthServer.Services.UserImport;
+using TeacherIdentity.AuthServer.Services.UserVerification;
+using TeacherIdentity.AuthServer.Services.Zendesk;
+
+namespace TeacherIdentity.AuthServer.Tests;
+
+public class TestScopedServices
+{
+    private static readonly AsyncLocal<TestScopedServices> _current = new();
+
+    public TestScopedServices()
+    {
+        Clock = new();
+        DqtApiClient = new();
+        NotificationSender = new();
+        RateLimitStore = new();
+        SpyRegistry = new();
+        UserImportCsvStorageService = new();
+        ZendeskApiWrapper = new();
+
+        DqtApiClient.Setup(mock => mock.FindTeachers(It.IsAny<FindTeachersRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FindTeachersResponse() { Results = Array.Empty<FindTeachersResponseResult>() });
+    }
+
+    public static TestScopedServices Current => _current.Value ??= new();
+
+    public TestClock Clock { get; }
+
+    public Mock<IDqtApiClient> DqtApiClient { get; }
+
+    public Mock<INotificationSender> NotificationSender { get; }
+
+    public Mock<IRateLimitStore> RateLimitStore { get; }
+
+    public SpyRegistry SpyRegistry { get; }
+
+    public Mock<IUserImportStorageService> UserImportCsvStorageService { get; }
+
+    public Mock<IZendeskApiWrapper> ZendeskApiWrapper { get; }
+}


### PR DESCRIPTION
Our tests all share a single `WebApplicationFactory` that's initialized once then re-used for ever more. This is for performance - there's a cost to spinning up a host. 

A knock-on effect of this is that all tests share the same services. This is generally fine but for 'mutable' services like mocks this is problematic; it's possible that multiple tests reconfigure the same mock concurrently and that leads to flaky tests. Up until now we've dealt with this by putting tests that configure mocks into a test collection that disables parallelisation. This works but is not ideal; one has to remember to add this annotation plus we lose the speed benefits of running tests in parallel.

This change moves mutable services into an `AsyncLocal` which effectively means we get a new service instance per test. With that we can remove the test collection annotation and safely run tests in parallel.