### PR TITLE
Add update date of birth pages for identity account

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -163,10 +163,10 @@ public static class IdentityLinkGeneratorExtensions
             linkGenerator.PageWithAuthenticationJourneyId("/Account/DateOfBirth/Index", authenticationJourneyRequired: false)
                 .SetQueryParam("returnUrl", returnUrl);
 
-        public static string AccountDateOfBirthConfirm(this IIdentityLinkGenerator linkGenerator, ProtectedString dateOfBirth, string? returnUrl) =>
-            linkGenerator.PageWithAuthenticationJourneyId("/Account/DateOfBirth/Confirm", authenticationJourneyRequired: false)
-                .SetQueryParam("dateOfBirth", dateOfBirth.EncryptedValue)
-                .SetQueryParam("returnUrl", returnUrl);
+    public static string AccountDateOfBirthConfirm(this IIdentityLinkGenerator linkGenerator, ProtectedString dateOfBirth, string? returnUrl) =>
+        linkGenerator.PageWithAuthenticationJourneyId("/Account/DateOfBirth/Confirm", authenticationJourneyRequired: false)
+            .SetQueryParam("dateOfBirth", dateOfBirth.EncryptedValue)
+            .SetQueryParam("returnUrl", returnUrl);
 
     public static string AccountEmail(this IIdentityLinkGenerator linkGenerator, string? returnUrl) =>
         linkGenerator.PageWithAuthenticationJourneyId("/Account/Email/Index", authenticationJourneyRequired: false)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -159,6 +159,15 @@ public static class IdentityLinkGeneratorExtensions
             .SetQueryParam("lastName", lastName.EncryptedValue)
             .SetQueryParam("returnUrl", returnUrl);
 
+    public static string AccountDateOfBirth(this IIdentityLinkGenerator linkGenerator, string? returnUrl) =>
+            linkGenerator.PageWithAuthenticationJourneyId("/Account/DateOfBirth/Index", authenticationJourneyRequired: false)
+                .SetQueryParam("returnUrl", returnUrl);
+
+        public static string AccountDateOfBirthConfirm(this IIdentityLinkGenerator linkGenerator, ProtectedString dateOfBirth, string? returnUrl) =>
+            linkGenerator.PageWithAuthenticationJourneyId("/Account/DateOfBirth/Confirm", authenticationJourneyRequired: false)
+                .SetQueryParam("dateOfBirth", dateOfBirth.EncryptedValue)
+                .SetQueryParam("returnUrl", returnUrl);
+
     public static string AccountEmail(this IIdentityLinkGenerator linkGenerator, string? returnUrl) =>
         linkGenerator.PageWithAuthenticationJourneyId("/Account/Email/Index", authenticationJourneyRequired: false)
             .SetQueryParam("returnUrl", returnUrl);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Confirm.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Confirm.cshtml
