### PR TITLE
Add pending review tags for account details under review

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
@@ -22,7 +22,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        @if (dateOfBirthConflict)
+        @if (dateOfBirthConflict && !Model.PendingDqtDateOfBirthChange)
         {
             <govuk-notification-banner data-testid="dob-conflict-notification-banner">
                 <h3 class="govuk-notification-banner__heading">Confirm your correct date of birth</h3>
@@ -47,13 +47,24 @@
             {
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Official name</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value>
-                        @Model.OfficialName
-                        <p class="govuk-hint govuk-!-font-size-14">Displayed on teaching certificates </p>
-                    </govuk-summary-list-row-value>
-                    <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="#" visually-hidden-text="official name">Change</govuk-summary-list-row-action>
-                    </govuk-summary-list-row-actions>
+                    @if (Model.PendingDqtNameChange)
+                    {
+                        <govuk-summary-list-row-value>
+                            @Model.OfficialName
+                            <p class="govuk-hint govuk-!-font-size-14">Displayed on teaching certificates </p>
+                            <govuk-tag class="govuk-tag--yellow" data-testid="name-pending-review-tag">PENDING REVIEW</govuk-tag>
+                        </govuk-summary-list-row-value>
+                    }
+                    else
+                    {
+                        <govuk-summary-list-row-value>
+                            @Model.OfficialName
+                            <p class="govuk-hint govuk-!-font-size-14">Displayed on teaching certificates </p>
+                        </govuk-summary-list-row-value>
+                        <govuk-summary-list-row-actions>
+                            <govuk-summary-list-row-action href="#" visually-hidden-text="official name">Change</govuk-summary-list-row-action>
+                        </govuk-summary-list-row-actions>
+                    }
                 </govuk-summary-list-row>
             }
             <govuk-summary-list-row>
@@ -73,13 +84,24 @@
             {
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value>
-                        @Model.DqtDateOfBirth?.ToString("dd MMMM yyyy")
-                        <p class="govuk-hint govuk-!-font-size-14">Date of birth already in our records</p>
-                    </govuk-summary-list-row-value>
-                    <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="#" visually-hidden-text="date of birth">Change</govuk-summary-list-row-action>
-                    </govuk-summary-list-row-actions>
+                    @if (Model.PendingDqtDateOfBirthChange)
+                    {
+                        <govuk-summary-list-row-value>
+                            @Model.DqtDateOfBirth?.ToString("dd MMMM yyyy")
+                            <p class="govuk-hint govuk-!-font-size-14">Date of birth already in our records</p>
+                            <govuk-tag class="govuk-tag--yellow" data-testid="dob-pending-review-tag">PENDING REVIEW</govuk-tag>
+                        </govuk-summary-list-row-value>
+                    }
+                    else
+                    {
+                        <govuk-summary-list-row-value>
+                            @Model.DqtDateOfBirth?.ToString("dd MMMM yyyy")
+                            <p class="govuk-hint govuk-!-font-size-14">Date of birth already in our records</p>
+                        </govuk-summary-list-row-value>
+                        <govuk-summary-list-row-actions>
+                            <govuk-summary-list-row-action href="#" visually-hidden-text="date of birth">Change</govuk-summary-list-row-action>
+                        </govuk-summary-list-row-actions>
+                    }
                 </govuk-summary-list-row>
             }
         </govuk-summary-list>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml.cs
@@ -40,6 +40,8 @@ public class IndexModel : PageModel
     public string? MobileNumber { get; set; }
     public string? Trn { get; set; }
     public DateOnly? DqtDateOfBirth { get; set; }
+    public bool PendingDqtNameChange { get; set; }
+    public bool PendingDqtDateOfBirthChange { get; set; }
 
     public async Task OnGet()
     {
@@ -71,6 +73,8 @@ public class IndexModel : PageModel
 
             OfficialName = $"{dqtUser.FirstName} {dqtUser.LastName}";
             DqtDateOfBirth = dqtUser.DateOfBirth;
+            PendingDqtNameChange = dqtUser.PendingNameChange;
+            PendingDqtDateOfBirthChange = dqtUser.PendingDateOfBirthChange;
         }
     }
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/TeacherInfo.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/TeacherInfo.cs
@@ -7,4 +7,6 @@ public record TeacherInfo
     public required string LastName { get; init; }
     public required DateOnly DateOfBirth { get; init; }
     public required string? NationalInsuranceNumber { get; init; }
+    public bool PendingNameChange { get; init; }
+    public bool PendingDateOfBirthChange { get; init; }
 }


### PR DESCRIPTION
### Context

When DQT name/DOB changes are submitted, they are reviewed manually. During this time, we should indicate to the user that their changes are pending and prevent them submitting any more.

### Changes proposed in this pull request

If pendingDateOfBirthChange is true, add a ‘Pending review’ tag to the summary list row and remove the ‘Change’ link. If pendingNameChange is true, add a ‘Pending review’ tag to the summary list row and remove the ‘Change’ link.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
