### PR TITLE
Update account page for DQT DOB conflict

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
@@ -78,7 +78,7 @@
                         <p class="govuk-hint govuk-!-font-size-14">Date of birth already in our records</p>
                     </govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="#" visually-hidden-text="dqt date of birth">Change</govuk-summary-list-row-action>
+                        <govuk-summary-list-row-action href="#" visually-hidden-text="date of birth">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
             }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
@@ -5,6 +5,7 @@
     ViewBag.Title = "DfE Identity account";
 
     var returnUrl = Request.GetUri().PathAndQuery;
+    var dateOfBirthConflict = Model.DqtDateOfBirth is not null && !Model.DqtDateOfBirth.Equals(Model.DateOfBirth);
 }
 
 @section BeforeContent
@@ -21,6 +22,15 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
+        @if (dateOfBirthConflict)
+        {
+            <govuk-notification-banner data-testid="dob-conflict-notification-banner">
+                <h3 class="govuk-notification-banner__heading">Confirm your correct date of birth</h3>
+                <p>We’ve got two different dates of birth for you. The one you entered when you created your DfE Identity
+                    account is different to the one already in our records. Change the incorrect date of birth.</p>
+            </govuk-notification-banner>
+        }
+
         <span class="govuk-caption-xl">DfE Identity account</span>
         <h1 class="govuk-heading-xl">Your details</h1>
 
@@ -48,11 +58,30 @@
             }
             <govuk-summary-list-row>
                 <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
-                <govuk-summary-list-row-value>@Model.DateOfBirth?.ToString("dd MMMM yyyy")</govuk-summary-list-row-value>
+                <govuk-summary-list-row-value>
+                    @Model.DateOfBirth?.ToString("dd MMMM yyyy")
+                    @if (dateOfBirthConflict)
+                    {
+                        <p class="govuk-hint govuk-!-font-size-14">Entered when creating account</p>
+                    }
+                </govuk-summary-list-row-value>
                 <govuk-summary-list-row-actions>
                     <govuk-summary-list-row-action href="#" visually-hidden-text="date of birth">Change</govuk-summary-list-row-action>
                 </govuk-summary-list-row-actions>
             </govuk-summary-list-row>
+            @if (dateOfBirthConflict)
+            {
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>
+                        @Model.DqtDateOfBirth?.ToString("dd MMMM yyyy")
+                        <p class="govuk-hint govuk-!-font-size-14">Date of birth already in our records</p>
+                    </govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="#" visually-hidden-text="dqt date of birth">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+            }
         </govuk-summary-list>
 
         @if (Model.Trn is not null)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml.cs
@@ -39,6 +39,7 @@ public class IndexModel : PageModel
     public string? Email { get; set; }
     public string? MobileNumber { get; set; }
     public string? Trn { get; set; }
+    public DateOnly? DqtDateOfBirth { get; set; }
 
     public async Task OnGet()
     {
@@ -69,6 +70,7 @@ public class IndexModel : PageModel
                 throw new Exception($"User with TRN '{Trn}' cannot be found in DQT.");
 
             OfficialName = $"{dqtUser.FirstName} {dqtUser.LastName}";
+            DqtDateOfBirth = dqtUser.DateOfBirth;
         }
     }
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AngleSharpExtensions.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AngleSharpExtensions.cs
@@ -45,6 +45,24 @@ public static class AngleSharpExtensions
         return row?.QuerySelectorAll(".govuk-summary-list__actions>*").ToArray() ?? Array.Empty<IElement>();
     }
 
+    public static int GetSummaryListRowCountForKey(this IHtmlDocument doc, string key)
+    {
+        var count = 0;
+        var allRows = doc.QuerySelectorAll(".govuk-summary-list__row");
+
+        foreach (var row in allRows)
+        {
+            var rowKey = row.QuerySelector(".govuk-summary-list__key");
+
+            if (rowKey?.TextContent.Trim() == key)
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+
     public static IElement? GetSummaryListRowForKey(this IHtmlDocument doc, string key)
     {
         var allRows = doc.QuerySelectorAll(".govuk-summary-list__row");

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/IndexTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/IndexTests.cs
@@ -163,6 +163,66 @@ public class IndexTests : TestBase
     }
 
     [Fact]
+    public async Task Get_ValidRequestForUserWithoutDobConflict_DoesNotShowNotificationBanner()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(hasTrn: true);
+        HostFixture.SetUserId(user.UserId);
+
+        HostFixture.DqtApiClient
+            .Setup(mock => mock.GetTeacherByTrn(user.Trn!, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TeacherInfo()
+            {
+                DateOfBirth = user.DateOfBirth!.Value,
+                FirstName = Faker.Name.First(),
+                LastName = Faker.Name.Last(),
+                NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber(),
+                Trn = user.Trn!
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/account");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await response.GetDocument();
+
+        Assert.Null(doc.GetElementByTestId("dob-conflict-notification-banner"));
+        Assert.Equal(1, doc.GetSummaryListRowCountForKey("Date of birth"));
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestForUserWithDobConflict_DoesShowNotificationBannerAndDqtDobRow()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(hasTrn: true);
+        HostFixture.SetUserId(user.UserId);
+
+        HostFixture.DqtApiClient
+            .Setup(mock => mock.GetTeacherByTrn(user.Trn!, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TeacherInfo()
+            {
+                DateOfBirth = user.DateOfBirth!.Value.AddDays(1),
+                FirstName = Faker.Name.First(),
+                LastName = Faker.Name.Last(),
+                NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber(),
+                Trn = user.Trn!
+            });
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/account");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await response.GetDocument();
+
+        Assert.NotNull(doc.GetElementByTestId("dob-conflict-notification-banner"));
+        Assert.Equal(2, doc.GetSummaryListRowCountForKey("Date of birth"));
+    }
+
+    [Fact]
     public async Task Get_ValidRequestWithClientIdAndRedirectUri_RendersBackLinks()
     {
         // Arrange


### PR DESCRIPTION
### Context

The Identity Account page is where a user can update both their ID details and their DQT details. We need to call out when the DOB in ID and DQT are different.

### Changes proposed in this pull request

For user accounts that have a TRN, if the DQT DOB is different to the ID DOB, show a message at the top of the page, as per the design. In addition, show an extra DOB row in the summary list that shows the DQT DOB. Both DOB rows should have hint text, as per the design.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
