### PR TITLE
Enforce correct page order in register journey

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -127,6 +127,7 @@ public class AuthenticationState
     public bool PreferredNameSet => HasPreferredName.HasValue;
     public bool OfficialNameSet => OfficialFirstName is not null && OfficialLastName is not null;
     public bool DateOfBirthSet => DateOfBirth.HasValue;
+    public bool ExistingAccountFound => ExistingAccountUserId.HasValue;
     public bool HasNationalInsuranceNumberSet => HasNationalInsuranceNumber.HasValue;
     public bool NationalInsuranceNumberSet => NationalInsuranceNumber is not null;
     public bool AwardedQtsSet => AwardedQts.HasValue;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/AccountExists.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/AccountExists.cshtml.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 using TeacherIdentity.AuthServer.Helpers;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Services.UserVerification;
@@ -90,5 +91,15 @@ public class AccountExists : BaseExistingEmailPageModel
         await DbContext.SaveChangesAsync();
 
         return user;
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var authenticationState = context.HttpContext.GetAuthenticationState();
+
+        if (!authenticationState.ExistingAccountFound)
+        {
+            context.Result = new RedirectResult(LinkGenerator.RegisterDateOfBirth());
+        }
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/DateOfBirthPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/DateOfBirthPage.cshtml.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeacherIdentity.AuthServer.Helpers;
 using TeacherIdentity.AuthServer.Models;
@@ -93,5 +94,15 @@ public class DateOfBirthPage : PageModel
         await _dbContext.SaveChangesAsync();
 
         return user;
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var authenticationState = context.HttpContext.GetAuthenticationState();
+
+        if (!authenticationState.PreferredNameSet)
+        {
+            context.Result = new RedirectResult(_linkGenerator.RegisterName());
+        }
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/EmailExists.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/EmailExists.cshtml.cs
@@ -1,11 +1,28 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeacherIdentity.AuthServer.State;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
 
 [AllowCompletedAuthenticationJourney]
