### PR TITLE
Add account update phone pages

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Events/UserUpdatedEvent.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Events/UserUpdatedEvent.cs
@@ -18,7 +18,8 @@ public enum UserUpdatedEventChanges
     LastName = 1 << 2,
     DateOfBirth = 1 << 3,
     Trn = 1 << 4,
-    TrnLookupStatus = 1 << 5
+    TrnLookupStatus = 1 << 5,
+    MobileNumber = 1 << 6,
 }
 
 public enum UserUpdatedEventSource

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -173,6 +173,20 @@ public static class IdentityLinkGeneratorExtensions
             .SetQueryParam("email", email.EncryptedValue)
             .SetQueryParam("returnUrl", returnUrl);
 
+    public static string AccountPhone(this IIdentityLinkGenerator linkGenerator, string? returnUrl) =>
+        linkGenerator.PageWithAuthenticationJourneyId("/Account/Phone/Index", authenticationJourneyRequired: false)
+            .SetQueryParam("returnUrl", returnUrl);
+
+    public static string AccountPhoneResend(this IIdentityLinkGenerator linkGenerator, ProtectedString mobileNumber, string? returnUrl) =>
+        linkGenerator.PageWithAuthenticationJourneyId("/Account/Phone/Resend", authenticationJourneyRequired: false)
+            .SetQueryParam("mobileNumber", mobileNumber.EncryptedValue)
+            .SetQueryParam("returnUrl", returnUrl);
+
+    public static string AccountPhoneConfirm(this IIdentityLinkGenerator linkGenerator, ProtectedString mobileNumber, string? returnUrl) =>
+        linkGenerator.PageWithAuthenticationJourneyId("/Account/Phone/Confirm", authenticationJourneyRequired: false)
+            .SetQueryParam("mobileNumber", mobileNumber.EncryptedValue)
+            .SetQueryParam("returnUrl", returnUrl);
+
     public static string Cookies(this IIdentityLinkGenerator linkGenerator) =>
         linkGenerator.PageWithAuthenticationJourneyId("/Cookies", authenticationJourneyRequired: false);
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
@@ -79,7 +79,7 @@
                 <govuk-summary-list-row-key>Mobile number</govuk-summary-list-row-key>
                 <govuk-summary-list-row-value>@Model.MobileNumber</govuk-summary-list-row-value>
                 <govuk-summary-list-row-actions>
-                    <govuk-summary-list-row-action href="#" visually-hidden-text="mobile number">Change</govuk-summary-list-row-action>
+                    <govuk-summary-list-row-action href="@LinkGenerator.AccountPhone(returnUrl)" visually-hidden-text="mobile number">Change</govuk-summary-list-row-action>
                 </govuk-summary-list-row-actions>
             </govuk-summary-list-row>
         </govuk-summary-list>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Confirm.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Confirm.cshtml
