### PR TITLE
Add validation for update email

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Common/BaseEmailConfirmationPageModel.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Common/BaseEmailConfirmationPageModel.cs
@@ -1,6 +1,6 @@
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
-namespace TeacherIdentity.AuthServer.Pages.SignIn;
+namespace TeacherIdentity.AuthServer.Pages.Common;
 
 public abstract class BaseEmailConfirmationPageModel : BasePinVerificationPageModel
 {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Common/BaseEmailPageModel.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Common/BaseEmailPageModel.cs
@@ -1,8 +1,9 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
-namespace TeacherIdentity.AuthServer.Pages.SignIn;
+namespace TeacherIdentity.AuthServer.Pages.Common;
 
 public class BaseEmailPageModel : BaseEmailPinGenerationPageModel
 {
@@ -41,5 +42,12 @@ public class BaseEmailPageModel : BaseEmailPinGenerationPageModel
             default:
                 throw new NotImplementedException($"Unknown {nameof(EmailPinGenerationFailedReason)}: '{emailPinGenerationFailedReasons}'.");
         }
+    }
+
+    public async Task<bool> EmailExists(string email)
+    {
+        // Check if email is already in use
+        var userWithNewEmail = await DbContext.Users.SingleOrDefaultAsync(u => u.EmailAddress == email);
+        return userWithNewEmail is not null && userWithNewEmail.UserId != User.GetUserId()!.Value;
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Common/BaseEmailPinGenerationPageModel.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Common/BaseEmailPinGenerationPageModel.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
-namespace TeacherIdentity.AuthServer.Pages.SignIn;
+namespace TeacherIdentity.AuthServer.Pages.Common;
 
 public class BaseEmailPinGenerationPageModel : PageModel
 {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Common/BaseExistingEmailPageModel.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Common/BaseExistingEmailPageModel.cs
@@ -2,7 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
-namespace TeacherIdentity.AuthServer.Pages.SignIn;
+namespace TeacherIdentity.AuthServer.Pages.Common;
 
 public class BaseExistingEmailPageModel : BaseEmailPinGenerationPageModel
 {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Common/BaseExistingPhonePageModel.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Common/BaseExistingPhonePageModel.cs
@@ -2,7 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
-namespace TeacherIdentity.AuthServer.Pages.SignIn;
+namespace TeacherIdentity.AuthServer.Pages.Common;
 
 public class BaseExistingPhonePageModel : PageModel
 {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Common/BasePhoneConfirmationPageModel.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Common/BasePhoneConfirmationPageModel.cs
@@ -1,4 +1,3 @@
-using TeacherIdentity.AuthServer.Pages.SignIn;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.Common;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Common/BasePhoneConfirmationPageModel.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Common/BasePhoneConfirmationPageModel.cs
@@ -1,6 +1,7 @@
+using TeacherIdentity.AuthServer.Pages.SignIn;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
-namespace TeacherIdentity.AuthServer.Pages.SignIn;
+namespace TeacherIdentity.AuthServer.Pages.Common;
 
 public abstract class BasePhoneConfirmationPageModel : BasePinVerificationPageModel
 {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Common/BasePhonePageModel.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Common/BasePhonePageModel.cs
@@ -4,7 +4,7 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeacherIdentity.AuthServer.Helpers;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
-namespace TeacherIdentity.AuthServer.Pages.SignIn;
+namespace TeacherIdentity.AuthServer.Pages.Common;
 
 public class BasePhonePageModel : PageModel
 {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Common/BasePinVerificationPageModel.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Common/BasePinVerificationPageModel.cs
@@ -3,7 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
-namespace TeacherIdentity.AuthServer.Pages.SignIn;
+namespace TeacherIdentity.AuthServer.Pages.Common;
 
 public abstract class BasePinVerificationPageModel : PageModel
 {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Email.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Email.cshtml.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Pages.Common;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/EmailConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/EmailConfirmation.cshtml.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Pages.Common;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/AccountExists.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/AccountExists.cshtml.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using TeacherIdentity.AuthServer.Helpers;
 using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Pages.Common;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Email.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Email.cshtml.cs
@@ -1,6 +1,7 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Pages.Common;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/EmailConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/EmailConfirmation.cshtml.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Pages.Common;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ExistingAccountEmailConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ExistingAccountEmailConfirmation.cshtml.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Pages.Common;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ExistingAccountPhone.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ExistingAccountPhone.cshtml.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using TeacherIdentity.AuthServer.Pages.Common;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ExistingAccountPhoneConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ExistingAccountPhoneConfirmation.cshtml.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Pages.Common;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Phone.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Phone.cshtml.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using TeacherIdentity.AuthServer.Pages.Common;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/PhoneConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/PhoneConfirmation.cshtml.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Helpers;
 using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Pages.Common;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendEmailConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendEmailConfirmation.cshtml.cs
@@ -2,6 +2,7 @@ using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Pages.Common;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendExistingAccountEmail.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendExistingAccountEmail.cshtml.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Pages.Common;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendExistingAccountPhone.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendExistingAccountPhone.cshtml.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using TeacherIdentity.AuthServer.Pages.Common;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendPhoneConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendPhoneConfirmation.cshtml.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using TeacherIdentity.AuthServer.Pages.Common;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/ResendEmailConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/ResendEmailConfirmation.cshtml.cs
@@ -2,6 +2,7 @@ using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Pages.Common;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnInUse.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnInUse.cshtml.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using TeacherIdentity.AuthServer.Pages.Common;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn;

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TestData.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TestData.cs
@@ -55,6 +55,7 @@ public partial class TestData
             {
                 email = email.Substring(0, 1 + email.IndexOf("@", StringComparison.Ordinal)) + suffix;
             }
+
         } while (_emails.Contains(email));
 
         _emails.Add(email);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TestData.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TestData.cs
@@ -50,7 +50,7 @@ public partial class TestData
             if (prefix is not null)
             {
                 email = prefix + email.Substring(email.IndexOf("@", StringComparison.Ordinal));
-            } 
+            }
             else if (suffix is not null)
             {
                 email = email.Substring(0, 1 + email.IndexOf("@", StringComparison.Ordinal)) + suffix;

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TestData.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TestData.cs
@@ -50,7 +50,8 @@ public partial class TestData
             if (prefix is not null)
             {
                 email = prefix + email.Substring(email.IndexOf("@", StringComparison.Ordinal));
-            } else if (suffix is not null)
+            } 
+            else if (suffix is not null)
             {
                 email = email.Substring(0, 1 + email.IndexOf("@", StringComparison.Ordinal)) + suffix;
             }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TestData.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TestData.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using Microsoft.Extensions.DependencyInjection;
 using TeacherIdentity.AuthServer.Models;
 
@@ -30,23 +31,32 @@ public partial class TestData
             }
             while (_trns.Contains(trn));
 
+            _trns.Add(trn);
             return trn;
         }
     }
 
-    public string GenerateUniqueEmail(string? prefix)
+    public string GenerateUniqueEmail(string? prefix = null, string? suffix = null)
     {
         string email;
+
+        // if both prefix and suffix are defined, email is fully specified
+        Debug.Assert(prefix is null || suffix is null);
 
         do
         {
             email = Faker.Internet.Email();
+
             if (prefix is not null)
             {
                 email = prefix + email.Substring(email.IndexOf("@", StringComparison.Ordinal));
+            } else if (suffix is not null)
+            {
+                email = email.Substring(0, 1 + email.IndexOf("@", StringComparison.Ordinal)) + suffix;
             }
         } while (_emails.Contains(email));
 
+        _emails.Add(email);
         return email;
     }
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailTests.cs
@@ -209,7 +209,7 @@ public class EmailTests : TestBase
     public async Task Post_EmailWithInvalidSuffix_ReturnsError()
     {
         // Arrange
-        var invalidEmailSuffix = "myschool1231.sch.uk";
+        var invalidEmailSuffix = "invalid.sch.uk";
 
         await TestData.WithDbContext(async dbContext =>
         {


### PR DESCRIPTION
### Context

We’ve added validation to prevent signing up/registering with an establishment or shared email address but we’ve missed adding that same validation to the Update Email journey.

### Changes proposed in this pull request

Amend the /update-email page to add validation for both shared email prefixes and school establishment domains

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