-[RequireAuthenticationMilestone(AuthenticationState.AuthenticationMilestone.Complete)]
 public class EmailExists : PageModel
 {
+    private IIdentityLinkGenerator _linkGenerator;
+
+    public EmailExists(IIdentityLinkGenerator linkGenerator)
+    {
+        _linkGenerator = linkGenerator;
+    }
     public string? Email => HttpContext.GetAuthenticationState().EmailAddress;
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var authenticationState = context.HttpContext.GetAuthenticationState();
+
+        if (!authenticationState.IsComplete())
+        {
+            context.Result = new RedirectResult(_linkGenerator.RegisterEmailConfirmation());
+        }
+    }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ExistingAccountEmailConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ExistingAccountEmailConfirmation.cshtml.cs
@@ -63,7 +63,7 @@ public class ExistingAccountEmailConfirmation : BaseEmailConfirmationPageModel
     {
         var authenticationState = HttpContext.GetAuthenticationState();
 
-        if (HttpContext.GetAuthenticationState().ExistingAccountChosen != true)
+        if (authenticationState.ExistingAccountChosen != true)
         {
             context.Result = new RedirectResult(_linkGenerator.RegisterAccountExists());
             return;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ExistingAccountPhone.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ExistingAccountPhone.cshtml.cs
@@ -39,10 +39,15 @@ public class ExistingAccountPhone : BaseExistingPhonePageModel
     {
         var authenticationState = context.HttpContext.GetAuthenticationState();
 
-        if (authenticationState.ExistingAccountMobileNumber is null ||
-            authenticationState.ExistingAccountChosen != true)
+        if (authenticationState.ExistingAccountChosen != true)
         {
-            context.Result = new RedirectResult(_linkGenerator.RegisterAccountExists());
+            context.Result = Redirect(_linkGenerator.RegisterAccountExists());
+            return;
+        }
+
+        if (authenticationState.ExistingAccountMobileNumber is null)
+        {
+            context.Result = Redirect(_linkGenerator.RegisterExistingAccountEmailConfirmation());
         }
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ExistingAccountPhoneConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ExistingAccountPhoneConfirmation.cshtml.cs
@@ -63,9 +63,15 @@ public class ExistingAccountPhoneConfirmation : BasePhoneConfirmationPageModel
     {
         var authenticationState = context.HttpContext.GetAuthenticationState();
 
-        if (MobileNumber is null || authenticationState.ExistingAccountChosen != true)
+        if (authenticationState.ExistingAccountChosen != true)
         {
-            context.Result = new RedirectResult(_linkGenerator.RegisterAccountExists());
+            context.Result = Redirect(_linkGenerator.RegisterAccountExists());
+            return;
+        }
+
+        if (authenticationState.ExistingAccountMobileNumber is null)
+        {
+            context.Result = Redirect(_linkGenerator.RegisterExistingAccountEmailConfirmation());
             return;
         }
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Name.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Name.cshtml.cs
@@ -1,12 +1,11 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
-using static TeacherIdentity.AuthServer.AuthenticationState;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
 
 [BindProperties]
-[RequireAuthenticationMilestone(AuthenticationMilestone.EmailVerified)]
 public class Name : PageModel
 {
     private IIdentityLinkGenerator _linkGenerator;
@@ -40,5 +39,15 @@ public class Name : PageModel
         HttpContext.GetAuthenticationState().OnNameSet(FirstName!, LastName!);
 
         return Redirect(_linkGenerator.RegisterDateOfBirth());
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var authenticationState = context.HttpContext.GetAuthenticationState();
+
+        if (!authenticationState.MobileNumberVerified)
+        {
+            context.Result = new RedirectResult(_linkGenerator.RegisterPhoneConfirmation());
+        }
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Phone.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Phone.cshtml.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
@@ -36,5 +37,15 @@ public class Phone : BasePhonePageModel
         HttpContext.GetAuthenticationState().OnMobileNumberSet(MobileNumber!);
 
         return Redirect(_linkGenerator.RegisterPhoneConfirmation());
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var authenticationState = context.HttpContext.GetAuthenticationState();
+
+        if (!authenticationState.EmailAddressVerified)
+        {
+            context.Result = new RedirectResult(_linkGenerator.RegisterEmailConfirmation());
+        }
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/PhoneExists.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/PhoneExists.cshtml.cs
@@ -1,11 +1,29 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeacherIdentity.AuthServer.State;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
 
 [AllowCompletedAuthenticationJourney]
-[RequireAuthenticationMilestone(AuthenticationState.AuthenticationMilestone.Complete)]
 public class PhoneExists : PageModel
 {
+    private IIdentityLinkGenerator _linkGenerator;
+
+    public PhoneExists(IIdentityLinkGenerator linkGenerator)
+    {
+        _linkGenerator = linkGenerator;
+    }
+
     public string? MobileNumber => HttpContext.GetAuthenticationState().MobileNumber;
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var authenticationState = context.HttpContext.GetAuthenticationState();
+
+        if (!authenticationState.IsComplete())
+        {
+            context.Result = new RedirectResult(_linkGenerator.RegisterPhoneConfirmation());
+        }
+    }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendExistingAccountEmail.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendExistingAccountEmail.cshtml.cs
@@ -34,9 +34,11 @@ public class ResendExistingAccountEmail : BaseExistingEmailPageModel
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (HttpContext.GetAuthenticationState().ExistingAccountChosen != true)
+        var authenticationState = context.HttpContext.GetAuthenticationState();
+
+        if (authenticationState.ExistingAccountChosen != true)
         {
-            context.Result = new RedirectResult(LinkGenerator.RegisterAccountExists());
+            context.Result = Redirect(LinkGenerator.RegisterAccountExists());
         }
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendExistingAccountPhone.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendExistingAccountPhone.cshtml.cs
@@ -39,10 +39,15 @@ public class ResendExistingAccountPhone : BaseExistingPhonePageModel
     {
         var authenticationState = context.HttpContext.GetAuthenticationState();
 
-        if (authenticationState.ExistingAccountMobileNumber is null ||
-            authenticationState.ExistingAccountChosen != true)
+        if (authenticationState.ExistingAccountChosen != true)
         {
-            context.Result = new RedirectResult(_linkGenerator.RegisterAccountExists());
+            context.Result = Redirect(_linkGenerator.RegisterAccountExists());
+            return;
+        }
+
+        if (authenticationState.ExistingAccountMobileNumber is null)
+        {
+            context.Result = Redirect(_linkGenerator.RegisterExistingAccountEmailConfirmation());
         }
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
@@ -8,6 +8,8 @@ using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
 namespace TeacherIdentity.AuthServer.Tests;
 
+public delegate Func<AuthenticationState, Task> AuthenticationStateConfiguration(AuthenticationStateHelper.Configure config);
+
 public sealed class AuthenticationStateHelper
 {
     private readonly Guid _journeyId;
@@ -25,7 +27,7 @@ public sealed class AuthenticationStateHelper
     }
 
     public static async Task<AuthenticationStateHelper> Create(
-        Func<Configure, Func<AuthenticationState, Task>> configureAuthenticationState,
+        AuthenticationStateConfiguration configureAuthenticationState,
         HostFixture hostFixture,
         string? additionalScopes,
         TeacherIdentityApplicationDescriptor? client)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/AccountExistsTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/AccountExistsTests.cs
@@ -24,7 +24,13 @@ public class AccountExistsTests : TestBase
     [Fact]
     public async Task Get_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, additionalScopes: null, HttpMethod.Get, "/sign-in/register/account-exists");
+        await JourneyHasExpired_RendersErrorPage(_currentPageAuthenticationState(), additionalScopes: null, HttpMethod.Get, "/sign-in/register/account-exists");
+    }
+
+    [Fact]
+    public async Task Get_NullExistingAccountFound_RedirectsToDateOfBirth()
+    {
+        await GivenAuthenticationState_RedirectsTo(_previousPageAuthenticationState(), HttpMethod.Get, "/sign-in/register/account-exists", "/sign-in/register/date-of-birth");
     }
 
     [Fact]
@@ -60,14 +66,20 @@ public class AccountExistsTests : TestBase
     [Fact]
     public async Task Post_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, additionalScopes: null, HttpMethod.Post, "/sign-in/register/account-exists");
+        await JourneyHasExpired_RendersErrorPage(_currentPageAuthenticationState(), additionalScopes: null, HttpMethod.Post, "/sign-in/register/account-exists");
+    }
+
+    [Fact]
+    public async Task Post_NullExistingAccountFound_RedirectsToDateOfBirth()
+    {
+        await GivenAuthenticationState_RedirectsTo(_previousPageAuthenticationState(), HttpMethod.Post, "/sign-in/register/account-exists", "/sign-in/register/date-of-birth");
     }
 
     [Fact]
     public async Task Post_NullIsUserAccount_ReturnsError()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/account-exists?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -84,7 +96,7 @@ public class AccountExistsTests : TestBase
     public async Task Post_IsUserAccountTrue_DoesNotCreateNewUser()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/account-exists?{authStateHelper.ToQueryParam()}")
         {
@@ -111,7 +123,7 @@ public class AccountExistsTests : TestBase
     public async Task Post_IsUserAccountFalse_CreatesNewUserAndRedirects()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/account-exists?{authStateHelper.ToQueryParam()}")
         {
@@ -135,6 +147,6 @@ public class AccountExistsTests : TestBase
         });
     }
 
-    private Func<AuthenticationState, Task> ConfigureValidAuthenticationState(AuthenticationStateHelper.Configure configure) =>
-        configure.RegisterExistingUserAccountMatch();
+    private readonly AuthenticationStateConfigGenerator _currentPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.AccountExists);
+    private readonly AuthenticationStateConfigGenerator _previousPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.DateOfBirth);
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/DateOfBirthPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/DateOfBirthPageTests.cs
@@ -30,13 +30,19 @@ public class DateOfBirthPageTests : TestBase
     [Fact]
     public async Task Get_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, additionalScopes: null, HttpMethod.Get, "/sign-in/register/date-of-birth");
+        await JourneyHasExpired_RendersErrorPage(_currentPageAuthenticationState(), additionalScopes: null, HttpMethod.Get, "/sign-in/register/date-of-birth");
+    }
+
+    [Fact]
+    public async Task Get_NameNotSet_RedirectsToNamePage()
+    {
+        await GivenAuthenticationState_RedirectsTo(_previousPageAuthenticationState(), HttpMethod.Get, "/sign-in/register/date-of-birth", "/sign-in/register/name");
     }
 
     [Fact]
     public async Task Get_ValidRequest_RendersContent()
     {
-        await ValidRequest_RendersContent(ConfigureValidAuthenticationState, "/sign-in/register/date-of-birth", additionalScopes: null);
+        await ValidRequest_RendersContent(_currentPageAuthenticationState(), "/sign-in/register/date-of-birth", additionalScopes: null);
     }
 
     [Fact]
