### PR TITLE
Add account update name page

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -149,15 +149,15 @@ public static class IdentityLinkGeneratorExtensions
             .SetQueryParam("returnUrl", returnUrl)
             .SetQueryParam("cancelUrl", cancelUrl);
 
-    public static string AccountName(this IIdentityLinkGenerator linkGenerator, string? returnPath) =>
+    public static string AccountName(this IIdentityLinkGenerator linkGenerator, string? returnUrl) =>
         linkGenerator.PageWithAuthenticationJourneyId("/Account/Name/Index", authenticationJourneyRequired: false)
-            .SetQueryParam("returnPath", returnPath);
+            .SetQueryParam("returnUrl", returnUrl);
 
-    public static string AccountNameConfirm(this IIdentityLinkGenerator linkGenerator, ProtectedString firstName, ProtectedString lastName, string? returnPath) =>
+    public static string AccountNameConfirm(this IIdentityLinkGenerator linkGenerator, ProtectedString firstName, ProtectedString lastName, string? returnUrl) =>
         linkGenerator.PageWithAuthenticationJourneyId("/Account/Name/Confirm", authenticationJourneyRequired: false)
             .SetQueryParam("firstName", firstName.EncryptedValue)
             .SetQueryParam("lastName", lastName.EncryptedValue)
-            .SetQueryParam("returnPath", returnPath);
+            .SetQueryParam("returnUrl", returnUrl);
 
     public static string Cookies(this IIdentityLinkGenerator linkGenerator) =>
         linkGenerator.PageWithAuthenticationJourneyId("/Cookies", authenticationJourneyRequired: false);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -149,6 +149,16 @@ public static class IdentityLinkGeneratorExtensions
             .SetQueryParam("returnUrl", returnUrl)
             .SetQueryParam("cancelUrl", cancelUrl);
 
+    public static string AccountName(this IIdentityLinkGenerator linkGenerator, string? returnPath) =>
+        linkGenerator.PageWithAuthenticationJourneyId("/Account/Name/Index", authenticationJourneyRequired: false)
+            .SetQueryParam("returnPath", returnPath);
+
+    public static string AccountNameConfirm(this IIdentityLinkGenerator linkGenerator, ProtectedString firstName, ProtectedString lastName, string? returnPath) =>
+        linkGenerator.PageWithAuthenticationJourneyId("/Account/Name/Confirm", authenticationJourneyRequired: false)
+            .SetQueryParam("firstName", firstName.EncryptedValue)
+            .SetQueryParam("lastName", lastName.EncryptedValue)
+            .SetQueryParam("returnPath", returnPath);
+
     public static string Cookies(this IIdentityLinkGenerator linkGenerator) =>
         linkGenerator.PageWithAuthenticationJourneyId("/Cookies", authenticationJourneyRequired: false);
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
@@ -1,7 +1,10 @@
 @page "/account"
+@using Microsoft.ApplicationInsights.AspNetCore.Extensions
 @model TeacherIdentity.AuthServer.Pages.Account.IndexModel
 @{
     ViewBag.Title = "DfE Identity account";
+
+    var returnPath = Request.GetUri().PathAndQuery;
 }
 
 @section BeforeContent
@@ -27,7 +30,7 @@
                 <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
                 <govuk-summary-list-row-value>@Model.Name</govuk-summary-list-row-value>
                 <govuk-summary-list-row-actions>
-                    <govuk-summary-list-row-action href="#" visually-hidden-text="name">Change</govuk-summary-list-row-action>
+                    <govuk-summary-list-row-action href="@LinkGenerator.AccountName(returnPath)" visually-hidden-text="name">Change</govuk-summary-list-row-action>
                 </govuk-summary-list-row-actions>
             </govuk-summary-list-row>
             @if (Model.Trn is not null)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
@@ -4,7 +4,7 @@
 @{
     ViewBag.Title = "DfE Identity account";
 
-    var returnPath = Request.GetUri().PathAndQuery;
+    var returnUrl = Request.GetUri().PathAndQuery;
 }
 
 @section BeforeContent
@@ -30,7 +30,7 @@
                 <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
                 <govuk-summary-list-row-value>@Model.Name</govuk-summary-list-row-value>
                 <govuk-summary-list-row-actions>
