### PR TITLE
Improve email address rendering on overflow

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
@@ -127,7 +127,7 @@
         <govuk-summary-list>
             <govuk-summary-list-row>
                 <govuk-summary-list-row-key>Email</govuk-summary-list-row-key>
-                <govuk-summary-list-row-value>@Model.Email</govuk-summary-list-row-value>
+                <govuk-summary-list-row-value class="empty-hyphens">@Html.ShyEmail(Model.Email!)</govuk-summary-list-row-value>
                 <govuk-summary-list-row-actions>
                     <govuk-summary-list-row-action href="@LinkGenerator.AccountEmail(Model.ClientRedirectInfo)" visually-hidden-text="email">Change</govuk-summary-list-row-action>
                 </govuk-summary-list-row-actions>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Confirm.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Confirm.cshtml
@@ -29,7 +29,7 @@
                         </govuk-summary-list-row>
                         <govuk-summary-list-row>
                             <govuk-summary-list-row-key>Email address</govuk-summary-list-row-key>
-                            <govuk-summary-list-row-value>@Model.EmailAddress</govuk-summary-list-row-value>
+                            <govuk-summary-list-row-value class="empty-hyphens">@Html.ShyEmail(Model.EmailAddress!)</govuk-summary-list-row-value>
                         </govuk-summary-list-row>
                     </govuk-summary-list>
                 </div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/User.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/User.cshtml
@@ -42,7 +42,7 @@
             </govuk-summary-list-row>
             <govuk-summary-list-row>
                 <govuk-summary-list-row-key>Email address</govuk-summary-list-row-key>
-                <govuk-summary-list-row-value>@Model.EmailAddress</govuk-summary-list-row-value>
+                <govuk-summary-list-row-value class="empty-hyphens">@Html.ShyEmail(Model.EmailAddress!)</govuk-summary-list-row-value>
                 <govuk-summary-list-row-actions>
                     <govuk-summary-list-row-action asp-page="EditUserEmail" asp-route-userId="@Model.UserId" visually-hidden-text="email address">Change</govuk-summary-list-row-action>
                 </govuk-summary-list-row-actions>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Users.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Users.cshtml
@@ -91,7 +91,7 @@
                         {
                             <tr class="govuk-table__row" data-testid="user-@user.UserId">
                                 <td class="govuk-table__cell"><a asp-page="User" asp-route-userId="@user.UserId">@user.Name</a></td>
-                                <td class="govuk-table__cell">@user.EmailAddress</td>
+                                <td class="govuk-table__cell empty-hyphens">@Html.ShyEmail(user.EmailAddress)</td>
                                 @if (user.Trn is null)
                                 {
                                     <td class="govuk-table__cell"><a asp-page="AssignTrn/Trn" asp-route-userId="@user.UserId">Add a DQT record</a></td>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/CheckAnswers.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/CheckAnswers.cshtml
@@ -17,7 +17,7 @@
             <govuk-summary-list>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Email address</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value>@Model.EmailAddress</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-value class="empty-hyphens">@Html.ShyEmail(Model.EmailAddress!)</govuk-summary-list-row-value>
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/NoMatch.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/NoMatch.cshtml
@@ -26,7 +26,7 @@
             <govuk-summary-list>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Email address</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value>@Model.EmailAddress</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-value class="empty-hyphens">@Html.ShyEmail(Model.EmailAddress!)</govuk-summary-list-row-value>
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AngleSharpExtensions.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AngleSharpExtensions.cs
@@ -54,7 +54,7 @@ public static class AngleSharpExtensions
         {
             var rowKey = row.QuerySelector(".govuk-summary-list__key");
 
-            if (rowKey?.TextContent.Trim() == key)
+            if (rowKey.GetCleansedTextContent() == key)
             {
                 count++;
             }
@@ -71,7 +71,7 @@ public static class AngleSharpExtensions
         {
             var rowKey = row.QuerySelector(".govuk-summary-list__key");
 
-            if (rowKey?.TextContent.Trim() == key)
+            if (rowKey.GetCleansedTextContent() == key)
             {
                 return row;
             }
@@ -84,6 +84,12 @@ public static class AngleSharpExtensions
     {
         var row = GetSummaryListRowForKey(doc, key);
         var rowValue = row?.QuerySelector(".govuk-summary-list__value");
-        return rowValue?.TextContent.Trim();
+        return rowValue.GetCleansedTextContent();
     }
+
+    /// <summary>
+    /// Trims whitespace from an <see cref="INode"/>'s <see cref="INode.TextContent"/> and removes any
+    /// U+00AD (&amp;shy;) characters.
+    /// </summary>
+    private static string? GetCleansedTextContent(this INode? node) => node?.TextContent?.Trim()?.Replace("\u00ad", "");
 }


### PR DESCRIPTION
In a few places we use a soft hyphen to improve the wrapping of long email addresses. This extends the usage to a few new pages added recently.

I've also revised the methods that retrieve summary list row values in tests so they ignore these soft hyphen characters.

Before: 
![before](https://user-images.githubusercontent.com/2041280/227296194-791cf2d5-9c85-4575-ab26-64750851dff0.png)

After:
![after](https://user-images.githubusercontent.com/2041280/227296510-cb80f344-c51f-4643-9377-60e26827dcdd.png)