@@ -60,14 +66,20 @@ public class DateOfBirthPageTests : TestBase
     [Fact]
     public async Task Post_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, additionalScopes: null, HttpMethod.Post, "/sign-in/register/date-of-birth");
+        await JourneyHasExpired_RendersErrorPage(_currentPageAuthenticationState(), additionalScopes: null, HttpMethod.Post, "/sign-in/register/date-of-birth");
+    }
+
+    [Fact]
+    public async Task Post_NameNotSet_RedirectsToNamePage()
+    {
+        await GivenAuthenticationState_RedirectsTo(_previousPageAuthenticationState(), HttpMethod.Post, "/sign-in/register/date-of-birth", "/sign-in/register/name");
     }
 
     [Fact]
     public async Task Post_NullDateOfBirth_ReturnsError()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/date-of-birth?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -86,7 +98,7 @@ public class DateOfBirthPageTests : TestBase
         // Arrange
         var dateOfBirth = new DateOnly(2100, 1, 1);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/date-of-birth?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -110,7 +122,7 @@ public class DateOfBirthPageTests : TestBase
         // Arrange
         var dateOfBirth = new DateOnly(2000, 1, 1);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/date-of-birth?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -199,6 +211,6 @@ public class DateOfBirthPageTests : TestBase
         Assert.Equal(user.UserId, authStateHelper.AuthenticationState.ExistingAccountUserId);
     }
 
-    private Func<AuthenticationState, Task> ConfigureValidAuthenticationState(AuthenticationStateHelper.Configure configure) =>
-        configure.RegisterNameSet();
+    private readonly AuthenticationStateConfigGenerator _currentPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.DateOfBirth);
+    private readonly AuthenticationStateConfigGenerator _previousPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.Name);
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailConfirmationTests.cs
@@ -34,29 +34,20 @@ public class EmailConfirmationTests : TestBase
     [Fact]
     public async Task Get_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(c => c.EmailSet(), additionalScopes: null, HttpMethod.Get, "/sign-in/register/email-confirmation");
+        await JourneyHasExpired_RendersErrorPage(_currentPageAuthenticationState(), additionalScopes: null, HttpMethod.Get, "/sign-in/register/email-confirmation");
     }
 
     [Fact]
     public async Task Get_EmailNotSet_RedirectsToEmailPage()
     {
-        // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null);
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/email-confirmation?{authStateHelper.ToQueryParam()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Act
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith("/sign-in/register/email", response.Headers.Location?.OriginalString);
+        await GivenAuthenticationState_RedirectsTo(_previousPageAuthenticationState(), HttpMethod.Get, "/sign-in/register/email-confirmation", "/sign-in/register/email");
     }
 
     [Fact]
     public async Task Get_ValidRequest_RendersExpectedContent()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(), additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/email-confirmation?{authStateHelper.ToQueryParam()}");
 
         // Act
@@ -90,7 +81,13 @@ public class EmailConfirmationTests : TestBase
     [Fact]
     public async Task Post_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(c => c.EmailSet(), additionalScopes: null, HttpMethod.Post, "/sign-in/register/email-confirmation");
+        await JourneyHasExpired_RendersErrorPage(_currentPageAuthenticationState(), additionalScopes: null, HttpMethod.Post, "/sign-in/register/email-confirmation");
+    }
+
+    [Fact]
+    public async Task Post_EmailNotSet_RedirectsToEmailPage()
+    {
+        await GivenAuthenticationState_RedirectsTo(_previousPageAuthenticationState(), HttpMethod.Post, "/sign-in/register/email-confirmation", "/sign-in/register/email");
     }
 
     [Fact]
@@ -352,4 +349,7 @@ public class EmailConfirmationTests : TestBase
         // Assert
         Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
     }
+
+    private readonly AuthenticationStateConfigGenerator _currentPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.EmailConfirmation);
+    private readonly AuthenticationStateConfigGenerator _previousPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.Email);
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailExistsTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailExistsTests.cs
@@ -23,7 +23,13 @@ public class EmailExistsTests : TestBase
     public async Task Get_JourneyHasExpired_RendersErrorPage()
     {
         var user = await TestData.CreateUser();
-        await JourneyHasExpired_RendersErrorPage(c => c.Completed(user), additionalScopes: null, HttpMethod.Get, "/sign-in/register/email-exists");
+        await JourneyHasExpired_RendersErrorPage(_currentPageAuthenticationState(user), additionalScopes: null, HttpMethod.Get, "/sign-in/register/email-exists");
+    }
+
+    [Fact]
+    public async Task Get_UserNotSignedIn_RedirectsToEmailConfirmation()
+    {
+        await GivenAuthenticationState_RedirectsTo(_previousPageAuthenticationState(), HttpMethod.Get, "/sign-in/register/email-exists", "/sign-in/register/email-confirmation");
     }
 
     [Fact]
@@ -36,6 +42,15 @@ public class EmailExistsTests : TestBase
     public async Task Get_ValidRequest_RendersContent()
     {
         var user = await TestData.CreateUser();
-        await ValidRequest_RendersContent(c => c.Completed(user), "/sign-in/register/email-exists", additionalScopes: null);
+        await ValidRequest_RendersContent(_currentPageAuthenticationState(user), "/sign-in/register/email-exists", additionalScopes: null);
     }
+
+    [Fact]
+    public async Task Post_UserNotSignedIn_RedirectsToEmailConfirmation()
+    {
+        await GivenAuthenticationState_RedirectsTo(_previousPageAuthenticationState(), HttpMethod.Post, "/sign-in/register/email-exists", "/sign-in/register/email-confirmation");
+    }
+
+    private readonly AuthenticationStateConfigGenerator _currentPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.EmailExists);
+    private readonly AuthenticationStateConfigGenerator _previousPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.EmailConfirmation);
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailTests.cs
@@ -31,13 +31,13 @@ public class EmailTests : TestBase
     [Fact]
     public async Task Get_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(c => c.Start(), additionalScopes: null, HttpMethod.Get, "/sign-in/register/email");
+        await JourneyHasExpired_RendersErrorPage(_currentPageAuthenticationState(), additionalScopes: null, HttpMethod.Get, "/sign-in/register/email");
     }
 
     [Fact]
     public async Task Get_ValidRequest_RendersContent()
     {
-        await ValidRequest_RendersContent(c => c.Start(), "/sign-in/register/email", additionalScopes: null);
+        await ValidRequest_RendersContent(_currentPageAuthenticationState(), "/sign-in/register/email", additionalScopes: null);
     }
 
     [Fact]