-                    <govuk-summary-list-row-action href="@LinkGenerator.AccountName(returnPath)" visually-hidden-text="name">Change</govuk-summary-list-row-action>
+                    <govuk-summary-list-row-action href="@LinkGenerator.AccountName(returnUrl)" visually-hidden-text="name">Change</govuk-summary-list-row-action>
                 </govuk-summary-list-row-actions>
             </govuk-summary-list-row>
             @if (Model.Trn is not null)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Confirm.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Confirm.cshtml
@@ -13,6 +13,17 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <form action="@LinkGenerator.AccountNameConfirm(Model.FirstName!, Model.LastName!, Model.ReturnPath)" method="post" asp-antiforgery="true">
+
+            <govuk-summary-list>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.FirstName!.PlainValue @Model.LastName!.PlainValue</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AccountName(Model.ReturnPath)" visually-hidden-text="name">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+            </govuk-summary-list>
+
             <govuk-button type="submit">Submit change</govuk-button>
         </form>
     </div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Confirm.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Confirm.cshtml
@@ -7,19 +7,19 @@
 
 @section BeforeContent
 {
-    <govuk-back-link href="@LinkGenerator.AccountName(Model.ReturnPath)" />
+    <govuk-back-link href="@LinkGenerator.AccountName(Model.ReturnUrl)" />
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.AccountNameConfirm(Model.FirstName!, Model.LastName!, Model.ReturnPath)" method="post" asp-antiforgery="true">
+        <form action="@LinkGenerator.AccountNameConfirm(Model.FirstName!, Model.LastName!, Model.ReturnUrl)" method="post" asp-antiforgery="true">
 
             <govuk-summary-list>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value>@Model.FirstName!.PlainValue @Model.LastName!.PlainValue</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.AccountName(Model.ReturnPath)" visually-hidden-text="name">Change</govuk-summary-list-row-action>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AccountName(Model.ReturnUrl)" visually-hidden-text="name">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
             </govuk-summary-list>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Confirm.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Confirm.cshtml
@@ -1,0 +1,20 @@
+@page "/account/name/confirm"
+@model TeacherIdentity.AuthServer.Pages.Account.Name.Confirm
+@{
+    ViewBag.Title = "Confirm change";
+
+}
+
+@section BeforeContent
+{
+    <govuk-back-link href="@LinkGenerator.AccountName(Model.ReturnPath)" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.AccountNameConfirm(Model.FirstName!, Model.LastName!, Model.ReturnPath)" method="post" asp-antiforgery="true">
+            <govuk-button type="submit">Submit change</govuk-button>
+        </form>
+    </div>
+</div>
+

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Confirm.cshtml.cs
@@ -27,9 +27,9 @@ public class Confirm : PageModel
     [FromQuery(Name = "lastName")]
     public ProtectedString? LastName { get; set; }
 
-    [FromQuery(Name = "returnPath")]
-    public string? ReturnPath { get; set; }
-    public string? SafeReturnPath { get; set; }
+    [FromQuery(Name = "returnUrl")]
+    public string? ReturnUrl { get; set; }
+    public string? SafeReturnUrl { get; set; }
 
 
     public void OnGet()
@@ -39,7 +39,7 @@ public class Confirm : PageModel
     public async Task<IActionResult> OnPost()
     {
         await UpdateUser(User.GetUserId()!.Value);
-        return Redirect(SafeReturnPath!);
+        return Redirect(SafeReturnUrl!);
     }
 
     private async Task UpdateUser(Guid userId)
@@ -93,6 +93,6 @@ public class Confirm : PageModel
             return;
         }
 
-        SafeReturnPath = !string.IsNullOrEmpty(ReturnPath) && Url.IsLocalUrl(ReturnPath) ? ReturnPath : "/account";
+        SafeReturnUrl = !string.IsNullOrEmpty(ReturnUrl) && Url.IsLocalUrl(ReturnUrl) ? ReturnUrl : "/account";
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Confirm.cshtml.cs
@@ -1,0 +1,98 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.Pages.Account.Name;
+
+public class Confirm : PageModel
+{
+    private TeacherIdentityServerDbContext _dbContext;
+    private IClock _clock;
+
+    public Confirm(
+        IIdentityLinkGenerator linkGenerator,
+        TeacherIdentityServerDbContext dbContext,
+        IClock clock)
+    {
+        _dbContext = dbContext;
+        _clock = clock;
+    }
+
+    [FromQuery(Name = "firstName")]
+    public ProtectedString? FirstName { get; set; }
+
+    [FromQuery(Name = "lastName")]
+    public ProtectedString? LastName { get; set; }
+
+    [FromQuery(Name = "returnPath")]
+    public string? ReturnPath { get; set; }
+    public string? SafeReturnPath { get; set; }
+
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        await UpdateUser(User.GetUserId()!.Value);
+        return Redirect(SafeReturnPath!);
+    }
+
+    private async Task UpdateUser(Guid userId)
+    {
+        var user = await _dbContext.Users.SingleAsync(u => u.UserId == userId);
+
+        var newFirstName = FirstName!.PlainValue;
+        var newLastName = LastName!.PlainValue;
+
+        UserUpdatedEventChanges changes = UserUpdatedEventChanges.None;
+
+        if (user.FirstName != newFirstName)
+        {
+            changes |= UserUpdatedEventChanges.FirstName;
+        }
+
+        if (user.LastName != newLastName)
+        {
+            changes |= UserUpdatedEventChanges.LastName;
+        }
+
+        if (changes != UserUpdatedEventChanges.None)
+        {
+            user.FirstName = newFirstName;
+            user.LastName = newLastName;
+            user.Updated = _clock.UtcNow;
+
+            _dbContext.AddEvent(new UserUpdatedEvent()
+            {
+                Source = UserUpdatedEventSource.ChangedByUser,
+                CreatedUtc = _clock.UtcNow,
+                Changes = changes,
+                User = user,
+                UpdatedByUserId = User.GetUserId()!.Value,
+                UpdatedByClientId = null
+            });
+
+            await _dbContext.SaveChangesAsync();
+
+            await HttpContext.SignInCookies(user, resetIssued: false);
+
+            TempData.SetFlashSuccess("Your name has been updated");
+        }
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        if (FirstName is null || LastName is null)
+        {
+            context.Result = new BadRequestResult();
+            return;
+        }
+
+        SafeReturnPath = !string.IsNullOrEmpty(ReturnPath) && Url.IsLocalUrl(ReturnPath) ? ReturnPath : "/account";
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Index.cshtml
@@ -5,12 +5,12 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@Model.SafeReturnPath" />
+    <govuk-back-link href="@Model.SafeReturnUrl" />
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.AccountName(Model.ReturnPath)" method="post" asp-antiforgery="true">
+        <form action="@LinkGenerator.AccountName(Model.ReturnUrl)" method="post" asp-antiforgery="true">
             <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
 
             <govuk-input asp-for="FirstName" spellcheck="false" autocomplete="given-name">

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Index.cshtml
@@ -1,0 +1,28 @@
+@page "/account/name"
+@model TeacherIdentity.AuthServer.Pages.Account.Name.Name
+@{
+    ViewBag.Title = "Your name";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@Model.SafeReturnPath" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.AccountName(Model.ReturnPath)" method="post" asp-antiforgery="true">
+            <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
+
+            <govuk-input asp-for="FirstName" spellcheck="false" autocomplete="given-name">
+                <govuk-input-label class="govuk-label--s" />
+            </govuk-input>
+
+            <govuk-input asp-for="LastName" spellcheck="false" autocomplete="family-name">
+                <govuk-input-label class="govuk-label--s"/>
+            </govuk-input>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>
+

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Index.cshtml.cs
@@ -1,0 +1,55 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeacherIdentity.AuthServer.Pages.Account.Name;
+
+[BindProperties]
+public class Name : PageModel
+{
+    private IIdentityLinkGenerator _linkGenerator;
+    private readonly ProtectedStringFactory _protectedStringFactory;
+
+    public Name(IIdentityLinkGenerator linkGenerator, ProtectedStringFactory protectedStringFactory)
+    {
+        _linkGenerator = linkGenerator;
+        _protectedStringFactory = protectedStringFactory;
+    }
+
+    [Display(Name = "First name", Description = "Or given names")]
+    [Required(ErrorMessage = "Enter your first name")]
+    [StringLength(200, ErrorMessage = "First name must be 200 characters or less")]
+    public string? FirstName { get; set; }
+
+    [Display(Name = "Last name", Description = "Or family names")]
+    [Required(ErrorMessage = "Enter your last name")]
+    [StringLength(200, ErrorMessage = "Last name must be 200 characters or less")]
+    public string? LastName { get; set; }
+
+    [FromQuery(Name = "returnPath")]
+    public string? ReturnPath { get; set; }
+    public string? SafeReturnPath { get; set; }
+
+    public void OnGet()
+    {
+    }
+
+    public IActionResult OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        var protectedFirstName = _protectedStringFactory.CreateFromPlainValue(FirstName!);
+        var protectedLastName = _protectedStringFactory.CreateFromPlainValue(LastName!);
+
+        return Redirect(_linkGenerator.AccountNameConfirm(protectedFirstName, protectedLastName, ReturnPath));
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        SafeReturnPath = !string.IsNullOrEmpty(ReturnPath) && Url.IsLocalUrl(ReturnPath) ? ReturnPath : "/account";
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Index.cshtml.cs
@@ -27,9 +27,9 @@ public class Name : PageModel
     [StringLength(200, ErrorMessage = "Last name must be 200 characters or less")]
     public string? LastName { get; set; }
 
-    [FromQuery(Name = "returnPath")]
-    public string? ReturnPath { get; set; }
-    public string? SafeReturnPath { get; set; }
+    [FromQuery(Name = "returnUrl")]
+    public string? ReturnUrl { get; set; }
+    public string? SafeReturnUrl { get; set; }
 
     public void OnGet()
     {
@@ -45,11 +45,11 @@ public class Name : PageModel
         var protectedFirstName = _protectedStringFactory.CreateFromPlainValue(FirstName!);
         var protectedLastName = _protectedStringFactory.CreateFromPlainValue(LastName!);
 
-        return Redirect(_linkGenerator.AccountNameConfirm(protectedFirstName, protectedLastName, ReturnPath));
+        return Redirect(_linkGenerator.AccountNameConfirm(protectedFirstName, protectedLastName, ReturnUrl));
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        SafeReturnPath = !string.IsNullOrEmpty(ReturnPath) && Url.IsLocalUrl(ReturnPath) ? ReturnPath : "/account";
+        SafeReturnUrl = !string.IsNullOrEmpty(ReturnUrl) && Url.IsLocalUrl(ReturnUrl) ? ReturnUrl : "/account";
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Name/ConfirmTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Name/ConfirmTests.cs
@@ -1,0 +1,146 @@
+using System.Text.Encodings.Web;
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Account.Name;
+
+public class ConfirmTests : TestBase
+{
+    public ConfirmTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_NoFirstName_ReturnsBadRequest()
+    {
+        // Arrange
+        var lastName = Faker.Name.Last();
+        var protectedLastName = HostFixture.Services.GetRequiredService<ProtectedStringFactory>().CreateFromPlainValue(lastName);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/account/name/confirm?lastName={UrlEncode(protectedLastName.EncryptedValue)}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_NoLastName_ReturnsBadRequest()
+    {
+        var firstName = Faker.Name.First();
+        var protectedFirstName = HostFixture.Services.GetRequiredService<ProtectedStringFactory>().CreateFromPlainValue(firstName);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/account/name/confirm?firstName={UrlEncode(protectedFirstName.EncryptedValue)}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_ReturnsSuccess()
+    {
+        var firstName = Faker.Name.First();
+        var lastName = Faker.Name.Last();
+
+        var protectedFirstName = HostFixture.Services.GetRequiredService<ProtectedStringFactory>().CreateFromPlainValue(firstName);
+        var protectedLastName = HostFixture.Services.GetRequiredService<ProtectedStringFactory>().CreateFromPlainValue(lastName);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/account/name/confirm?firstName={UrlEncode(protectedFirstName.EncryptedValue)}&lastName={UrlEncode(protectedLastName.EncryptedValue)}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_NoFirstName_ReturnsBadRequest()
+    {
+        // Arrange
+        var lastName = Faker.Name.Last();
+        var protectedLastName = HostFixture.Services.GetRequiredService<ProtectedStringFactory>().CreateFromPlainValue(lastName);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/name/confirm?lastName={UrlEncode(protectedLastName.EncryptedValue)}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_NoLastName_ReturnsBadRequest()
+    {
+        var firstName = Faker.Name.First();
+        var protectedFirstName = HostFixture.Services.GetRequiredService<ProtectedStringFactory>().CreateFromPlainValue(firstName);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/name/confirm?firstName={UrlEncode(protectedFirstName.EncryptedValue)}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_ValidForm_UpdatesNameEmitsEventAndRedirects()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default);
+        HostFixture.SetUserId(user.UserId);
+
+        var client = TestClients.Client1;
+        var redirectUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority);
+
+        var returnPath = $"/account?client_id={client.ClientId}&redirect_uri={Uri.EscapeDataString(redirectUri)}";
+
+        var newFirstName = Faker.Name.First();
+        var newLastName = Faker.Name.Last();
+
+        var protectedFirstName = HostFixture.Services.GetRequiredService<ProtectedStringFactory>().CreateFromPlainValue(newFirstName);
+        var protectedLastName = HostFixture.Services.GetRequiredService<ProtectedStringFactory>().CreateFromPlainValue(newLastName);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/name/confirm?firstName={UrlEncode(protectedFirstName.EncryptedValue)}&lastName={UrlEncode(protectedLastName.EncryptedValue)}&returnPath={UrlEncode(returnPath)}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal(returnPath, response.Headers.Location?.OriginalString);
+
+        user = await TestData.WithDbContext(dbContext => dbContext.Users.SingleAsync(u => u.UserId == user.UserId));
+        Assert.Equal(newFirstName, user.FirstName);
+        Assert.Equal(newLastName, user.LastName);
+        Assert.Equal(Clock.UtcNow, user.Updated);
+
+        EventObserver.AssertEventsSaved(
+            e =>
+            {
+                var userUpdatedEvent = Assert.IsType<UserUpdatedEvent>(e);
+                Assert.Equal(Clock.UtcNow, userUpdatedEvent.CreatedUtc);
+                Assert.Equal(UserUpdatedEventSource.ChangedByUser, userUpdatedEvent.Source);
+                Assert.Equal(UserUpdatedEventChanges.FirstName | UserUpdatedEventChanges.LastName, userUpdatedEvent.Changes);
+                Assert.Equal(user.UserId, userUpdatedEvent.User.UserId);
+            });
+
+        var redirectedResponse = await response.FollowRedirect(HttpClient);
+        var redirectedDoc = await redirectedResponse.GetDocument();
+        AssertEx.HtmlDocumentHasFlashSuccess(redirectedDoc, "Your name has been updated");
+    }
+
+    private static string UrlEncode(string value) => UrlEncoder.Default.Encode(value);
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Name/ConfirmTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Name/ConfirmTests.cs
@@ -102,7 +102,7 @@ public class ConfirmTests : TestBase
         var client = TestClients.Client1;
         var redirectUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority);
 
-        var returnPath = $"/account?client_id={client.ClientId}&redirect_uri={Uri.EscapeDataString(redirectUri)}";
+        var returnUrl = $"/account?client_id={client.ClientId}&redirect_uri={Uri.EscapeDataString(redirectUri)}";
 
         var newFirstName = Faker.Name.First();
         var newLastName = Faker.Name.Last();
@@ -110,7 +110,7 @@ public class ConfirmTests : TestBase
         var protectedFirstName = HostFixture.Services.GetRequiredService<ProtectedStringFactory>().CreateFromPlainValue(newFirstName);
         var protectedLastName = HostFixture.Services.GetRequiredService<ProtectedStringFactory>().CreateFromPlainValue(newLastName);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/name/confirm?firstName={UrlEncode(protectedFirstName.EncryptedValue)}&lastName={UrlEncode(protectedLastName.EncryptedValue)}&returnPath={UrlEncode(returnPath)}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/name/confirm?firstName={UrlEncode(protectedFirstName.EncryptedValue)}&lastName={UrlEncode(protectedLastName.EncryptedValue)}&returnUrl={UrlEncode(returnUrl)}")
         {
             Content = new FormUrlEncodedContentBuilder()
         };
@@ -120,7 +120,7 @@ public class ConfirmTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(returnPath, response.Headers.Location?.OriginalString);
+        Assert.Equal(returnUrl, response.Headers.Location?.OriginalString);
 
         user = await TestData.WithDbContext(dbContext => dbContext.Users.SingleAsync(u => u.UserId == user.UserId));
         Assert.Equal(newFirstName, user.FirstName);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Name/NameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Name/NameTests.cs
@@ -91,15 +91,12 @@ public class NameTests : TestBase
     public async Task Post_ValidName_RedirectsToConfirmPage()
     {
         // Arrange
-        var firstName = Faker.Name.First();
-        var lastName = Faker.Name.Last();
-
         var request = new HttpRequestMessage(HttpMethod.Post, $"/account/name")
         {
             Content = new FormUrlEncodedContentBuilder()
             {
-                { "FirstName", firstName },
-                { "LastName", lastName },
+                { "FirstName", Faker.Name.First() },
+                { "LastName", Faker.Name.Last() },
             }
         };
 
@@ -120,15 +117,12 @@ public class NameTests : TestBase
 
         var returnPath = UrlEncoder.Default.Encode($"/account?client_id={client.ClientId}&redirect_uri={Uri.EscapeDataString(redirectUri)}");
 
-        var firstName = Faker.Name.First();
-        var lastName = Faker.Name.Last();
-
         var request = new HttpRequestMessage(HttpMethod.Post, $"/account/name?returnPath={returnPath}")
         {
             Content = new FormUrlEncodedContentBuilder()
             {
-                { "FirstName", firstName },
-                { "LastName", lastName },
+                { "FirstName", Faker.Name.First() },
+                { "LastName", Faker.Name.Last() },
             }
         };
 
@@ -137,7 +131,6 @@ public class NameTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        var thing = response.Headers.Location?.OriginalString;
         Assert.Contains($"returnPath={returnPath}", response.Headers.Location?.OriginalString);
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Name/NameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Name/NameTests.cs
@@ -109,15 +109,15 @@ public class NameTests : TestBase
     }
 
     [Fact]
-    public async Task Post_ValidName_RedirectsToConfirmPageWithCorrectReturnPath()
+    public async Task Post_ValidName_RedirectsToConfirmPageWithCorrectReturnUrl()
     {
         // Arrange
         var client = TestClients.Client1;
         var redirectUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority);
 
-        var returnPath = UrlEncoder.Default.Encode($"/account?client_id={client.ClientId}&redirect_uri={Uri.EscapeDataString(redirectUri)}");
+        var returnUrl = UrlEncoder.Default.Encode($"/account?client_id={client.ClientId}&redirect_uri={Uri.EscapeDataString(redirectUri)}");
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/name?returnPath={returnPath}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/name?returnUrl={returnUrl}")
         {
             Content = new FormUrlEncodedContentBuilder()
             {
@@ -131,6 +131,6 @@ public class NameTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Contains($"returnPath={returnPath}", response.Headers.Location?.OriginalString);
+        Assert.Contains($"returnUrl={returnUrl}", response.Headers.Location?.OriginalString);
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Name/NameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Name/NameTests.cs
@@ -1,0 +1,143 @@
+using System.Text.Encodings.Web;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Account.Name;
+
+public class NameTests : TestBase
+{
+    public NameTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Post_EmptyFirstName_ReturnsError()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/name")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "LastName", Faker.Name.Last() },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "FirstName", "Enter your first name");
+    }
+
+    [Fact]
+    public async Task Post_EmptyLastName_ReturnsError()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/name")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "FirstName", Faker.Name.First() },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "LastName", "Enter your last name");
+    }
+
+    [Fact]
+    public async Task Post_TooLongFirstName_ReturnsError()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/name")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "FirstName", new string('a', 201) },
+                { "LastName", Faker.Name.Last() },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "FirstName", "First name must be 200 characters or less");
+    }
+
+    [Fact]
+    public async Task Post_TooLongLastName_ReturnsError()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/name")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "FirstName", Faker.Name.First() },
+                { "LastName", new string('a', 201) },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "LastName", "Last name must be 200 characters or less");
+    }
+
+    [Fact]
+    public async Task Post_ValidName_RedirectsToConfirmPage()
+    {
+        // Arrange
+        var firstName = Faker.Name.First();
+        var lastName = Faker.Name.Last();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/name")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "FirstName", firstName },
+                { "LastName", lastName },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/account/name/confirm", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_ValidName_RedirectsToConfirmPageWithCorrectReturnPath()
+    {
+        // Arrange
+        var client = TestClients.Client1;
+        var redirectUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority);
+
+        var returnPath = UrlEncoder.Default.Encode($"/account?client_id={client.ClientId}&redirect_uri={Uri.EscapeDataString(redirectUri)}");
+
+        var firstName = Faker.Name.First();
+        var lastName = Faker.Name.Last();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/name?returnPath={returnPath}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "FirstName", firstName },
+                { "LastName", lastName },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        var thing = response.Headers.Location?.OriginalString;
+        Assert.Contains($"returnPath={returnPath}", response.Headers.Location?.OriginalString);
+    }
+}


### PR DESCRIPTION
### Context

We’re adding an account page to ID for a user to change their ID and DQT details.

### Changes proposed in this pull request

Add a new page at /account/name following the design at https://get-an-identity-prototype.herokuapp.com/account/name .
If the request is valid, redirect to /account/name/confirm?returnUrl=<returnUrl> following the designs at https://get-an-identity-prototype.herokuapp.com/account/check-answers .

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
