### PR TITLE
Add Account landing page

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Oidc/TeacherIdentityApplicationManager.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Oidc/TeacherIdentityApplicationManager.cs
@@ -52,18 +52,16 @@ public partial class TeacherIdentityApplicationManager : OpenIddictApplicationMa
         {
             var authority = new Uri(uri).GetLeftPart(UriPartial.Authority);
 
+            if (authority.Equals(addressAuthority))
+            {
+                return true;
+            }
+
             if (WildcardPathSegmentPattern().IsMatch(authority))
             {
                 var pattern = $"^{Regex.Escape(authority).Replace("__", ".*")}$";
 
                 if (Regex.IsMatch(addressAuthority, pattern))
-                {
-                    return true;
-                }
-            }
-            else
-            {
-                if (authority.Equals(addressAuthority))
                 {
                     return true;
                 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
@@ -1,0 +1,84 @@
+@page "/account"
+@model TeacherIdentity.AuthServer.Pages.Account.IndexModel
+@{
+    ViewBag.Title = "DfE Identity account";
+}
+
+@section BeforeContent
+{
+    @if (Model.SafeRedirectUri is not null)
+    {
+        <div class="gai-banner-bar">
+            <govuk-back-link href="@Model.SafeRedirectUri" data-testid="BackLink">
+                Back
+                @if (Model.ClientDisplayName is not null)
+                {
+                    <text>to @Model.ClientDisplayName</text>
+                }
+            </govuk-back-link>
+        </div>
+    }
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <span class="govuk-caption-xl">DfE Identity account</span>
+        <h1 class="govuk-heading-xl">Your details</h1>
+
+        <h3 class="govuk-heading-m">Personal details</h3>
+        <govuk-summary-list>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value>@Model.Name</govuk-summary-list-row-value>
+                <govuk-summary-list-row-actions>
+                    <govuk-summary-list-row-action href="#" visually-hidden-text="name">Change</govuk-summary-list-row-action>
+                </govuk-summary-list-row-actions>
+            </govuk-summary-list-row>
+            @if (Model.HasTrn)
+            {
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Official name</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>
+                        @Model.OfficialName
+                        <p class="govuk-hint govuk-!-font-size-14">Displayed on teaching certificates </p>
+                    </govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="#" visually-hidden-text="official name">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+            }
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value>@Model.DateOfBirth?.ToString("dd MMMM yyyy")</govuk-summary-list-row-value>
+                <govuk-summary-list-row-actions>
+                    <govuk-summary-list-row-action href="#" visually-hidden-text="date of birth">Change</govuk-summary-list-row-action>
+                </govuk-summary-list-row-actions>
+            </govuk-summary-list-row>
+        </govuk-summary-list>
+
+        <h3 class="govuk-heading-m">Sign in details</h3>
+        <govuk-summary-list>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Email</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value>@Model.Email</govuk-summary-list-row-value>
+                <govuk-summary-list-row-actions>
+                    <govuk-summary-list-row-action href="#" visually-hidden-text="email">Change</govuk-summary-list-row-action>
+                </govuk-summary-list-row-actions>
+            </govuk-summary-list-row>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Mobile number</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value>@Model.MobileNumber</govuk-summary-list-row-value>
+                <govuk-summary-list-row-actions>
+                    <govuk-summary-list-row-action href="#" visually-hidden-text="mobile number">Change</govuk-summary-list-row-action>
+                </govuk-summary-list-row-actions>
+            </govuk-summary-list-row>
+        </govuk-summary-list>
+
+        @if (Model.SafeRedirectUri is not null && Model.ClientDisplayName is not null)
+        {
+            <govuk-button-link href="@Model.SafeRedirectUri" data-testid="BackButton">
+                Back to @Model.ClientDisplayName
+            </govuk-button-link>
+        }
+    </div>
+</div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
@@ -6,15 +6,11 @@
 
 @section BeforeContent
 {
-    @if (Model.SafeRedirectUri is not null)
+    @if (Model.SafeRedirectUri is not null && Model.ClientDisplayName is not null)
     {
         <div class="gai-banner-bar">
             <govuk-back-link href="@Model.SafeRedirectUri" data-testid="BackLink">
-                Back
-                @if (Model.ClientDisplayName is not null)
-                {
-                    <text>to @Model.ClientDisplayName</text>
-                }
+                Back to @Model.ClientDisplayName
             </govuk-back-link>
         </div>
     }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml.cs
@@ -1,0 +1,114 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Oidc;
+using TeacherIdentity.AuthServer.Services.DqtApi;
+
+namespace TeacherIdentity.AuthServer.Pages.Account;
+
+public class IndexModel : PageModel
+{
+    private readonly TeacherIdentityServerDbContext _dbContext;
+    private readonly IDqtApiClient _dqtApiClient;
+    private readonly TeacherIdentityApplicationManager _applicationManager;
+
+    public IndexModel(
+        TeacherIdentityServerDbContext dbContext,
+        IDqtApiClient dqtApiClient,
+        TeacherIdentityApplicationManager applicationManager)
+    {
+        _dbContext = dbContext;
+        _dqtApiClient = dqtApiClient;
+        _applicationManager = applicationManager;
+    }
+
+    [FromQuery(Name = "client_id")]
+    public string? ClientId { get; set; }
+
+    [FromQuery(Name = "redirect_uri")]
+    public string? RedirectUri { get; set; }
+
+    public string? ClientDisplayName { get; set; }
+    public string? SafeRedirectUri { get; set; }
+
+    public string? Name { get; set; }
+    public string? OfficialName { get; set; }
+    public DateOnly? DateOfBirth { get; set; }
+    public string? Email { get; set; }
+    public string? MobileNumber { get; set; }
+    public bool HasTrn { get; set; }
+
+    public async Task OnGet()
+    {
+        var userId = User.GetUserId()!.Value;
+
+        var user = await _dbContext.Users
+            .Where(u => u.UserId == userId)
+            .Select(u => new
+            {
+                u.FirstName,
+                u.LastName,
+                u.DateOfBirth,
+                u.EmailAddress,
+                u.MobileNumber,
+                u.Trn
+            })
+            .SingleAsync();
+
+        Name = $"{user.FirstName} {user.LastName}";
+        DateOfBirth = user.DateOfBirth;
+        Email = user.EmailAddress;
+        MobileNumber = user.MobileNumber;
+        HasTrn = user.Trn is not null;
+
+        if (HasTrn)
+        {
+            var dqtUser = await _dqtApiClient.GetTeacherByTrn(user.Trn!) ??
+                throw new Exception($"User with TRN '{user.Trn}' cannot be found in DQT.");
+
+            OfficialName = $"{dqtUser.FirstName} {dqtUser.LastName}";
+        }
+    }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        // Services link to this page from the 'Account' option in their nav.
+        // They pass a `redirect_uri` query parameter along with their `client_id` so we know where to send the user
+        // back to when they're done.
+        // Check that the `redirect_uri` provided is valid for the specified client.
+        //
+        // Alternatively, if there's no `client_id` but there is a `redirect_uri` then require that it's a local URL.
+
+        if (ClientId is not null && RedirectUri != null)
+        {
+            var client = await _applicationManager.FindByClientIdAsync(ClientId);
+
+            if (client is null || !await _applicationManager.ValidateRedirectUriDomain(client, RedirectUri))
+            {
+                context.Result = OnInvalidParameters();
+            }
+            else
+            {
+                SafeRedirectUri = RedirectUri;
+                ClientDisplayName = client.DisplayName;
+            }
+        }
+        else if (!string.IsNullOrEmpty(RedirectUri))
+        {
+            if (Url.IsLocalUrl(RedirectUri))
+            {
+                SafeRedirectUri = RedirectUri;
+            }
+            else
+            {
+                context.Result = OnInvalidParameters();
+            }
+        }
+
+        await base.OnPageHandlerExecutionAsync(context, next);
+
+        IActionResult OnInvalidParameters() => BadRequest();
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
@@ -293,6 +293,13 @@ public class Program
                 {
                     model.Filters.Add(new AuthorizeFilter(AuthorizationPolicies.Authenticated));
                 });
+
+            options.Conventions.AddFolderApplicationModelConvention(
+                "/Account",
+                model =>
+                {
+                    model.Filters.Add(new AuthorizeFilter(AuthorizationPolicies.Authenticated));
+                });
         });
 
         builder.Services.AddSession(options =>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/wwwroot/Styles/site.scss
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/wwwroot/Styles/site.scss
@@ -158,3 +158,7 @@ $app-button-inverse-hover-background-colour: govuk-tint($app-button-inverse-fore
   border-bottom: 0 !important;
 }
 
+.gai-banner-bar {
+  padding-left: 5px;
+  background-color: #F3F2F1;
+}

--- a/dotnet-authserver/src/TeacherIdentity.TestClient/Views/Shared/_Layout.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.TestClient/Views/Shared/_Layout.cshtml
@@ -1,3 +1,8 @@
+@using Microsoft.AspNetCore.Http.Extensions;
+@inject IConfiguration Configuration
+@{
+    var accountLink = $"{Configuration["SignInAuthority"]}/account?client_id={Uri.EscapeDataString(Configuration["ClientId"]!)}&redirect_uri={Uri.EscapeDataString(Context.Request.GetEncodedUrl())}";
+}
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">
 
@@ -50,7 +55,12 @@
             <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide menu" hidden>Menu</button>
 
             <ul id="navigation" class="govuk-header__navigation-list">
-              <li class="govuk-header__navigation-item govuk-header__navigation-item--active">
+                <li class="govuk-header__navigation-item">
+                  <a class="govuk-header__link" href="@accountLink">
+                      Account
+                  </a>
+                </li>
+              <li class="govuk-header__navigation-item">
                 <a class="govuk-header__link" asp-controller="Home" asp-action="SignOut">
                   Sign out
                 </a>

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/IndexTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/IndexTests.cs
@@ -1,0 +1,157 @@
+using TeacherIdentity.AuthServer.Services.DqtApi;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Account;
+
+public class IndexTests : TestBase
+{
+    public IndexTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_UnknownClientId_ReturnsBadRequest()
+    {
+        // Arrange
+        var user = await TestData.CreateUser();
+        HostFixture.SetUserId(user.UserId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/account?client_id=not_a_real_client_id&redirect_uri={{Uri.EscapeDataString(\"https://google.com\")");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_InvalidRedirectUriDomain_ReturnsBadRequest()
+    {
+        // Arrange
+        var user = await TestData.CreateUser();
+        HostFixture.SetUserId(user.UserId);
+
+        var client = TestClients.Client1;
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/account?client_id={client.ClientId}&redirect_uri={Uri.EscapeDataString("https://google.com")}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_ReturnsUserDetails()
+    {
+        // Arrange
+        var user = await TestData.CreateUser();
+        HostFixture.SetUserId(user.UserId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/account");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await response.GetDocument();
+
+        Assert.Equal($"{user.FirstName} {user.LastName}", doc.GetSummaryListValueForKey("Name"));
+        Assert.Equal($"{user.DateOfBirth:dd MMMM yyyy}", doc.GetSummaryListValueForKey("Date of birth"));
+        Assert.Equal(user.EmailAddress, doc.GetSummaryListValueForKey("Email"));
+        Assert.Equal(user.MobileNumber, doc.GetSummaryListValueForKey("Mobile number"));
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestForUserWithoutTrn_DoesNotShowOfficialNameRow()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(hasTrn: false);
+        HostFixture.SetUserId(user.UserId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/account");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await response.GetDocument();
+
+        Assert.Null(doc.GetSummaryListRowForKey("Official name"));
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestForUserWithTrn_DoesShowOfficialNameRow()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(hasTrn: true);
+        HostFixture.SetUserId(user.UserId);
+
+        var officialFirstName = Faker.Name.First();
+        var officialLastName = Faker.Name.Last();
+
+        HostFixture.DqtApiClient
+            .Setup(mock => mock.GetTeacherByTrn(user.Trn!, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TeacherInfo()
+            {
+                DateOfBirth = user.DateOfBirth!.Value,
+                FirstName = officialFirstName,
+                LastName = officialLastName,
+                NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber(),
+                Trn = user.Trn!
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/account");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await response.GetDocument();
+
+        Assert.Equal(
+            $"{officialFirstName} {officialLastName}",
+            doc.GetSummaryListValueForKey("Official name")?.Replace("Displayed on teaching certificates", "").Trim());
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithClientIdAndRedirectUri_RendersBackLinks()
+    {
+        // Arrange
+        var user = await TestData.CreateUser();
+        HostFixture.SetUserId(user.UserId);
+
+        var client = TestClients.Client1;
+        var redirectUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/account?client_id={client.ClientId}&redirect_uri={Uri.EscapeDataString(redirectUri)}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await response.GetDocument();
+
+        Assert.NotNull(doc.GetElementByTestId("BackLink"));
+        Assert.NotNull(doc.GetElementByTestId("BackButton"));
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithoutRedirectUri_DoesNotRenderBackLinks()
+    {
+        // Arrange
+        var user = await TestData.CreateUser();
+        HostFixture.SetUserId(user.UserId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/account");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await response.GetDocument();
+
+        Assert.Null(doc.GetElementByTestId("BackLink"));
+        Assert.Null(doc.GetElementByTestId("BackButton"));
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/TestBase.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/TestBase.cs
@@ -1,0 +1,30 @@
+using TeacherIdentity.AuthServer.Tests.Infrastructure;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Account;
+
+public partial class TestBase
+{
+    protected TestBase(HostFixture hostFixture)
+    {
+        HostFixture = hostFixture;
+        HostFixture.SetUserId(TestUsers.DefaultUser.UserId);
+
+        HttpClient = HostFixture.CreateClient(new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions()
+        {
+            AllowAutoRedirect = false
+        });
+
+        HostFixture.ResetMocks();
+        HostFixture.InitEventObserver();
+    }
+
+    public TestClock Clock => (TestClock)HostFixture.Services.GetRequiredService<IClock>();
+
+    public CaptureEventObserver EventObserver => HostFixture.EventObserver;
+
+    public HostFixture HostFixture { get; }
+
+    public TestData TestData => HostFixture.Services.GetRequiredService<TestData>();
+
+    public HttpClient HttpClient { get; }
+}


### PR DESCRIPTION
Identity needs an Account page that services can link to that enables a user to change their details.

This change adds the initial Account landing page that shows the user's ID and DQT details. Pages to actually update details will follow separately.

Since we need to be able to go 'back' to the calling service, we support passing in `client_id` and `redirect_uri` parameters, much like the OAuth authorization endpoint. We can be fairly permissive around checking `redirect_uri`; if the domain of the parameter matches the domain name of a redirect URI we have registered for that client then we're happy.