@@ -61,14 +61,14 @@ public class EmailTests : TestBase
     [Fact]
     public async Task Post_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(c => c.Start(), additionalScopes: null, HttpMethod.Post, "/sign-in/register/email");
+        await JourneyHasExpired_RendersErrorPage(_currentPageAuthenticationState(), additionalScopes: null, HttpMethod.Post, "/sign-in/register/email");
     }
 
     [Fact]
     public async Task Post_ValidEmailWithBlockedClient_ReturnsTooManyRequestsStatusCode()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
         var email = Faker.Internet.Email();
 
         HostFixture.RateLimitStore.Setup(x => x.IsClientIpBlockedForPinGeneration(TestRequestClientIpProvider.ClientIpAddress)).ReturnsAsync(true);
@@ -93,7 +93,7 @@ public class EmailTests : TestBase
     public async Task Post_EmptyEmail_ReturnsError()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -110,7 +110,7 @@ public class EmailTests : TestBase
     public async Task Post_InvalidEmail_ReturnsError()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -132,7 +132,7 @@ public class EmailTests : TestBase
     public async Task Post_ValidEmail_SetsEmailOnAuthenticationStateGeneratesPinAndRedirectsToRegisterEmailConfirmation(bool emailIsKnown)
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
         var email = Faker.Internet.Email();
 
         if (emailIsKnown)
@@ -166,7 +166,7 @@ public class EmailTests : TestBase
     public async Task Post_EmailWithInvalidPrefix_ReturnsError(string emailPrefix)
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -189,7 +189,7 @@ public class EmailTests : TestBase
         var invalidPrefix = "headteacher";
         var user = await TestData.CreateUser(email: TestData.GenerateUniqueEmail(invalidPrefix));
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -222,7 +222,7 @@ public class EmailTests : TestBase
             await dbContext.SaveChangesAsync();
         });
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -257,7 +257,7 @@ public class EmailTests : TestBase
 
         var user = await TestData.CreateUser(email: $"john.doe12@{invalidEmailSuffix}");
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -281,7 +281,7 @@ public class EmailTests : TestBase
             .Setup(mock => mock.SendEmail(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
             .Throws(new Exception("ValidationError"));
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
         var email = Faker.Internet.Email();
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/email?{authStateHelper.ToQueryParam()}")
@@ -298,4 +298,6 @@ public class EmailTests : TestBase
         // Assert
         await AssertEx.HtmlResponseHasError(response, "Email", "Enter a valid email address");
     }
+
+    private readonly AuthenticationStateConfigGenerator _currentPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.Email);
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ExistingAccountEmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ExistingAccountEmailConfirmationTests.cs
@@ -48,29 +48,20 @@ public class ExistingAccountEmailConfirmationTests : TestBase, IAsyncLifetime
     [Fact]
     public async Task Get_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, additionalScopes: null, HttpMethod.Get, "/sign-in/register/existing-account-email-confirmation");
+        await JourneyHasExpired_RendersErrorPage(_currentPageAuthenticationState(_existingUserAccount), additionalScopes: null, HttpMethod.Get, "/sign-in/register/existing-account-email-confirmation");
     }
 
     [Fact]
-    public async Task Get_ExistingAccountChosenNotSet_RedirectsToCheckAccount()
+    public async Task Get_AccountNotConfirmed_RedirectsToAccountExists()
     {
-        // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.RegisterExistingUserAccountMatch(), additionalScopes: null);
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/existing-account-email-confirmation?{authStateHelper.ToQueryParam()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Act
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith("/sign-in/register/account-exists", response.Headers.Location?.OriginalString);
+        await GivenAuthenticationState_RedirectsTo(_previousPageAuthenticationState(_existingUserAccount), HttpMethod.Get, "/sign-in/register/existing-account-email-confirmation", "/sign-in/register/account-exists");
     }
 
     [Fact]
     public async Task Get_ValidRequest_RendersExpectedContent()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(_existingUserAccount), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/existing-account-email-confirmation?{authStateHelper.ToQueryParam()}");
 
         // Act
@@ -104,7 +95,13 @@ public class ExistingAccountEmailConfirmationTests : TestBase, IAsyncLifetime
     [Fact]
     public async Task Post_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, additionalScopes: null, HttpMethod.Post, "/sign-in/register/existing-account-email-confirmation");
+        await JourneyHasExpired_RendersErrorPage(_currentPageAuthenticationState(_existingUserAccount), additionalScopes: null, HttpMethod.Post, "/sign-in/register/existing-account-email-confirmation");
+    }
+
+    [Fact]
+    public async Task Post_AccountNotConfirmed_RedirectsToAccountExists()
+    {
+        await GivenAuthenticationState_RedirectsTo(_previousPageAuthenticationState(_existingUserAccount), HttpMethod.Post, "/sign-in/register/existing-account-email-confirmation", "/sign-in/register/account-exists");
     }
 
     [Fact]