@@ -1,0 +1,32 @@
+@page "/account/phone/confirm"
+@model TeacherIdentity.AuthServer.Pages.Account.Phone.Confirm
+@{
+    ViewBag.Title = "Confirm change";
+
+}
+
+@section BeforeContent
+{
+    <govuk-back-link href="@LinkGenerator.AccountPhone(Model.ReturnUrl)" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.AccountPhoneConfirm(Model.MobileNumber!, Model.ReturnUrl)" method="post" asp-antiforgery="true">
+            <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
+
+            <p>We’ve sent you a text message with a security code to <b data-testid="mobileNumber">@Model.MobileNumber!.PlainValue</b></p>
+
+            <govuk-input asp-for="Code" input-class="govuk-!-width-one-quarter" pattern="[0-9]*" inputmode="numeric" autocomplete="one-time-code">
+                <govuk-input-label class="govuk-label--s" />
+            </govuk-input>
+
+            <p>
+                <a href="@LinkGenerator.AccountPhoneResend(Model.MobileNumber!, Model.ReturnUrl)">I have not received an text message</a>
+            </p>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>
+

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Confirm.cshtml.cs
@@ -1,0 +1,116 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Pages.Common;
+using TeacherIdentity.AuthServer.Services.UserVerification;
+
+namespace TeacherIdentity.AuthServer.Pages.Account.Phone;
+
+public class Confirm : BasePinVerificationPageModel
+{
+    private TeacherIdentityServerDbContext _dbContext;
+    private IClock _clock;
+
+    public Confirm(
+        IUserVerificationService userVerificationService,
+        PinValidator pinValidator,
+        TeacherIdentityServerDbContext dbContext,
+        IClock clock) :
+        base(userVerificationService, pinValidator)
+    {
+        _dbContext = dbContext;
+        _clock = clock;
+    }
+
+    [BindProperty]
+    [Display(Name = "Confirmation code")]
+    public override string? Code { get; set; }
+
+    [FromQuery(Name = "mobileNumber")]
+    public ProtectedString? MobileNumber { get; set; }
+
+    [FromQuery(Name = "returnUrl")]
+    public string? ReturnUrl { get; set; }
+    public string? SafeReturnUrl { get; set; }
+
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        Code = Code?.Trim();
+        ValidateCode();
+
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        var smsPinFailedReasons = await UserVerificationService.VerifySmsPin(MobileNumber!.PlainValue, Code!);
+
+        if (smsPinFailedReasons != PinVerificationFailedReasons.None)
+        {
+            return await HandlePinVerificationFailed(smsPinFailedReasons);
+        }
+
+        await UpdateUserPhone(User.GetUserId()!.Value);
+        return Redirect(SafeReturnUrl!);
+    }
+
+    private async Task UpdateUserPhone(Guid userId)
+    {
+        var user = await _dbContext.Users.SingleAsync(u => u.UserId == userId);
+
+        var newMobileNumber = MobileNumber!.PlainValue;
+
+        UserUpdatedEventChanges changes = UserUpdatedEventChanges.None;
+
+        if (user.MobileNumber != newMobileNumber)
+        {
+            changes |= UserUpdatedEventChanges.MobileNumber;
+        }
+
+        if (changes != UserUpdatedEventChanges.None)
+        {
+            user.MobileNumber = newMobileNumber;
+            user.Updated = _clock.UtcNow;
+
+            _dbContext.AddEvent(new UserUpdatedEvent()
+            {
+                Source = UserUpdatedEventSource.ChangedByUser,
+                CreatedUtc = _clock.UtcNow,
+                Changes = changes,
+                User = user,
+                UpdatedByUserId = User.GetUserId()!.Value,
+                UpdatedByClientId = null
+            });
+
+            await _dbContext.SaveChangesAsync();
+
+            await HttpContext.SignInCookies(user, resetIssued: false);
+
+            TempData.SetFlashSuccess("Your mobile number has been updated");
+        }
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        if (MobileNumber is null)
+        {
+            context.Result = new BadRequestResult();
+            return;
+        }
+
+        SafeReturnUrl = !string.IsNullOrEmpty(ReturnUrl) && Url.IsLocalUrl(ReturnUrl) ? ReturnUrl : "/account";
+    }
+
+    protected override Task<PinGenerationResult> GeneratePin()
+    {
+        return UserVerificationService.GenerateSmsPin(MobileNumber!.PlainValue);
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Index.cshtml
@@ -1,0 +1,26 @@
+@page "/account/phone"
+@model TeacherIdentity.AuthServer.Pages.Account.Phone.PhonePage
+@{
+    ViewBag.Title = "Your mobile number";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@Model.SafeReturnUrl" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.AccountPhone(Model.ReturnUrl)" method="post" asp-antiforgery="true">
+            <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
+
+            <p>We’ll send a security code to this number by text message.</p>
+
+            <govuk-input asp-for="MobileNumber" type="tel" autocomplete="tel">
+                <govuk-input-label class="govuk-label--s" />
+            </govuk-input>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>
+

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Index.cshtml.cs
@@ -1,0 +1,69 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Pages.Common;
+using TeacherIdentity.AuthServer.Services.UserVerification;
+
+namespace TeacherIdentity.AuthServer.Pages.Account.Phone;
+
+[BindProperties]
+public class PhonePage : BasePhonePageModel
+{
+    private readonly ProtectedStringFactory _protectedStringFactory;
+    private IIdentityLinkGenerator _linkGenerator;
+
+    public PhonePage(
+        IUserVerificationService userVerificationService,
+        IIdentityLinkGenerator linkGenerator,
+        TeacherIdentityServerDbContext dbContext,
+        ProtectedStringFactory protectedStringFactory) :
+        base(userVerificationService, dbContext)
+    {
+        _linkGenerator = linkGenerator;
+        _protectedStringFactory = protectedStringFactory;
+    }
+
+    [Display(Name = "Mobile number", Description = "For international numbers include the country code")]
+    [Required(ErrorMessage = "Enter your new mobile phone number")]
+    [Phone(ErrorMessage = "Enter a valid mobile phone number")]
+    public new string? MobileNumber { get; set; }
+
+    [FromQuery(Name = "returnUrl")]
+    public string? ReturnUrl { get; set; }
+    public string? SafeReturnUrl { get; set; }
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        if (await MobileNumberExists(MobileNumber!))
+        {
+            ModelState.AddModelError(nameof(MobileNumber), "This mobile phone number is already in use - Enter a different mobile phone number");
+            return this.PageWithErrors();
+        }
+
+        var smsPinGenerationResult = await GenerateSmsPinForNewPhone(MobileNumber!);
+
+        if (!smsPinGenerationResult.Success)
+        {
+            return smsPinGenerationResult.Result!;
+        }
+
+        var protectedMobileNumber = _protectedStringFactory.CreateFromPlainValue(MobileNumber!);
+
+        return Redirect(_linkGenerator.AccountPhoneConfirm(protectedMobileNumber, ReturnUrl));
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        SafeReturnUrl = !string.IsNullOrEmpty(ReturnUrl) && Url.IsLocalUrl(ReturnUrl) ? ReturnUrl : "/account";
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Resend.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Resend.cshtml
@@ -1,16 +1,16 @@
-@page "/sign-in/register/resend-phone-confirmation"
-@model TeacherIdentity.AuthServer.Pages.SignIn.Register.ResendPhoneConfirmationModel
+@page "/account/phone/resend"
+@model TeacherIdentity.AuthServer.Pages.Account.Phone.Resend
 @{
     ViewBag.Title = "Request a new security code";
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.RegisterPhoneConfirmation()" />
+    <govuk-back-link href="@LinkGenerator.AccountPhoneConfirm(Model.MobileNumber!, Model.ReturnUrl)" />
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.RegisterResendPhoneConfirmation()" method="post" asp-antiforgery="true">
+        <form action="@LinkGenerator.AccountPhoneResend(Model.MobileNumber!, Model.ReturnUrl)" method="post" asp-antiforgery="true">
             <h1 class="govuk-heading-xl">Send new text message</h1>
 
             <p>Text messages sometimes take a few minutes to arrive. If you do not receive the text message, you can request a new one.</p>
@@ -18,11 +18,11 @@
             <govuk-details open="@(!ModelState.IsValid)">
                 <govuk-details-summary>Change where the text message is sent</govuk-details-summary>
                 <govuk-details-text>
-                    <govuk-input asp-for="MobileNumber" type="tel" autocomplete="tel" />
+                    <govuk-input asp-for="NewMobileNumber" type="tel" autocomplete="tel" />
                 </govuk-details-text>
             </govuk-details>
 
-            <govuk-button type="submit">Request a new code</govuk-button>
+            <govuk-button type="submit">Request security code</govuk-button>
         </form>
     </div>
 </div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Resend.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Resend.cshtml.cs
@@ -1,0 +1,75 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Pages.Common;
+using TeacherIdentity.AuthServer.Services.UserVerification;
+
+namespace TeacherIdentity.AuthServer.Pages.Account.Phone;
+
+public class Resend : BasePhonePageModel
+{
+    private ProtectedStringFactory _protectedStringFactory;
+    private IIdentityLinkGenerator _linkGenerator;
+
+    public Resend(
+        IUserVerificationService userVerificationService,
+        IIdentityLinkGenerator linkGenerator,
+        TeacherIdentityServerDbContext dbContext,
+        ProtectedStringFactory protectedStringFactory) :
+        base(userVerificationService, dbContext)
+    {
+        _linkGenerator = linkGenerator;
+        _protectedStringFactory = protectedStringFactory;
+    }
+
+    [BindProperty]
+    [Display(Name = "Mobile number")]
+    [Required(ErrorMessage = "Enter your new mobile phone number")]
+    [Phone(ErrorMessage = "Enter a valid mobile phone number")]
+    public string? NewMobileNumber { get; set; }
+
+    [FromQuery(Name = "mobileNumber")]
+    public new ProtectedString? MobileNumber { get; set; }
+
+    [FromQuery(Name = "returnUrl")]
+    public string? ReturnUrl { get; set; }
+
+    public void OnGet()
+    {
+        NewMobileNumber = MobileNumber!.PlainValue;
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        if (await MobileNumberExists(NewMobileNumber!))
+        {
+            ModelState.AddModelError(nameof(NewMobileNumber), "This mobile phone number is already in use - Enter a different mobile phone number");
+            return this.PageWithErrors();
+        }
+
+        var smsPinGenerationResult = await GenerateSmsPinForNewPhone(NewMobileNumber!, nameof(NewMobileNumber));
+
+        if (!smsPinGenerationResult.Success)
+        {
+            return smsPinGenerationResult.Result!;
+        }
+
+        var protectedMobileNumber = _protectedStringFactory.CreateFromPlainValue(NewMobileNumber!);
+
+        return Redirect(_linkGenerator.AccountPhoneConfirm(protectedMobileNumber, ReturnUrl));
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        if (MobileNumber is null)
+        {
+            context.Result = new BadRequestResult();
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Phone.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Phone.cshtml.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Pages.Common;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
@@ -11,8 +12,9 @@ public class Phone : BasePhonePageModel
 
     public Phone(
         IUserVerificationService userVerificationService,
-        IIdentityLinkGenerator linkGenerator) :
-        base(userVerificationService)
+        IIdentityLinkGenerator linkGenerator,
+        TeacherIdentityServerDbContext dbContext) :
+        base(userVerificationService, dbContext)
     {
         _linkGenerator = linkGenerator;
     }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendPhoneConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendPhoneConfirmation.cshtml.cs
@@ -1,5 +1,6 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
+using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Pages.Common;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 
@@ -11,8 +12,9 @@ public class ResendPhoneConfirmationModel : BasePhonePageModel
 
     public ResendPhoneConfirmationModel(
         IUserVerificationService userVerificationService,
-        IIdentityLinkGenerator linkGenerator) :
-        base(userVerificationService)
+        IIdentityLinkGenerator linkGenerator,
+        TeacherIdentityServerDbContext dbContext) :
+        base(userVerificationService, dbContext)
     {
         _linkGenerator = linkGenerator;
     }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Phone/ConfirmTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Phone/ConfirmTests.cs
@@ -1,0 +1,291 @@
+using System.Text.Encodings.Web;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Services.UserVerification;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Account.Phone;
+
+public class ConfirmTests : TestBase
+{
+    public ConfirmTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_NoPhone_ReturnsBadRequest()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/account/phone/confirm");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_ReturnsSuccess()
+    {
+        var mobileNumber = Faker.Phone.Number();
+        var protectedMobileNumber = HostFixture.Services.GetRequiredService<ProtectedStringFactory>().CreateFromPlainValue(mobileNumber);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/account/phone/confirm?mobileNumber={UrlEncode(protectedMobileNumber.EncryptedValue)}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_NoPhone_ReturnsBadRequest()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/phone/confirm");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_UnknownPin_ReturnsError()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default);
+        HostFixture.SetUserId(user.UserId);
+
+        var newMobileNumber = Faker.Phone.Number();
+
+        // The real PIN generation service never generates pins that start with a '0'
+        var pin = "01234";
+
+        var protectedMobilePhone = HostFixture.Services.GetRequiredService<ProtectedStringFactory>().CreateFromPlainValue(newMobileNumber);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/phone/confirm?mobileNumber={UrlEncode(protectedMobilePhone.EncryptedValue)}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pin }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Code", "Enter a correct security code");
+    }
+
+    [Fact]
+    public async Task Post_PinTooShort_ReturnsError()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default);
+        HostFixture.SetUserId(user.UserId);
+
+        var newMobileNumber = Faker.Phone.Number();
+        var pin = "0";
+
+        var protectedMobileNumber = HostFixture.Services.GetRequiredService<ProtectedStringFactory>().CreateFromPlainValue(newMobileNumber);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/phone/confirm?mobileNumber={UrlEncode(protectedMobileNumber.EncryptedValue)}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pin }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Code", "You’ve not entered enough numbers, the code must be 5 numbers");
+    }
+
+    [Fact]
+    public async Task Post_PinTooLong_ReturnsError()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default);
+        HostFixture.SetUserId(user.UserId);
+
+        var newMobileNumber = Faker.Phone.Number();
+        var pin = "0123345678";
+
+        var protectedMobileNumber = HostFixture.Services.GetRequiredService<ProtectedStringFactory>().CreateFromPlainValue(newMobileNumber);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/phone/confirm?mobileNumber={UrlEncode(protectedMobileNumber.EncryptedValue)}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pin }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Code", "You’ve entered too many numbers, the code must be 5 numbers");
+    }
+
+    [Fact]
+    public async Task Post_NonNumericPin_ReturnsError()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default);
+        HostFixture.SetUserId(user.UserId);
+
+        var newMobileNumber = Faker.Phone.Number();
+        var pin = "abc";
+
+        var protectedMobileNumber = HostFixture.Services.GetRequiredService<ProtectedStringFactory>().CreateFromPlainValue(newMobileNumber);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/phone/confirm?mobileNumber={UrlEncode(protectedMobileNumber.EncryptedValue)}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pin }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Code", "The code must be 5 numbers");
+    }
+
+    [Fact]
+    public async Task Post_PinExpiredLessThanTwoHoursAgo_ReturnsErrorAndSendsANewPin()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default);
+        HostFixture.SetUserId(user.UserId);
+
+        var newMobileNumber = Faker.Phone.Number();
+        var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
+        var pinResult = await userVerificationService.GenerateSmsPin(newMobileNumber);
+
+        Assert.True(pinResult.Succeeded);
+        Clock.AdvanceBy(TimeSpan.FromHours(1));
+        SpyRegistry.Get<IUserVerificationService>().Reset();
+
+        var protectedMobileNumber = HostFixture.Services.GetRequiredService<ProtectedStringFactory>().CreateFromPlainValue(newMobileNumber);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/phone/confirm?mobileNumber={UrlEncode(protectedMobileNumber.EncryptedValue)}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pinResult.Pin! }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Code", "The security code has expired. New code sent.");
+
+        HostFixture.UserVerificationService.Verify(mock => mock.GenerateSmsPin(newMobileNumber), Times.Once);
+    }
+
+    [Fact]
+    public async Task Post_PinExpiredMoreThanTwoHoursAgo_ReturnsErrorAndDoesNotSendANewPin()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default);
+        HostFixture.SetUserId(user.UserId);
+
+        var newMobileNumber = Faker.Phone.Number();
+        var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
+        var userVerificationOptions = HostFixture.Services.GetRequiredService<IOptions<UserVerificationOptions>>();
+        var pinResult = await userVerificationService.GenerateSmsPin(newMobileNumber);
+
+        Assert.True(pinResult.Succeeded);
+        Clock.AdvanceBy(TimeSpan.FromHours(2) + TimeSpan.FromSeconds(userVerificationOptions.Value.PinLifetimeSeconds));
+        SpyRegistry.Get<IUserVerificationService>().Reset();
+
+        var protectedMobileNumber = HostFixture.Services.GetRequiredService<ProtectedStringFactory>().CreateFromPlainValue(newMobileNumber);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/phone/confirm?mobileNumber={UrlEncode(protectedMobileNumber.EncryptedValue)}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pinResult.Pin! }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "Code", "Enter a correct security code");
+
+        HostFixture.UserVerificationService.Verify(mock => mock.GenerateSmsPin(newMobileNumber), Times.Never);
+    }
+
+    [Fact]
+    public async Task Post_ValidForm_UpdatesNameEmitsEventAndRedirects()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default);
+        HostFixture.SetUserId(user.UserId);
+
+        var client = TestClients.Client1;
+        var redirectUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority);
+
+        var returnUrl = $"/account?client_id={client.ClientId}&redirect_uri={Uri.EscapeDataString(redirectUri)}";
+
+        var newMobileNumber = Faker.Phone.Number();
+        var protectedMobileNumber = HostFixture.Services.GetRequiredService<ProtectedStringFactory>().CreateFromPlainValue(newMobileNumber);
+
+        var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
+        var pinResult = await userVerificationService.GenerateSmsPin(newMobileNumber);
+        Assert.True(pinResult.Succeeded);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/phone/confirm?mobileNumber={UrlEncode(protectedMobileNumber.EncryptedValue)}&returnUrl={UrlEncode(returnUrl)}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pinResult.Pin! },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal(returnUrl, response.Headers.Location?.OriginalString);
+
+        user = await TestData.WithDbContext(dbContext => dbContext.Users.SingleAsync(u => u.UserId == user.UserId));
+        Assert.Equal(newMobileNumber, user.MobileNumber);
+        Assert.Equal(Clock.UtcNow, user.Updated);
+
+        EventObserver.AssertEventsSaved(
+            e =>
+            {
+                var userUpdatedEvent = Assert.IsType<UserUpdatedEvent>(e);
+                Assert.Equal(Clock.UtcNow, userUpdatedEvent.CreatedUtc);
+                Assert.Equal(UserUpdatedEventSource.ChangedByUser, userUpdatedEvent.Source);
+                Assert.Equal(UserUpdatedEventChanges.MobileNumber, userUpdatedEvent.Changes);
+                Assert.Equal(user.UserId, userUpdatedEvent.User.UserId);
+            });
+
+        var redirectedResponse = await response.FollowRedirect(HttpClient);
+        var redirectedDoc = await redirectedResponse.GetDocument();
+        AssertEx.HtmlDocumentHasFlashSuccess(redirectedDoc, "Your mobile number has been updated");
+    }
+
+    private static string UrlEncode(string value) => UrlEncoder.Default.Encode(value);
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Phone/PhoneTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Phone/PhoneTests.cs
@@ -1,0 +1,187 @@
+using System.Text.Encodings.Web;
+using TeacherIdentity.AuthServer.Helpers;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Tests.Infrastructure;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Account.Phone;
+
+public class PhoneTests : TestBase
+{
+    public PhoneTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Post_EmptyMobileNumber_ReturnsError()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Post, "/account/phone")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "MobileNumber", "Enter your new mobile phone number");
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidPhoneData))]
+    public async Task Post_InvalidMobileNumber_RendersError(string newMobileNumber, string expectedErrorMessage)
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default);
+        HostFixture.SetUserId(user.UserId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/phone")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "MobileNumber", newMobileNumber }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "MobileNumber", expectedErrorMessage);
+    }
+
+    [Fact]
+    public async Task Post_MobileNumberInUse_RendersError()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default);
+        HostFixture.SetUserId(user.UserId);
+
+        var anotherUser = await TestData.CreateUser();
+        var newMobileNumber = anotherUser.MobileNumber;
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/phone")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "MobileNumber", newMobileNumber! }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "MobileNumber", "This mobile phone number is already in use - Enter a different mobile phone number");
+    }
+
+    [Fact]
+    public async Task Post_MobileNumberMatchesCurrentMobileNumber_DoesNotProduceError()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default);
+        HostFixture.SetUserId(user.UserId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/phone")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "MobileNumber", user.MobileNumber! }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.True((int)response.StatusCode < 400);
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_GeneratesPinAndRedirects()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default);
+        HostFixture.SetUserId(user.UserId);
+
+        var newMobileNumber = Faker.Phone.Number();
+        var formattedMobileNumber = PhoneHelper.FormatMobileNumber(newMobileNumber);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/phone")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "MobileNumber", newMobileNumber }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith($"/account/phone/confirm", response.Headers.Location?.OriginalString);
+
+        HostFixture.UserVerificationService.Verify(mock => mock.GenerateSmsPin(formattedMobileNumber), Times.Once);
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_RedirectsWithCorrectReturnUrl()
+    {
+        // Arrange
+        var client = TestClients.Client1;
+        var redirectUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority);
+
+        var returnUrl = UrlEncoder.Default.Encode($"/account?client_id={client.ClientId}&redirect_uri={Uri.EscapeDataString(redirectUri)}");
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/phone?returnUrl={returnUrl}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "MobileNumber", Faker.Phone.Number() },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Contains($"returnUrl={returnUrl}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_PinGenerationRateLimitedExceeded_ReturnsTooManyRequests()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default);
+        HostFixture.SetUserId(user.UserId);
+
+        HostFixture.RateLimitStore
+            .Setup(x => x.IsClientIpBlockedForPinGeneration(TestRequestClientIpProvider.ClientIpAddress))
+            .ReturnsAsync(true);
+
+        var newMobileNumber = Faker.Phone.Number();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/phone")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "MobileNumber", newMobileNumber }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status429TooManyRequests, (int)response.StatusCode);
+    }
+
+    public static TheoryData<string, string> InvalidPhoneData { get; } = new()
+    {
+        { "", "Enter your new mobile phone number" },
+        { "xx", "Enter a valid mobile phone number" }
+    };
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Phone/ResendTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Phone/ResendTests.cs
@@ -1,0 +1,190 @@
+using System.Text.Encodings.Web;
+using TeacherIdentity.AuthServer.Helpers;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Tests.Infrastructure;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Account.Phone;
+
+public class ResendTests : TestBase
+{
+    private readonly ProtectedString _mobileNumber;
+
+    public ResendTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+        _mobileNumber = HostFixture.Services.GetRequiredService<ProtectedStringFactory>().CreateFromPlainValue(Faker.Phone.Number());
+    }
+
+    [Fact]
+    public async Task Post_EmptyMobileNumber_ReturnsError()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/phone/resend?mobileNumber={_mobileNumber}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "NewMobileNumber", "Enter your new mobile phone number");
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidPhoneData))]
+    public async Task Post_InvalidMobileNumber_RendersError(string newMobileNumber, string expectedErrorMessage)
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default);
+        HostFixture.SetUserId(user.UserId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/phone/resend?mobileNumber={_mobileNumber}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "NewMobileNumber", newMobileNumber }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "NewMobileNumber", expectedErrorMessage);
+    }
+
+    [Fact]
+    public async Task Post_MobileNumberInUse_RendersError()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default);
+        HostFixture.SetUserId(user.UserId);
+
+        var anotherUser = await TestData.CreateUser();
+        var newMobileNumber = anotherUser.MobileNumber;
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/phone/resend?mobileNumber={_mobileNumber}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "NewMobileNumber", newMobileNumber! }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "NewMobileNumber", "This mobile phone number is already in use - Enter a different mobile phone number");
+    }
+
+    [Fact]
+    public async Task Post_MobileNumberMatchesCurrentMobileNumber_DoesNotProduceError()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default);
+        HostFixture.SetUserId(user.UserId);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/phone/resend?mobileNumber={_mobileNumber}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "NewMobileNumber", user.MobileNumber! }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.True((int)response.StatusCode < 400);
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_GeneratesPinAndRedirects()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default);
+        HostFixture.SetUserId(user.UserId);
+
+        var newMobileNumber = Faker.Phone.Number();
+        var formattedMobileNumber = PhoneHelper.FormatMobileNumber(newMobileNumber);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/phone/resend?mobileNumber={_mobileNumber}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "NewMobileNumber", newMobileNumber }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/account/phone/confirm", response.Headers.Location?.OriginalString);
+
+        HostFixture.UserVerificationService.Verify(mock => mock.GenerateSmsPin(formattedMobileNumber), Times.Once);
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_RedirectsWithCorrectReturnUrl()
+    {
+        // Arrange
+        var client = TestClients.Client1;
+        var redirectUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority);
+
+        var returnUrl = UrlEncoder.Default.Encode($"/account?client_id={client.ClientId}&redirect_uri={Uri.EscapeDataString(redirectUri)}");
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/phone/resend?mobileNumber={_mobileNumber}&returnUrl={returnUrl}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "NewMobileNumber", Faker.Phone.Number() },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Contains($"returnUrl={returnUrl}", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_PinGenerationRateLimitedExceeded_ReturnsTooManyRequests()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default);
+        HostFixture.SetUserId(user.UserId);
+
+        HostFixture.RateLimitStore
+            .Setup(x => x.IsClientIpBlockedForPinGeneration(TestRequestClientIpProvider.ClientIpAddress))
+            .ReturnsAsync(true);
+
+        var newMobileNumber = Faker.Phone.Number();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/phone/resend?mobileNumber={_mobileNumber}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "NewMobileNumber", newMobileNumber }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status429TooManyRequests, (int)response.StatusCode);
+    }
+
+    public static TheoryData<string, string> InvalidPhoneData { get; } = new()
+    {
+        { "", "Enter your new mobile phone number" },
+        { "xx", "Enter a valid mobile phone number" }
+    };
+}


### PR DESCRIPTION
### Context

We’re adding an account page to ID for a user to change their ID and DQT details.

### Changes proposed in this pull request

Add a new page at /account/phone following the design at https://get-an-identity-prototype.herokuapp.com/account/phone

If the user clicks ‘I have not received an text message', redirect to /account/phone/resend-confirmation. This page should follow the design at https://get-an-identity-prototype.herokuapp.com/auth/resend-phone

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