@@ -1,0 +1,31 @@
+@page "/account/date-of-birth/confirm"
+@model TeacherIdentity.AuthServer.Pages.Account.DateOfBirth.Confirm
+@{
+    ViewBag.Title = "Confirm change";
+
+}
+
+@section BeforeContent
+{
+    <govuk-back-link href="@LinkGenerator.AccountDateOfBirth(Model.ReturnUrl)" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.AccountDateOfBirthConfirm(Model.DateOfBirth!, Model.ReturnUrl)" method="post" asp-antiforgery="true">
+
+            <govuk-summary-list>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.DateOfBirth!.PlainValue</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AccountDateOfBirth(Model.ReturnUrl)" visually-hidden-text="date of birth">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+            </govuk-summary-list>
+
+            <govuk-button type="submit">Submit change</govuk-button>
+        </form>
+    </div>
+</div>
+

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Confirm.cshtml.cs
@@ -1,0 +1,87 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.Pages.Account.DateOfBirth;
+
+public class Confirm : PageModel
+{
+    private TeacherIdentityServerDbContext _dbContext;
+    private IClock _clock;
+
+    public Confirm(
+        TeacherIdentityServerDbContext dbContext,
+        IClock clock)
+    {
+        _dbContext = dbContext;
+        _clock = clock;
+    }
+
+    [FromQuery(Name = "dateOfBirth")]
+    public ProtectedString? DateOfBirth { get; set; }
+    public DateOnly NewDateOfBirth { get; set; }
+
+    [FromQuery(Name = "returnUrl")]
+    public string? ReturnUrl { get; set; }
+    public string? SafeReturnUrl { get; set; }
+
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        await UpdateUserDateOfBirth(User.GetUserId()!.Value);
+        return Redirect(SafeReturnUrl!);
+    }
+
+    private async Task UpdateUserDateOfBirth(Guid userId)
+    {
+        var user = await _dbContext.Users.SingleAsync(u => u.UserId == userId);
+
+        UserUpdatedEventChanges changes = UserUpdatedEventChanges.None;
+
+        if (user.DateOfBirth != NewDateOfBirth)
+        {
+            changes |= UserUpdatedEventChanges.DateOfBirth;
+        }
+
+        if (changes != UserUpdatedEventChanges.None)
+        {
+            user.DateOfBirth = NewDateOfBirth;
+            user.Updated = _clock.UtcNow;
+
+            _dbContext.AddEvent(new UserUpdatedEvent()
+            {
+                Source = UserUpdatedEventSource.ChangedByUser,
+                CreatedUtc = _clock.UtcNow,
+                Changes = changes,
+                User = user,
+                UpdatedByUserId = User.GetUserId()!.Value,
+                UpdatedByClientId = null
+            });
+
+            await _dbContext.SaveChangesAsync();
+
+            await HttpContext.SignInCookies(user, resetIssued: false);
+
+            TempData.SetFlashSuccess("Your date of birth has been updated");
+        }
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        if (DateOfBirth is null || !DateOnly.TryParse(DateOfBirth.PlainValue, out var newDateOfBirth))
+        {
+            context.Result = new BadRequestResult();
+            return;
+        }
+
+        NewDateOfBirth = newDateOfBirth;
+        SafeReturnUrl = !string.IsNullOrEmpty(ReturnUrl) && Url.IsLocalUrl(ReturnUrl) ? ReturnUrl : "/account";
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Index.cshtml
@@ -1,0 +1,24 @@
+@page "/account/date-of-birth"
+@model TeacherIdentity.AuthServer.Pages.Account.DateOfBirth.DateOfBirthPage
+@{
+    ViewBag.Title = Html.DisplayNameFor(m => m.DateOfBirth);
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@Model.SafeReturnUrl" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.AccountDateOfBirth(Model.ReturnUrl)" method="post" asp-antiforgery="true">
+            <govuk-date-input asp-for="DateOfBirth">
+                <govuk-date-input-fieldset>
+                    <govuk-date-input-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--xl"/>
+                </govuk-date-input-fieldset>
+            </govuk-date-input>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>
+

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Index.cshtml.cs
@@ -1,0 +1,49 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeacherIdentity.AuthServer.Pages.Account.DateOfBirth;
+
+[BindProperties]
+public class DateOfBirthPage : PageModel
+{
+    private IIdentityLinkGenerator _linkGenerator;
+    private readonly ProtectedStringFactory _protectedStringFactory;
+
+    public DateOfBirthPage(IIdentityLinkGenerator linkGenerator, ProtectedStringFactory protectedStringFactory)
+    {
+        _linkGenerator = linkGenerator;
+        _protectedStringFactory = protectedStringFactory;
+    }
+
+    [Display(Name = "Your date of birth", Description = "For example, 27 3 1987")]
+    [Required(ErrorMessage = "Enter your date of birth")]
+    [IsPastDate(typeof(DateOnly), ErrorMessage = "Your date of birth must be in the past")]
+    public DateOnly? DateOfBirth { get; set; }
+
+    [FromQuery(Name = "returnUrl")]
+    public string? ReturnUrl { get; set; }
+    public string? SafeReturnUrl { get; set; }
+
+    public void OnGet()
+    {
+    }
+
+    public IActionResult OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        var protectedDateOfBirth = _protectedStringFactory.CreateFromPlainValue(DateOfBirth.ToString()!);
+
+        return Redirect(_linkGenerator.AccountDateOfBirthConfirm(protectedDateOfBirth, ReturnUrl));
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        SafeReturnUrl = !string.IsNullOrEmpty(ReturnUrl) && Url.IsLocalUrl(ReturnUrl) ? ReturnUrl : "/account";
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
@@ -77,7 +77,7 @@
                     }
                 </govuk-summary-list-row-value>
                 <govuk-summary-list-row-actions>
-                    <govuk-summary-list-row-action href="#" visually-hidden-text="date of birth">Change</govuk-summary-list-row-action>
+                    <govuk-summary-list-row-action href="@LinkGenerator.AccountDateOfBirth(returnUrl)" visually-hidden-text="date of birth">Change</govuk-summary-list-row-action>
                 </govuk-summary-list-row-actions>
             </govuk-summary-list-row>
             @if (dateOfBirthConflict)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/DateOfBirth/ConfirmTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/DateOfBirth/ConfirmTests.cs
@@ -1,0 +1,120 @@
+using System.Text.Encodings.Web;
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Account.DateOfBirth;
+
+public class ConfirmTests : TestBase
+{
+    public ConfirmTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_NoDateOfBirth_ReturnsBadRequest()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/account/date-of-birth/confirm");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_InvalidDateOfBirth_ReturnsBadRequest()
+    {
+        // Arrange
+        var dateOfBirthString = "";
+        var protectedDateOfBirthString = HostFixture.Services.GetRequiredService<ProtectedStringFactory>().CreateFromPlainValue(dateOfBirthString);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/account/date-of-birth/confirm?dateOfBirth={UrlEncode(protectedDateOfBirthString.EncryptedValue)}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_ReturnsSuccess()
+    {
+        var dateOfBirth = new DateOnly(2000, 1, 1);
+
+        var protectedDateOfBirth = HostFixture.Services.GetRequiredService<ProtectedStringFactory>().CreateFromPlainValue(dateOfBirth.ToString());
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/account/date-of-birth/confirm?dateOfBirth={UrlEncode(protectedDateOfBirth.EncryptedValue)}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_NoDateOfBirth_ReturnsBadRequest()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/date-of-birth/confirm");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_ValidForm_UpdatesDateOfBirthEmitsEventAndRedirects()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default);
+        HostFixture.SetUserId(user.UserId);
+
+        var client = TestClients.Client1;
+        var redirectUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority);
+
+        var returnUrl = $"/account?client_id={client.ClientId}&redirect_uri={Uri.EscapeDataString(redirectUri)}";
+
+        var newDateOfBirth = new DateOnly(2000, 1, 1);
+        var protectedDateOfBirth = HostFixture.Services.GetRequiredService<ProtectedStringFactory>().CreateFromPlainValue(newDateOfBirth.ToString());
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/date-of-birth/confirm?dateOfBirth={UrlEncode(protectedDateOfBirth.EncryptedValue)}&returnUrl={UrlEncode(returnUrl)}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal(returnUrl, response.Headers.Location?.OriginalString);
+
+        user = await TestData.WithDbContext(dbContext => dbContext.Users.SingleAsync(u => u.UserId == user.UserId));
+        Assert.Equal(newDateOfBirth, user.DateOfBirth);
+        Assert.Equal(Clock.UtcNow, user.Updated);
+
+        EventObserver.AssertEventsSaved(
+            e =>
+            {
+                var userUpdatedEvent = Assert.IsType<UserUpdatedEvent>(e);
+                Assert.Equal(Clock.UtcNow, userUpdatedEvent.CreatedUtc);
+                Assert.Equal(UserUpdatedEventSource.ChangedByUser, userUpdatedEvent.Source);
+                Assert.Equal(UserUpdatedEventChanges.DateOfBirth, userUpdatedEvent.Changes);
+                Assert.Equal(user.UserId, userUpdatedEvent.User.UserId);
+            });
+
+        var redirectedResponse = await response.FollowRedirect(HttpClient);
+        var redirectedDoc = await redirectedResponse.GetDocument();
+        AssertEx.HtmlDocumentHasFlashSuccess(redirectedDoc, "Your date of birth has been updated");
+    }
+
+    private static string UrlEncode(string value) => UrlEncoder.Default.Encode(value);
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/DateOfBirth/DateOfBirthTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/DateOfBirth/DateOfBirthTests.cs
@@ -1,0 +1,103 @@
+using System.Text.Encodings.Web;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Account.DateOfBirth;
+
+public class DateOfBirthTests : TestBase
+{
+    public DateOfBirthTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Post_EmptyDateOfBirth_ReturnsError()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/date-of-birth")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "DateOfBirth", "Enter your date of birth");
+    }
+
+    [Fact]
+    public async Task Post_FutureDateOfBirth_RedirectsToConfirmPage()
+    {
+        // Arrange
+        var dateOfBirth = new DateOnly(2100, 1, 1);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/date-of-birth")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "DateOfBirth.Day", dateOfBirth.Day.ToString() },
+                { "DateOfBirth.Month", dateOfBirth.Month.ToString() },
+                { "DateOfBirth.Year", dateOfBirth.Year.ToString() },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "DateOfBirth", "Your date of birth must be in the past");
+    }
+
+    [Fact]
+    public async Task Post_ValidDateOfBirth_RedirectsToConfirmPage()
+    {
+        // Arrange
+        var dateOfBirth = new DateOnly(2000, 1, 1);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/date-of-birth")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "DateOfBirth.Day", dateOfBirth.Day.ToString() },
+                { "DateOfBirth.Month", dateOfBirth.Month.ToString() },
+                { "DateOfBirth.Year", dateOfBirth.Year.ToString() },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/account/date-of-birth/confirm", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_ValidDateOfBirth_RedirectsToConfirmPageWithCorrectReturnUrl()
+    {
+        // Arrange
+        var dateOfBirth = new DateOnly(2000, 1, 1);
+
+        var client = TestClients.Client1;
+        var redirectUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority);
+
+        var returnUrl = UrlEncoder.Default.Encode($"/account?client_id={client.ClientId}&redirect_uri={Uri.EscapeDataString(redirectUri)}");
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/date-of-birth?returnUrl={returnUrl}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "DateOfBirth.Day", dateOfBirth.Day.ToString() },
+                { "DateOfBirth.Month", dateOfBirth.Month.ToString() },
+                { "DateOfBirth.Year", dateOfBirth.Year.ToString() },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Contains($"returnUrl={returnUrl}", response.Headers.Location?.OriginalString);
+    }
+}


### PR DESCRIPTION
### Context

We’re adding an account page to ID for a user to change their ID and DQT details.

### Changes proposed in this pull request

Add a new page at /account/date-of-birth following the designs at https://get-an-identity-prototype.herokuapp.com/account/date-of-birth .

If the date is valid, redirect to /account/date-of-birth/confirm passing the date as query parameter (using ProtectedString). The confirm page should follow the design at https://get-an-identity-prototype.herokuapp.com/account/check-answers .

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