@@ -113,7 +110,7 @@ public class ExistingAccountEmailConfirmationTests : TestBase, IAsyncLifetime
         // The real PIN generation service never generates pins that start with a '0'
         var pin = "01234";
 
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(_existingUserAccount), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/existing-account-email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -135,7 +132,7 @@ public class ExistingAccountEmailConfirmationTests : TestBase, IAsyncLifetime
         // Arrange
         var pin = "0";
 
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(_existingUserAccount), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/existing-account-email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -157,7 +154,7 @@ public class ExistingAccountEmailConfirmationTests : TestBase, IAsyncLifetime
         // Arrange
         var pin = "0123345678";
 
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(_existingUserAccount), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/existing-account-email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -179,7 +176,7 @@ public class ExistingAccountEmailConfirmationTests : TestBase, IAsyncLifetime
         // Arrange
         var pin = "abc";
 
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(_existingUserAccount), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/existing-account-email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -204,7 +201,7 @@ public class ExistingAccountEmailConfirmationTests : TestBase, IAsyncLifetime
         Clock.AdvanceBy(TimeSpan.FromHours(1));
         SpyRegistry.Get<IUserVerificationService>().Reset();
 
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(_existingUserAccount), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/existing-account-email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -232,7 +229,7 @@ public class ExistingAccountEmailConfirmationTests : TestBase, IAsyncLifetime
         Clock.AdvanceBy(TimeSpan.FromHours(2) + TimeSpan.FromSeconds(userVerificationOptions.Value.PinLifetimeSeconds));
         SpyRegistry.Get<IUserVerificationService>().Reset();
 
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(_existingUserAccount), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/existing-account-email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -257,7 +254,7 @@ public class ExistingAccountEmailConfirmationTests : TestBase, IAsyncLifetime
         var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
         var pinResult = await userVerificationService.GenerateEmailPin(_existingUserAccount!.EmailAddress);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(_existingUserAccount), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/existing-account-email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -284,7 +281,7 @@ public class ExistingAccountEmailConfirmationTests : TestBase, IAsyncLifetime
         var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
         var pinResult = await userVerificationService.GenerateEmailPin(_existingUserAccount!.EmailAddress);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(_existingUserAccount), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/existing-account-email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -307,7 +304,7 @@ public class ExistingAccountEmailConfirmationTests : TestBase, IAsyncLifetime
         var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
         var pinResult = await userVerificationService.GenerateEmailPin(_existingUserAccount!.EmailAddress);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: CustomScopes.StaffUserTypeScopes.First());
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(_existingUserAccount), additionalScopes: CustomScopes.StaffUserTypeScopes.First());
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/existing-account-email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -330,7 +327,7 @@ public class ExistingAccountEmailConfirmationTests : TestBase, IAsyncLifetime
         var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
         var pinResult = await userVerificationService.GenerateEmailPin(_existingUserAccount!.EmailAddress);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: CustomScopes.DefaultUserTypesScopes.First());
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(_existingUserAccount), additionalScopes: CustomScopes.DefaultUserTypesScopes.First());
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/existing-account-email-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -365,6 +362,6 @@ public class ExistingAccountEmailConfirmationTests : TestBase, IAsyncLifetime
         Assert.True(authStateHelper.AuthenticationState.EmailAddressVerified);
     }
 
-    private Func<AuthenticationState, Task> ConfigureValidAuthenticationState(AuthenticationStateHelper.Configure configure) =>
-        configure.RegisterExistingUserAccountChosen(existingUserAccount: _existingUserAccount);
+    private readonly AuthenticationStateConfigGenerator _currentPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.ExistingAccountEmailConfirmation);
+    private readonly AuthenticationStateConfigGenerator _previousPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.AccountExists);
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ExistingAccountPhoneConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ExistingAccountPhoneConfirmationTests.cs
@@ -48,46 +48,27 @@ public class ExistingAccountPhoneConfirmationTests : TestBase, IAsyncLifetime
     [Fact]
     public async Task Get_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, additionalScopes: null, HttpMethod.Get, "/sign-in/register/existing-account-phone-confirmation");
+        await JourneyHasExpired_RendersErrorPage(_currentPageAuthenticationState(_existingUserAccount), additionalScopes: null, HttpMethod.Get, "/sign-in/register/existing-account-phone-confirmation");
     }
 
     [Fact]
-    public async Task Get_ExistingAccountChosenNotSet_RedirectsToCheckAccount()
+    public async Task Get_NullExistingAccountMobileNumber_RedirectsToExistingAccountConfirmEmail()
     {
-        // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.RegisterExistingUserAccountMatch(), additionalScopes: null);
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/existing-account-phone-confirmation?{authStateHelper.ToQueryParam()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Act
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith("/sign-in/register/account-exists", response.Headers.Location?.OriginalString);
-    }
-
-    [Fact]
-    public async Task Get_ExistingAccountMobileNumberNull_RedirectsToCheckAccount()
-    {
-        // Arrange
         _existingUserAccount!.MobileNumber = null;
+        await GivenAuthenticationState_RedirectsTo(_currentPageAuthenticationState(_existingUserAccount), HttpMethod.Get, "/sign-in/register/existing-account-phone-confirmation", "/sign-in/register/existing-account-email-confirmation");
+    }
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.RegisterExistingUserAccountMatch(), additionalScopes: null);
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/existing-account-phone-confirmation?{authStateHelper.ToQueryParam()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Act
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith("/sign-in/register/account-exists", response.Headers.Location?.OriginalString);
+    [Fact]
+    public async Task Get_ExistingAccountNotChosen_RedirectsToAccountExists()
+    {
+        await GivenAuthenticationState_RedirectsTo(_previousPageAuthenticationState(_existingUserAccount), HttpMethod.Get, "/sign-in/register/existing-account-phone-confirmation", "/sign-in/register/account-exists");
     }
 
     [Fact]
     public async Task Get_ValidRequest_RendersExpectedContent()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(_existingUserAccount), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/existing-account-phone-confirmation?{authStateHelper.ToQueryParam()}");
 
         // Act
@@ -121,7 +102,20 @@ public class ExistingAccountPhoneConfirmationTests : TestBase, IAsyncLifetime
     [Fact]
     public async Task Post_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, additionalScopes: null, HttpMethod.Post, "/sign-in/register/existing-account-phone-confirmation");
+        await JourneyHasExpired_RendersErrorPage(_currentPageAuthenticationState(_existingUserAccount), additionalScopes: null, HttpMethod.Post, "/sign-in/register/existing-account-phone-confirmation");
+    }
+
+    [Fact]
+    public async Task Post_NullExistingAccountMobileNumber_RedirectsToExistingAccountConfirmEmail()
+    {
+        _existingUserAccount!.MobileNumber = null;
+        await GivenAuthenticationState_RedirectsTo(_currentPageAuthenticationState(_existingUserAccount), HttpMethod.Post, "/sign-in/register/existing-account-phone-confirmation", "/sign-in/register/existing-account-email-confirmation");
+    }
+
+    [Fact]
+    public async Task Post_ExistingAccountNotChosen_RedirectsToAccountExists()
+    {
+        await GivenAuthenticationState_RedirectsTo(_previousPageAuthenticationState(_existingUserAccount), HttpMethod.Post, "/sign-in/register/existing-account-phone-confirmation", "/sign-in/register/account-exists");
     }
 
     [Fact]
