### PR TITLE
Update change button enabled logic for Account Date Of Birth

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Confirm.cshtml.cs
@@ -98,27 +98,21 @@ public class Confirm : PageModel
 
     private async Task<bool> ChangeDateOfBirthEnabled()
     {
-        var userId = User.GetUserId()!.Value;
-
-        var user = await _dbContext.Users
-            .Where(u => u.UserId == userId)
-            .Select(u => new
-            {
-                u.DateOfBirth,
-                u.Trn
-            })
-            .SingleAsync();
-
-        var trn = user.Trn;
+        var trn = User.GetTrn();
 
         if (trn is null)
         {
             return true;
         }
 
+        var dateOfBirth = await _dbContext.Users
+            .Where(u => u.Trn == trn)
+            .Select(u => u.DateOfBirth)
+            .SingleAsync();
+
         var dqtUser = await _dqtApiClient.GetTeacherByTrn(trn) ??
                       throw new Exception($"User with TRN '{trn}' cannot be found in DQT.");
 
-        return !user.DateOfBirth.Equals(dqtUser.DateOfBirth) && !dqtUser.PendingDateOfBirthChange;
+        return !dateOfBirth.Equals(dqtUser.DateOfBirth) && !dqtUser.PendingDateOfBirthChange;
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Confirm.cshtml.cs
@@ -98,7 +98,7 @@ public class Confirm : PageModel
 
     private async Task<bool> ChangeDateOfBirthEnabled()
     {
-        var trn = User.GetTrn();
+        var trn = User.GetTrn(false);
 
         if (trn is null)
         {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Index.cshtml.cs
@@ -2,19 +2,30 @@ using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Services.DqtApi;
 
 namespace TeacherIdentity.AuthServer.Pages.Account.DateOfBirth;
 
 [BindProperties]
 public class DateOfBirthPage : PageModel
 {
-    private IIdentityLinkGenerator _linkGenerator;
+    private readonly IIdentityLinkGenerator _linkGenerator;
     private readonly ProtectedStringFactory _protectedStringFactory;
+    private readonly TeacherIdentityServerDbContext _dbContext;
+    private readonly IDqtApiClient _dqtApiClient;
 
-    public DateOfBirthPage(IIdentityLinkGenerator linkGenerator, ProtectedStringFactory protectedStringFactory)
+    public DateOfBirthPage(
+        IIdentityLinkGenerator linkGenerator,
+        ProtectedStringFactory protectedStringFactory,
+        TeacherIdentityServerDbContext dbContext,
+        IDqtApiClient dqtApiClient)
     {
         _linkGenerator = linkGenerator;
         _protectedStringFactory = protectedStringFactory;
+        _dbContext = dbContext;
+        _dqtApiClient = dqtApiClient;
     }
 
     [Display(Name = "Your date of birth", Description = "For example, 27 3 1987")]
@@ -42,8 +53,42 @@ public class DateOfBirthPage : PageModel
         return Redirect(_linkGenerator.AccountDateOfBirthConfirm(protectedDateOfBirth, ReturnUrl));
     }
 
-    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
     {
+        var b = await ChangeDateOfBirthEnabled();
+        if (!await ChangeDateOfBirthEnabled())
+        {
+            context.Result = BadRequest();
+            return;
+        }
+
         SafeReturnUrl = !string.IsNullOrEmpty(ReturnUrl) && Url.IsLocalUrl(ReturnUrl) ? ReturnUrl : "/account";
+        await next();
+    }
+
+    private async Task<bool> ChangeDateOfBirthEnabled()
+    {
+        var userId = User.GetUserId()!.Value;
+
+        var user = await _dbContext.Users
+            .Where(u => u.UserId == userId)
+            .Select(u => new
+            {
+                u.DateOfBirth,
+                u.Trn
+            })
+            .SingleAsync();
+
+        var trn = user.Trn;
+
+        if (trn is null)
+        {
+            return true;
+        }
+
+        var dqtUser = await _dqtApiClient.GetTeacherByTrn(trn) ??
+                      throw new Exception($"User with TRN '{trn}' cannot be found in DQT.");
+
+        return !user.DateOfBirth.Equals(dqtUser.DateOfBirth) && !dqtUser.PendingDateOfBirthChange;
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Index.cshtml.cs
@@ -68,27 +68,21 @@ public class DateOfBirthPage : PageModel
 
     private async Task<bool> ChangeDateOfBirthEnabled()
     {
-        var userId = User.GetUserId()!.Value;
-
-        var user = await _dbContext.Users
-            .Where(u => u.UserId == userId)
-            .Select(u => new
-            {
-                u.DateOfBirth,
-                u.Trn
-            })
-            .SingleAsync();
-
-        var trn = user.Trn;
+        var trn = User.GetTrn();
 
         if (trn is null)
         {
             return true;
         }
 
+        var dateOfBirth = await _dbContext.Users
+            .Where(u => u.Trn == trn)
+            .Select(u => u.DateOfBirth)
+            .SingleAsync();
+
         var dqtUser = await _dqtApiClient.GetTeacherByTrn(trn) ??
                       throw new Exception($"User with TRN '{trn}' cannot be found in DQT.");
 
-        return !user.DateOfBirth.Equals(dqtUser.DateOfBirth) && !dqtUser.PendingDateOfBirthChange;
+        return !dateOfBirth.Equals(dqtUser.DateOfBirth) && !dqtUser.PendingDateOfBirthChange;
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Index.cshtml.cs
@@ -68,7 +68,7 @@ public class DateOfBirthPage : PageModel
 
     private async Task<bool> ChangeDateOfBirthEnabled()
     {
-        var trn = User.GetTrn();
+        var trn = User.GetTrn(false);
 
         if (trn is null)
         {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
@@ -6,6 +6,7 @@
 
     var returnUrl = Request.GetUri().PathAndQuery;
     var dateOfBirthConflict = Model.DqtDateOfBirth is not null && !Model.DqtDateOfBirth.Equals(Model.DateOfBirth);
+    var dateOfBirthChangeEnabled = Model.DqtDateOfBirth is null || (dateOfBirthConflict && !Model.PendingDqtDateOfBirthChange);
 }
 
 @section BeforeContent
@@ -73,33 +74,39 @@
                     @Model.DateOfBirth?.ToString("dd MMMM yyyy")
                     @if (dateOfBirthConflict)
                     {
-                        <p class="govuk-hint govuk-!-font-size-14">Entered when creating account</p>
+                        <p class="govuk-hint govuk-!-font-size-14" data-testid="dob-hint-text">Entered when creating account</p>
+                    }
+                    @if (Model.PendingDqtDateOfBirthChange)
+                    {
+                        <govuk-tag class="govuk-tag--yellow" data-testid="dob-pending-review-tag">PENDING REVIEW</govuk-tag>
                     }
                 </govuk-summary-list-row-value>
-                <govuk-summary-list-row-actions>
-                    <govuk-summary-list-row-action href="@LinkGenerator.AccountDateOfBirth(returnUrl)" visually-hidden-text="date of birth">Change</govuk-summary-list-row-action>
-                </govuk-summary-list-row-actions>
+                @if (dateOfBirthChangeEnabled)
+                {
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AccountDateOfBirth(returnUrl)" visually-hidden-text="date of birth" data-testid="dob-change-link">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                }
             </govuk-summary-list-row>
             @if (dateOfBirthConflict)
             {
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
-                    @if (Model.PendingDqtDateOfBirthChange)
+                    <govuk-summary-list-row-value>
+                        @Model.DqtDateOfBirth?.ToString("dd MMMM yyyy")
+                        <p class="govuk-hint govuk-!-font-size-14" data-testid="dqt-dob-hint-text">
+                            Your verified date of birth.<br/>
+                            Contact us to change.
+                        </p>
+                        @if (Model.PendingDqtDateOfBirthChange)
+                        {
+                            <govuk-tag class="govuk-tag--yellow" data-testid="dqt-dob-pending-review-tag">PENDING REVIEW</govuk-tag>
+                        }
+                    </govuk-summary-list-row-value>
+                    @if (dateOfBirthChangeEnabled)
                     {
-                        <govuk-summary-list-row-value>
-                            @Model.DqtDateOfBirth?.ToString("dd MMMM yyyy")
-                            <p class="govuk-hint govuk-!-font-size-14">Date of birth already in our records</p>
-                            <govuk-tag class="govuk-tag--yellow" data-testid="dob-pending-review-tag">PENDING REVIEW</govuk-tag>
-                        </govuk-summary-list-row-value>
-                    }
-                    else
-                    {
-                        <govuk-summary-list-row-value>
-                            @Model.DqtDateOfBirth?.ToString("dd MMMM yyyy")
-                            <p class="govuk-hint govuk-!-font-size-14">Date of birth already in our records</p>
-                        </govuk-summary-list-row-value>
                         <govuk-summary-list-row-actions>
-                            <govuk-summary-list-row-action href="#" visually-hidden-text="date of birth">Change</govuk-summary-list-row-action>
+                            <govuk-summary-list-row-action href="#" visually-hidden-text="date of birth" data-testid="dqt-dob-change-link">Change</govuk-summary-list-row-action>
                         </govuk-summary-list-row-actions>
                     }
                 </govuk-summary-list-row>

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/DateOfBirth/DateOfBirthTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/DateOfBirth/DateOfBirthTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Encodings.Web;
+using TeacherIdentity.AuthServer.Models;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Account.DateOfBirth;
 
@@ -7,6 +8,34 @@ public class DateOfBirthTests : TestBase
     public DateOfBirthTests(HostFixture hostFixture)
         : base(hostFixture)
     {
+    }
+
+    [Theory]
+    [InlineData(false, false)]
+    [InlineData(true, true)]
+    public async Task Post_DateOfBirthChangeDisabled_ReturnsBadRequest(bool hasDobConflict, bool hasPendingDobChange)
+    {
+        // Arrange
+        HostFixture.SetUserId(TestUsers.DefaultUserWithTrn.UserId);
+        MockDqtApiResponse(TestUsers.DefaultUserWithTrn, hasDobConflict, hasPendingDobChange);
+
+        var dateOfBirth = new DateOnly(2000, 1, 1);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/date-of-birth")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "DateOfBirth.Day", dateOfBirth.Day.ToString() },
+                { "DateOfBirth.Month", dateOfBirth.Month.ToString() },
+                { "DateOfBirth.Year", dateOfBirth.Year.ToString() },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
     [Fact]
@@ -99,5 +128,19 @@ public class DateOfBirthTests : TestBase
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Contains($"returnUrl={returnUrl}", response.Headers.Location?.OriginalString);
+    }
+
+    private void MockDqtApiResponse(User user, bool hasDobConflict, bool hasPendingDobChange)
+    {
+        HostFixture.DqtApiClient.Setup(mock => mock.GetTeacherByTrn(user.Trn!, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AuthServer.Services.DqtApi.TeacherInfo()
+            {
+                DateOfBirth = hasDobConflict ? user.DateOfBirth!.Value.AddDays(1) : user.DateOfBirth!.Value,
+                FirstName = user.FirstName,
+                LastName = user.LastName,
+                NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber(),
+                Trn = user.Trn!,
+                PendingDateOfBirthChange = hasPendingDobChange
+            });
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/GetAllUsersTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/GetAllUsersTests.cs
@@ -43,7 +43,10 @@ public class GetAllUsersTests : TestBase, IAsyncLifetime
         var user1 = await TestData.CreateUser(hasTrn: true);
         var user2 = await TestData.CreateUser(hasTrn: true);
         var user3 = await TestData.CreateUser(hasTrn: false);
-        var allUsers = new[] { user1, user2, user3 }.Append(TestUsers.DefaultUser).OrderBy(u => u.LastName).ThenBy(u => u.FirstName).ToArray();
+        var allUsers = new[] { user1, user2, user3 }
+            .Append(TestUsers.DefaultUser)
+            .Append(TestUsers.DefaultUserWithTrn)
+            .OrderBy(u => u.LastName).ThenBy(u => u.FirstName).ToArray();
 
         // Act
         var response = await httpClient.GetAsync("/api/v1/users");
@@ -133,7 +136,7 @@ public class GetAllUsersTests : TestBase, IAsyncLifetime
         var user5 = await TestData.CreateUser(hasTrn: false);
         var user6 = await TestData.CreateUser(hasTrn: false);
         var user7 = await TestData.CreateUser(hasTrn: false);
-        var sortedUsers = new[] { user1, user2, user3, user4, user5, user6, user7, TestUsers.DefaultUser }.OrderBy(u => u.LastName).ThenBy(u => u.FirstName).ToArray();
+        var sortedUsers = new[] { user1, user2, user3, user4, user5, user6, user7, TestUsers.DefaultUser, TestUsers.DefaultUserWithTrn }.OrderBy(u => u.LastName).ThenBy(u => u.FirstName).ToArray();
 
         var pagedUsers = sortedUsers.Skip(skip).Take(pageSize).ToArray();
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/TestUsers.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/TestUsers.cs
@@ -55,7 +55,7 @@ public static class TestUsers
         Updated = DateTime.UtcNow,
         UserType = UserType.Default,
         StaffRoles = StaffRoles.None,
-        Trn = "7654321",
+        Trn = "7754311",
         TrnLookupStatus = TrnLookupStatus.Found,
     };
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/TestUsers.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/TestUsers.cs
@@ -44,9 +44,24 @@ public static class TestUsers
         StaffRoles = StaffRoles.None
     };
 
+    public static User DefaultUserWithTrn { get; } = new User()
+    {
+        UserId = new Guid("3828dc03-7500-402a-beeb-acd45b635fc3"),
+        Created = DateTime.UtcNow,
+        DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
+        EmailAddress = Faker.Internet.Email(),
+        FirstName = Faker.Name.First(),
+        LastName = Faker.Name.Last(),
+        Updated = DateTime.UtcNow,
+        UserType = UserType.Default,
+        StaffRoles = StaffRoles.None,
+        Trn = "7654321",
+        TrnLookupStatus = TrnLookupStatus.Found,
+    };
+
     public static IReadOnlyCollection<User> All => Default.Concat(Staff).ToArray();
 
-    public static IReadOnlyCollection<User> Default => new[] { DefaultUser };
+    public static IReadOnlyCollection<User> Default => new[] { DefaultUser, DefaultUserWithTrn };
 
     public static IReadOnlyCollection<User> Staff => new[] { AdminUserWithAllRoles, AdminUserWithNoRoles };
 


### PR DESCRIPTION
### Context

The Change link should only be available if the account has no associated TRN, or the ID date of birth and DQT date of birth are different.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
