### PR TITLE
Add TRN row to Account Details page

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
@@ -30,7 +30,7 @@
                     <govuk-summary-list-row-action href="#" visually-hidden-text="name">Change</govuk-summary-list-row-action>
                 </govuk-summary-list-row-actions>
             </govuk-summary-list-row>
-            @if (Model.HasTrn)
+            @if (Model.Trn is not null)
             {
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Official name</govuk-summary-list-row-key>
@@ -50,6 +50,13 @@
                     <govuk-summary-list-row-action href="#" visually-hidden-text="date of birth">Change</govuk-summary-list-row-action>
                 </govuk-summary-list-row-actions>
             </govuk-summary-list-row>
+            @if (Model.Trn is not null)
+                {
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>TRN</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value>@Model.Trn</govuk-summary-list-row-value>
+                    </govuk-summary-list-row>
+                }
         </govuk-summary-list>
 
         <h3 class="govuk-heading-m">Sign in details</h3>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
@@ -50,14 +50,18 @@
                     <govuk-summary-list-row-action href="#" visually-hidden-text="date of birth">Change</govuk-summary-list-row-action>
                 </govuk-summary-list-row-actions>
             </govuk-summary-list-row>
-            @if (Model.Trn is not null)
-                {
-                    <govuk-summary-list-row>
-                        <govuk-summary-list-row-key>TRN</govuk-summary-list-row-key>
-                        <govuk-summary-list-row-value>@Model.Trn</govuk-summary-list-row-value>
-                    </govuk-summary-list-row>
-                }
         </govuk-summary-list>
+
+        @if (Model.Trn is not null)
+        {
+            <h3 class="govuk-heading-m">Teacher reference number (TRN)</h3>
+            <govuk-summary-list>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>TRN</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.Trn</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+            </govuk-summary-list>
+        }
 
         <h3 class="govuk-heading-m">Sign in details</h3>
         <govuk-summary-list>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml.cs
@@ -38,7 +38,7 @@ public class IndexModel : PageModel
     public DateOnly? DateOfBirth { get; set; }
     public string? Email { get; set; }
     public string? MobileNumber { get; set; }
-    public bool HasTrn { get; set; }
+    public string? Trn { get; set; }
 
     public async Task OnGet()
     {
@@ -61,12 +61,12 @@ public class IndexModel : PageModel
         DateOfBirth = user.DateOfBirth;
         Email = user.EmailAddress;
         MobileNumber = user.MobileNumber;
-        HasTrn = user.Trn is not null;
+        Trn = user.Trn;
 
-        if (HasTrn)
+        if (Trn is not null)
         {
-            var dqtUser = await _dqtApiClient.GetTeacherByTrn(user.Trn!) ??
-                throw new Exception($"User with TRN '{user.Trn}' cannot be found in DQT.");
+            var dqtUser = await _dqtApiClient.GetTeacherByTrn(Trn) ??
+                throw new Exception($"User with TRN '{Trn}' cannot be found in DQT.");
 
             OfficialName = $"{dqtUser.FirstName} {dqtUser.LastName}";
         }


### PR DESCRIPTION
### Context

We’re adding an account page to ID for a user to change their ID and DQT details.

### Changes proposed in this pull request

Add the ‘Teacher reference number (TRN)' section and ‘TRN’ field if the user has a TRN

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