@@ -130,7 +124,7 @@ public class ExistingAccountPhoneConfirmationTests : TestBase, IAsyncLifetime
         // The real PIN generation service never generates pins that start with a '0'
         var pin = "01234";
 
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(_existingUserAccount), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/existing-account-phone-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -152,7 +146,7 @@ public class ExistingAccountPhoneConfirmationTests : TestBase, IAsyncLifetime
         // Arrange
         var pin = "0";
 
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(_existingUserAccount), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/existing-account-phone-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -174,7 +168,7 @@ public class ExistingAccountPhoneConfirmationTests : TestBase, IAsyncLifetime
         // Arrange
         var pin = "0123345678";
 
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(_existingUserAccount), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/existing-account-phone-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -196,7 +190,7 @@ public class ExistingAccountPhoneConfirmationTests : TestBase, IAsyncLifetime
         // Arrange
         var pin = "abc";
 
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(_existingUserAccount), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/existing-account-phone-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -221,7 +215,7 @@ public class ExistingAccountPhoneConfirmationTests : TestBase, IAsyncLifetime
         Clock.AdvanceBy(TimeSpan.FromHours(1));
         SpyRegistry.Get<IUserVerificationService>().Reset();
 
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(_existingUserAccount), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/existing-account-phone-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -249,7 +243,7 @@ public class ExistingAccountPhoneConfirmationTests : TestBase, IAsyncLifetime
         Clock.AdvanceBy(TimeSpan.FromHours(2) + TimeSpan.FromSeconds(userVerificationOptions.Value.PinLifetimeSeconds));
         SpyRegistry.Get<IUserVerificationService>().Reset();
 
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(_existingUserAccount), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/existing-account-phone-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -274,7 +268,7 @@ public class ExistingAccountPhoneConfirmationTests : TestBase, IAsyncLifetime
         var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
         var pinResult = await userVerificationService.GenerateSmsPin(_existingUserAccount!.MobileNumber!);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(_existingUserAccount), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/existing-account-phone-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -301,7 +295,7 @@ public class ExistingAccountPhoneConfirmationTests : TestBase, IAsyncLifetime
         var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
         var pinResult = await userVerificationService.GenerateSmsPin(_existingUserAccount!.MobileNumber!);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(_existingUserAccount), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/existing-account-phone-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -324,7 +318,7 @@ public class ExistingAccountPhoneConfirmationTests : TestBase, IAsyncLifetime
         var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
         var pinResult = await userVerificationService.GenerateSmsPin(_existingUserAccount!.MobileNumber!);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: CustomScopes.StaffUserTypeScopes.First());
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(_existingUserAccount), additionalScopes: CustomScopes.StaffUserTypeScopes.First());
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/existing-account-phone-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -347,7 +341,7 @@ public class ExistingAccountPhoneConfirmationTests : TestBase, IAsyncLifetime
         var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
         var pinResult = await userVerificationService.GenerateSmsPin(_existingUserAccount!.MobileNumber!);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: CustomScopes.DefaultUserTypesScopes.First());
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(_existingUserAccount), additionalScopes: CustomScopes.DefaultUserTypesScopes.First());
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/existing-account-phone-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -382,6 +376,6 @@ public class ExistingAccountPhoneConfirmationTests : TestBase, IAsyncLifetime
         Assert.True(authStateHelper.AuthenticationState.MobileNumberVerified);
     }
 
-    private Func<AuthenticationState, Task> ConfigureValidAuthenticationState(AuthenticationStateHelper.Configure configure) =>
-        configure.RegisterExistingUserAccountChosen(existingUserAccount: _existingUserAccount);
+    private readonly AuthenticationStateConfigGenerator _currentPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.ExistingAccountPhoneConfirmation);
+    private readonly AuthenticationStateConfigGenerator _previousPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.AccountExists);
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/NameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/NameTests.cs
@@ -28,13 +28,19 @@ public class NameTests : TestBase
     [Fact]
     public async Task Get_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, additionalScopes: null, HttpMethod.Get, "/sign-in/register/name");
+        await JourneyHasExpired_RendersErrorPage(_currentPageAuthenticationState(), additionalScopes: null, HttpMethod.Get, "/sign-in/register/name");
+    }
+
+    [Fact]
+    public async Task Get_MobileNumberNotVerified_RedirectsToPhoneConfirmation()
+    {
+        await GivenAuthenticationState_RedirectsTo(_previousPageAuthenticationState(), HttpMethod.Get, "/sign-in/register/name", "/sign-in/register/phone-confirmation");
     }
 
     [Fact]
     public async Task Get_ValidRequest_RendersContent()
     {
-        await ValidRequest_RendersContent(ConfigureValidAuthenticationState, "/sign-in/register/name", additionalScopes: null);
+        await ValidRequest_RendersContent(_currentPageAuthenticationState(), "/sign-in/register/name", additionalScopes: null);
     }
 
     [Fact]
@@ -58,14 +64,20 @@ public class NameTests : TestBase
     [Fact]
     public async Task Post_JourneyHasExpired_RendersErrorPage()
     {
-        await JourneyHasExpired_RendersErrorPage(ConfigureValidAuthenticationState, additionalScopes: null, HttpMethod.Post, "/sign-in/register/name");
+        await JourneyHasExpired_RendersErrorPage(_currentPageAuthenticationState(), additionalScopes: null, HttpMethod.Post, "/sign-in/register/name");
+    }
+
+    [Fact]
+    public async Task Post_MobileNumberNotVerified_RedirectsToPhoneConfirmation()
+    {
+        await GivenAuthenticationState_RedirectsTo(_previousPageAuthenticationState(), HttpMethod.Post, "/sign-in/register/name", "/sign-in/register/phone-confirmation");
     }
 
     [Fact]
     public async Task Post_EmptyFirstName_ReturnsError()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/name?{authStateHelper.ToQueryParam()}")
         {
@@ -86,7 +98,7 @@ public class NameTests : TestBase
     public async Task Post_EmptyLastName_ReturnsError()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/name?{authStateHelper.ToQueryParam()}")
         {
@@ -107,7 +119,7 @@ public class NameTests : TestBase
     public async Task Post_TooLongFirstName_ReturnsError()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/name?{authStateHelper.ToQueryParam()}")
         {
@@ -129,7 +141,7 @@ public class NameTests : TestBase
     public async Task Post_TooLongLastName_ReturnsError()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/name?{authStateHelper.ToQueryParam()}")
         {
@@ -151,7 +163,7 @@ public class NameTests : TestBase
     public async Task Post_ValidName_SetsNameOnAuthenticationStateAndRedirects()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
         var firstName = Faker.Name.First();
         var lastName = Faker.Name.Last();
 
@@ -175,6 +187,6 @@ public class NameTests : TestBase
         Assert.Equal(lastName, authStateHelper.AuthenticationState.LastName);
     }
 
-    private Func<AuthenticationState, Task> ConfigureValidAuthenticationState(AuthenticationStateHelper.Configure configure) =>
-        configure.MobileNumberSet();
+    private readonly AuthenticationStateConfigGenerator _currentPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.Name);
+    private readonly AuthenticationStateConfigGenerator _previousPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.PhoneConfirmation);
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/PhoneConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/PhoneConfirmationTests.cs
@@ -40,16 +40,7 @@ public class PhoneConfirmationTests : TestBase
     [Fact]
     public async Task Get_MobileNumberNotSet_RedirectsToPhonePage()
     {
-        // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified(), additionalScopes: null);
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/phone-confirmation?{authStateHelper.ToQueryParam()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Act
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith("/sign-in/register/phone", response.Headers.Location?.OriginalString);
+        await GivenAuthenticationState_RedirectsTo(_previousPageAuthenticationState(), HttpMethod.Get, "/sign-in/register/phone-confirmation", "/sign-in/register/phone");
     }
 
     [Fact]
@@ -94,6 +85,12 @@ public class PhoneConfirmationTests : TestBase
     }
 
     [Fact]
+    public async Task Post_MobileNumberNotSet_RedirectsToPhonePage()
+    {
+        await GivenAuthenticationState_RedirectsTo(_previousPageAuthenticationState(), HttpMethod.Post, "/sign-in/register/phone-confirmation", "/sign-in/register/phone");
+    }
+
+    [Fact]
     public async Task Post_UnknownPin_ReturnsError()
     {
         // Arrange
@@ -102,7 +99,7 @@ public class PhoneConfirmationTests : TestBase
         // The real PIN generation service never generates pins that start with a '0'
         var pin = "01234";
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.MobileNumberSet(mobileNumber), additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(mobileNumber: mobileNumber), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/phone-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -125,7 +122,7 @@ public class PhoneConfirmationTests : TestBase
         var mobileNumber = Faker.Phone.Number();
         var pin = "0";
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.MobileNumberSet(mobileNumber), additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(mobileNumber: mobileNumber), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/phone-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -148,7 +145,7 @@ public class PhoneConfirmationTests : TestBase
         var mobileNumber = Faker.Phone.Number();
         var pin = "0123345678";
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.MobileNumberSet(mobileNumber), additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(mobileNumber: mobileNumber), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/phone-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -171,7 +168,7 @@ public class PhoneConfirmationTests : TestBase
         var mobileNumber = Faker.Phone.Number();
         var pin = "abc";
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.MobileNumberSet(mobileNumber), additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(mobileNumber: mobileNumber), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/phone-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -198,7 +195,7 @@ public class PhoneConfirmationTests : TestBase
         Clock.AdvanceBy(TimeSpan.FromHours(1));
         SpyRegistry.Get<IUserVerificationService>().Reset();
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.MobileNumberSet(mobileNumber), additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(mobileNumber: mobileNumber), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/phone-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -228,7 +225,7 @@ public class PhoneConfirmationTests : TestBase
         Clock.AdvanceBy(TimeSpan.FromHours(2) + TimeSpan.FromSeconds(userVerificationOptions.Value.PinLifetimeSeconds));
         SpyRegistry.Get<IUserVerificationService>().Reset();
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.MobileNumberSet(mobileNumber), additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(mobileNumber: mobileNumber), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/phone-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -255,7 +252,7 @@ public class PhoneConfirmationTests : TestBase
         var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
         var pinResult = await userVerificationService.GenerateSmsPin(mobileNumber);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.MobileNumberSet(mobileNumber), additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(mobileNumber: mobileNumber), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/phone-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -284,7 +281,7 @@ public class PhoneConfirmationTests : TestBase
         var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
         var pinResult = await userVerificationService.GenerateSmsPin(mobileNumber);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.MobileNumberSet(mobileNumber), additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(mobileNumber: mobileNumber), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/phone-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -309,7 +306,7 @@ public class PhoneConfirmationTests : TestBase
         var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
         var pinResult = await userVerificationService.GenerateSmsPin(user.MobileNumber!);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.MobileNumberSet(user.MobileNumber), additionalScopes: CustomScopes.DefaultUserTypesScopes.First());
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(mobileNumber: user.MobileNumber), additionalScopes: CustomScopes.DefaultUserTypesScopes.First());
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/phone-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -338,7 +335,7 @@ public class PhoneConfirmationTests : TestBase
         var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
         var pinResult = await userVerificationService.GenerateSmsPin(user.MobileNumber!);
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.MobileNumberSet(user.MobileNumber), additionalScopes: CustomScopes.StaffUserTypeScopes.First());
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(mobileNumber: user.MobileNumber), additionalScopes: CustomScopes.StaffUserTypeScopes.First());
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/phone-confirmation?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -353,4 +350,7 @@ public class PhoneConfirmationTests : TestBase
         // Assert
         Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
     }
+
+    private readonly AuthenticationStateConfigGenerator _currentPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.PhoneConfirmation);
+    private readonly AuthenticationStateConfigGenerator _previousPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.Phone);
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/PhoneExistsTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/PhoneExistsTests.cs
@@ -23,7 +23,13 @@ public class PhoneExistsTests : TestBase
     public async Task Get_JourneyHasExpired_RendersErrorPage()
     {
         var user = await TestData.CreateUser();
-        await JourneyHasExpired_RendersErrorPage(c => c.Completed(user), additionalScopes: null, HttpMethod.Get, "/sign-in/register/phone-exists");
+        await JourneyHasExpired_RendersErrorPage(_currentPageAuthenticationState(user), additionalScopes: null, HttpMethod.Get, "/sign-in/register/phone-exists");
+    }
+
+    [Fact]
+    public async Task Get_UserNotSignedIn_RedirectsToPhoneConfirmation()
+    {
+        await GivenAuthenticationState_RedirectsTo(_previousPageAuthenticationState(), HttpMethod.Get, "/sign-in/register/phone-exists", "/sign-in/register/phone-confirmation");
     }
 
     [Fact]
@@ -36,6 +42,15 @@ public class PhoneExistsTests : TestBase
     public async Task Get_ValidRequest_RendersContent()
     {
         var user = await TestData.CreateUser();
-        await ValidRequest_RendersContent(c => c.Completed(user), "/sign-in/register/phone-exists", additionalScopes: null);
+        await ValidRequest_RendersContent(_currentPageAuthenticationState(user), "/sign-in/register/phone-exists", additionalScopes: null);
     }
+
+    [Fact]
+    public async Task Post_UserNotSignedIn_RedirectsToPhoneConfirmation()
+    {
+        await GivenAuthenticationState_RedirectsTo(_previousPageAuthenticationState(), HttpMethod.Post, "/sign-in/register/phone-exists", "/sign-in/register/phone-confirmation");
+    }
+
+    private readonly AuthenticationStateConfigGenerator _currentPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.PhoneExists);
+    private readonly AuthenticationStateConfigGenerator _previousPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.PhoneConfirmation);
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/RegisterJourneyAuthenticationStateHelper.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/RegisterJourneyAuthenticationStateHelper.cs
@@ -1,0 +1,77 @@
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
+
+public delegate AuthenticationStateConfiguration AuthenticationStateConfigGenerator(User? user = null, string? mobileNumber = null);
+
+public static class RegisterJourneyAuthenticationStateHelper
+{
+    public static AuthenticationStateConfigGenerator ConfigureAuthenticationStateForPage(RegisterJourneyPage page)
+    {
+        return (user, mobileNumber) =>
+        {
+            switch (page)
+            {
+                case RegisterJourneyPage.Index:
+                case RegisterJourneyPage.Email:
+                    return c => c.Start();
+
+                case RegisterJourneyPage.EmailConfirmation:
+                case RegisterJourneyPage.ResendEmail:
+                    return c => c.EmailSet();
+
+                case RegisterJourneyPage.Phone:
+                    return c => c.EmailVerified();
+
+                case RegisterJourneyPage.PhoneConfirmation:
+                case RegisterJourneyPage.ResendPhone:
+                    return c => c.MobileNumberSet(mobileNumber);
+
+                case RegisterJourneyPage.Name:
+                    return c => c.MobileVerified();
+
+                case RegisterJourneyPage.DateOfBirth:
+                    return c => c.RegisterNameSet();
+
+                case RegisterJourneyPage.AccountExists:
+                    return c => c.RegisterExistingUserAccountMatch(user);
+
+                case RegisterJourneyPage.ExistingAccountEmailConfirmation:
+                case RegisterJourneyPage.ResendExistingAccountEmail:
+                case RegisterJourneyPage.ExistingAccountPhone:
+                case RegisterJourneyPage.ExistingAccountPhoneConfirmation:
+                case RegisterJourneyPage.ResendExistingAccountPhone:
+                    return c => c.RegisterExistingUserAccountChosen(user);
+
+                case RegisterJourneyPage.EmailExists:
+                case RegisterJourneyPage.PhoneExists:
+                    return c => c.Completed(user!);
+
+
+                default:
+                    return c => c.Start();
+            }
+        };
+    }
+}
+
+public enum RegisterJourneyPage
+{
+    Index,
+    Email,
+    EmailConfirmation,
+    EmailExists,
+    ResendEmail,
+    Phone,
+    PhoneConfirmation,
+    PhoneExists,
+    ResendPhone,
+    Name,
+    DateOfBirth,
+    AccountExists,
+    ExistingAccountEmailConfirmation,
+    ResendExistingAccountEmail,
+    ExistingAccountPhone,
+    ExistingAccountPhoneConfirmation,
+    ResendExistingAccountPhone
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TestBase.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TestBase.cs
@@ -32,7 +32,7 @@ public abstract partial class TestBase
     public TestData TestData => HostFixture.Services.GetRequiredService<TestData>();
 
     public Task<AuthenticationStateHelper> CreateAuthenticationStateHelper(
-        Func<AuthenticationStateHelper.Configure, Func<AuthenticationState, Task>> configure,
+        AuthenticationStateConfiguration configure,
         string? additionalScopes,
         TeacherIdentityApplicationDescriptor? client = null) =>
         AuthenticationStateHelper.Create(configure, HostFixture, additionalScopes, client);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/CheckAnswersTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/CheckAnswersTests.cs
@@ -448,7 +448,7 @@ public class CheckAnswersTests : TestBase
         });
     }
 
-    public static TheoryData<Func<Configure, Func<AuthenticationState, Task>>, string> MissingAnswersData
+    public static TheoryData<AuthenticationStateConfiguration, string> MissingAnswersData
     {
         get
         {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/CheckAnswersTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/CheckAnswersTests.cs
@@ -52,7 +52,7 @@ public class CheckAnswersTests : TestBase
     [Theory]
     [MemberData(nameof(MissingAnswersData))]
     public async Task Get_MissingAnswersAndNotFoundTrn_RedirectsToPageOfFirstMissingAnswer(
-        Func<Configure, Func<AuthenticationState, Task>> configureAuthStateHelper,
+        AuthenticationStateConfiguration configureAuthStateHelper,
         string expectedRedirect)
     {
         // Arrange

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/CheckAnswersTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/CheckAnswersTests.cs
@@ -1,6 +1,5 @@
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Oidc;
-using static TeacherIdentity.AuthServer.Tests.AuthenticationStateHelper;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Trn;
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/NoMatchTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/NoMatchTests.cs
@@ -451,7 +451,7 @@ public class NoMatchTests : TestBase
         s.OnTrnLookupCompleted(trn: null, trnLookupStatus: TrnLookupStatus.Pending);
     };
 
-    public static TheoryData<Func<Configure, Func<AuthenticationState, Task>>, string> MissingAnswersData
+    public static TheoryData<AuthenticationStateConfiguration, string> MissingAnswersData
     {
         get
         {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/NoMatchTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/NoMatchTests.cs
@@ -53,7 +53,7 @@ public class NoMatchTests : TestBase
     [Theory]
     [MemberData(nameof(MissingAnswersData))]
     public async Task Get_MissingAnswersAndNotFoundTrn_RedirectsToPageOfFirstMissingAnswer(
-        Func<Configure, Func<AuthenticationState, Task>> configureAuthStateHelper,
+        AuthenticationStateConfiguration configureAuthStateHelper,
         string expectedRedirect)
     {
         // Arrange
@@ -335,7 +335,7 @@ public class NoMatchTests : TestBase
     [Theory]
     [MemberData(nameof(MissingAnswersData))]
     public async Task Post_MissingAnswersAndNotFoundTrn_RedirectsToPageOfFirstMissingAnswer(
-        Func<Configure, Func<AuthenticationState, Task>> configureAuthStateHelper,
+        AuthenticationStateConfiguration configureAuthStateHelper,
         string expectedRedirect)
     {
         // Arrange


### PR DESCRIPTION
### Context

For the new core /sign-in/register journey we don’t currently check whether it’s valid for a user to access a given page or not, meaning they could jump around and potentially get into a bad state.

### Changes proposed in this pull request

Add checks to each page in the /SignIn/Register folder to enforce that the previous question was answered.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
