### PR TITLE
Simplify propagating client callback URLs for account pages

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/ClientRedirectInfo.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/ClientRedirectInfo.cs
@@ -1,0 +1,63 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Security.Cryptography;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.WebUtilities;
+
+namespace TeacherIdentity.AuthServer;
+
+public sealed record ClientRedirectInfo
+{
+    public const string QueryParameterName = "cri";
+
+    private readonly string _encoded;
+
+    public ClientRedirectInfo(IDataProtector dataProtector, string clientId, string redirectUri)
+        : this(Encode(clientId, redirectUri, dataProtector), clientId, redirectUri)
+    {
+    }
+
+    private ClientRedirectInfo(string encoded, string clientId, string redirectUri)
+    {
+        ClientId = clientId;
+        RedirectUri = redirectUri;
+        _encoded = encoded;
+    }
+
+    public string ClientId { get; }
+    public string RedirectUri { get; }
+
+    public static bool TryDecode(string encoded, IDataProtector dataProtector, [NotNullWhen(true)] out ClientRedirectInfo? clientRedirectInfo)
+    {
+        string unprotected;
+        try
+        {
+            unprotected = dataProtector.Unprotect(encoded);
+        }
+        catch (CryptographicException)
+        {
+            clientRedirectInfo = default;
+            return false;
+        }
+
+        var asQueryParams = QueryHelpers.ParseQuery(unprotected);
+        var clientId = asQueryParams[nameof(ClientId)].ToString();
+        var redirectUri = asQueryParams[nameof(RedirectUri)].ToString();
+
+        clientRedirectInfo = new ClientRedirectInfo(encoded, clientId, redirectUri);
+        return true;
+    }
+
+    private static string Encode(string clientId, string redirectUri, IDataProtector dataProtector)
+    {
+        var asQueryParams = QueryString
+           .Create(nameof(ClientId), clientId)
+           .Add(nameof(RedirectUri), redirectUri)
+           .Value!;
+
+        return dataProtector.Protect(asQueryParams);
+    }
+
+    public override string ToString() => _encoded;
+
+    public string ToQueryParam() => $"{QueryParameterName}={Uri.EscapeDataString(_encoded)}";
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/HttpContextExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/HttpContextExtensions.cs
@@ -3,6 +3,7 @@ using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using OpenIddict.Abstractions;
+using TeacherIdentity.AuthServer.Infrastructure.Middleware;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.State;
 
@@ -14,6 +15,9 @@ public static class HttpContextExtensions
         TryGetAuthenticationState(httpContext, out var authenticationState) ?
             authenticationState :
             throw new InvalidOperationException($"The current request has no {nameof(AuthenticationState)}.");
+
+    public static ClientRedirectInfo? GetClientRedirectInfo(this HttpContext httpContext) =>
+        httpContext.Features.Get<ClientRedirectInfoFeature>()?.ClientRedirectInfo;
 
     public static Task<ClaimsPrincipal> SignInCookies(
         this HttpContext httpContext,

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -149,52 +149,56 @@ public static class IdentityLinkGeneratorExtensions
             .SetQueryParam("returnUrl", returnUrl)
             .SetQueryParam("cancelUrl", cancelUrl);
 
-    public static string AccountName(this IIdentityLinkGenerator linkGenerator, string? returnUrl) =>
-        linkGenerator.PageWithAuthenticationJourneyId("/Account/Name/Index", authenticationJourneyRequired: false)
-            .SetQueryParam("returnUrl", returnUrl);
+    public static string Account(this IIdentityLinkGenerator linkGenerator, ClientRedirectInfo? clientRedirectInfo) =>
+        linkGenerator.PageWithAuthenticationJourneyId("/Account/Index", authenticationJourneyRequired: false)
+            .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo);
 
-    public static string AccountNameConfirm(this IIdentityLinkGenerator linkGenerator, ProtectedString firstName, ProtectedString lastName, string? returnUrl) =>
+    public static string AccountName(this IIdentityLinkGenerator linkGenerator, ClientRedirectInfo? clientRedirectInfo) =>
+        linkGenerator.PageWithAuthenticationJourneyId("/Account/Name/Index", authenticationJourneyRequired: false)
+            .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo);
+
+    public static string AccountNameConfirm(this IIdentityLinkGenerator linkGenerator, ProtectedString firstName, ProtectedString lastName, ClientRedirectInfo? clientRedirectInfo) =>
         linkGenerator.PageWithAuthenticationJourneyId("/Account/Name/Confirm", authenticationJourneyRequired: false)
             .SetQueryParam("firstName", firstName.EncryptedValue)
             .SetQueryParam("lastName", lastName.EncryptedValue)
-            .SetQueryParam("returnUrl", returnUrl);
+            .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo);
 
-    public static string AccountDateOfBirth(this IIdentityLinkGenerator linkGenerator, string? returnUrl) =>
-            linkGenerator.PageWithAuthenticationJourneyId("/Account/DateOfBirth/Index", authenticationJourneyRequired: false)
-                .SetQueryParam("returnUrl", returnUrl);
+    public static string AccountDateOfBirth(this IIdentityLinkGenerator linkGenerator, ClientRedirectInfo? clientRedirectInfo) =>
+        linkGenerator.PageWithAuthenticationJourneyId("/Account/DateOfBirth/Index", authenticationJourneyRequired: false)
+            .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo);
 
-    public static string AccountDateOfBirthConfirm(this IIdentityLinkGenerator linkGenerator, ProtectedString dateOfBirth, string? returnUrl) =>
+    public static string AccountDateOfBirthConfirm(this IIdentityLinkGenerator linkGenerator, ProtectedString dateOfBirth, ClientRedirectInfo? clientRedirectInfo) =>
         linkGenerator.PageWithAuthenticationJourneyId("/Account/DateOfBirth/Confirm", authenticationJourneyRequired: false)
             .SetQueryParam("dateOfBirth", dateOfBirth.EncryptedValue)
-            .SetQueryParam("returnUrl", returnUrl);
+            .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo);
 
-    public static string AccountEmail(this IIdentityLinkGenerator linkGenerator, string? returnUrl) =>
+    public static string AccountEmail(this IIdentityLinkGenerator linkGenerator, ClientRedirectInfo? clientRedirectInfo) =>
         linkGenerator.PageWithAuthenticationJourneyId("/Account/Email/Index", authenticationJourneyRequired: false)
-            .SetQueryParam("returnUrl", returnUrl);
+            .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo);
 
-    public static string AccountEmailResend(this IIdentityLinkGenerator linkGenerator, ProtectedString email, string? returnUrl) =>
+    public static string AccountEmailResend(this IIdentityLinkGenerator linkGenerator, ProtectedString email, ClientRedirectInfo? clientRedirectInfo) =>
         linkGenerator.PageWithAuthenticationJourneyId("/Account/Email/Resend", authenticationJourneyRequired: false)
             .SetQueryParam("email", email.EncryptedValue)
-            .SetQueryParam("returnUrl", returnUrl);
+            .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo);
 
-    public static string AccountEmailConfirm(this IIdentityLinkGenerator linkGenerator, ProtectedString email, string? returnUrl) =>
+    public static string AccountEmailConfirm(this IIdentityLinkGenerator linkGenerator, ProtectedString email, ClientRedirectInfo? clientRedirectInfo) =>
         linkGenerator.PageWithAuthenticationJourneyId("/Account/Email/Confirm", authenticationJourneyRequired: false)
             .SetQueryParam("email", email.EncryptedValue)
-            .SetQueryParam("returnUrl", returnUrl);
+            .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo);
 
-    public static string AccountPhone(this IIdentityLinkGenerator linkGenerator, string? returnUrl) =>
+    public static string AccountPhone(this IIdentityLinkGenerator linkGenerator, ClientRedirectInfo? clientRedirectInfo) =>
         linkGenerator.PageWithAuthenticationJourneyId("/Account/Phone/Index", authenticationJourneyRequired: false)
-            .SetQueryParam("returnUrl", returnUrl);
+            .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo);
 
-    public static string AccountPhoneResend(this IIdentityLinkGenerator linkGenerator, ProtectedString mobileNumber, string? returnUrl) =>
+    public static string AccountPhoneResend(this IIdentityLinkGenerator linkGenerator, ProtectedString mobileNumber, ClientRedirectInfo? clientRedirectInfo) =>
         linkGenerator.PageWithAuthenticationJourneyId("/Account/Phone/Resend", authenticationJourneyRequired: false)
             .SetQueryParam("mobileNumber", mobileNumber.EncryptedValue)
-            .SetQueryParam("returnUrl", returnUrl);
+            .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo);
 
-    public static string AccountPhoneConfirm(this IIdentityLinkGenerator linkGenerator, ProtectedString mobileNumber, string? returnUrl) =>
+    public static string AccountPhoneConfirm(this IIdentityLinkGenerator linkGenerator, ProtectedString mobileNumber, ClientRedirectInfo? clientRedirectInfo) =>
         linkGenerator.PageWithAuthenticationJourneyId("/Account/Phone/Confirm", authenticationJourneyRequired: false)
             .SetQueryParam("mobileNumber", mobileNumber.EncryptedValue)
-            .SetQueryParam("returnUrl", returnUrl);
+            .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo);
 
     public static string Cookies(this IIdentityLinkGenerator linkGenerator) =>
         linkGenerator.PageWithAuthenticationJourneyId("/Cookies", authenticationJourneyRequired: false);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/Middleware/ClientRedirectInfoMiddleware.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/Middleware/ClientRedirectInfoMiddleware.cs
@@ -1,0 +1,78 @@
+using Microsoft.AspNetCore.DataProtection;
+using TeacherIdentity.AuthServer.Oidc;
+
+namespace TeacherIdentity.AuthServer.Infrastructure.Middleware;
+
+public class ClientRedirectInfoMiddleware
+{
+    private readonly IDataProtector _dataProtector;
+    private readonly ILogger<ClientRedirectInfoMiddleware> _logger;
+    private readonly RequestDelegate _next;
+
+    public ClientRedirectInfoMiddleware(
+        IDataProtectionProvider dataProtectionProvider,
+        ILogger<ClientRedirectInfoMiddleware> logger,
+        RequestDelegate next)
+    {
+        _dataProtector = dataProtectionProvider.CreateProtector(nameof(ClientRedirectInfo));
+        _logger = logger;
+        _next = next;
+    }
+
+    public async Task Invoke(HttpContext context, TeacherIdentityApplicationManager applicationManager)
+    {
+        ClientRedirectInfo? clientRedirectInfo = null;
+
+        // Look for an existing encoded ClientRedirectInfo query parameter
+        if (context.Request.Query.TryGetValue(ClientRedirectInfo.QueryParameterName, out var encodedQueryParam))
+        {
+            if (!ClientRedirectInfo.TryDecode(encodedQueryParam!, _dataProtector, out clientRedirectInfo))
+            {
+                _logger.LogDebug("Failed decoding encoded query parameter: '{QueryParameter}'.", encodedQueryParam!);
+                OnInvalidRequest();
+                return;
+            }
+        }
+        // No encoded query parameter found, check for unencoded client_id and redirect_uri
+        else if (context.Request.Query.TryGetValue("client_id", out var clientId) &&
+            context.Request.Query.TryGetValue("redirect_uri", out var redirectUri))
+        {
+            var client = await applicationManager.FindByClientIdAsync(clientId!);
+
+            if (client is null)
+            {
+                _logger.LogDebug("Unknown client ID: '{ClientId}'.", clientId!);
+                OnInvalidRequest();
+                return;
+            }
+
+            if (!await applicationManager.ValidateRedirectUriDomain(client, redirectUri!))
+            {
+                _logger.LogDebug("Invalid redirect URI '{RedirectUri}' specified for client: '{ClientId}'.", redirectUri!, clientId!);
+                OnInvalidRequest();
+                return;
+            }
+
+            clientRedirectInfo = new ClientRedirectInfo(_dataProtector, clientId!, redirectUri!);
+        }
+
+        if (clientRedirectInfo is not null)
+        {
+            context.Features.Set(new ClientRedirectInfoFeature(clientRedirectInfo));
+        }
+
+        await _next(context);
+
+        void OnInvalidRequest() => context.Response.StatusCode = StatusCodes.Status400BadRequest;
+    }
+}
+
+public class ClientRedirectInfoFeature
+{
+    public ClientRedirectInfoFeature(ClientRedirectInfo clientRedirectInfo)
+    {
+        ClientRedirectInfo = clientRedirectInfo;
+    }
+
+    public ClientRedirectInfo ClientRedirectInfo { get; }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Confirm.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Confirm.cshtml
@@ -7,19 +7,19 @@
 
 @section BeforeContent
 {
-    <govuk-back-link href="@LinkGenerator.AccountDateOfBirth(Model.ReturnUrl)" />
+    <govuk-back-link href="@LinkGenerator.AccountDateOfBirth(Model.ClientRedirectInfo)" />
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.AccountDateOfBirthConfirm(Model.DateOfBirth!, Model.ReturnUrl)" method="post" asp-antiforgery="true">
+        <form action="@LinkGenerator.AccountDateOfBirthConfirm(Model.DateOfBirth!, Model.ClientRedirectInfo)" method="post" asp-antiforgery="true">
 
             <govuk-summary-list>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value>@Model.DateOfBirth!.PlainValue</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.AccountDateOfBirth(Model.ReturnUrl)" visually-hidden-text="date of birth">Change</govuk-summary-list-row-action>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AccountDateOfBirth(Model.ClientRedirectInfo)" visually-hidden-text="date of birth">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
             </govuk-summary-list>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Index.cshtml
@@ -5,12 +5,12 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@Model.SafeReturnUrl" />
+    <govuk-back-link href="@LinkGenerator.Account(Model.ClientRedirectInfo)" />
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.AccountDateOfBirth(Model.ReturnUrl)" method="post" asp-antiforgery="true">
+        <form action="@LinkGenerator.AccountDateOfBirth(Model.ClientRedirectInfo)" method="post" asp-antiforgery="true">
             <govuk-date-input asp-for="DateOfBirth">
                 <govuk-date-input-fieldset>
                     <govuk-date-input-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--xl"/>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Email/Confirm.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Email/Confirm.cshtml
@@ -2,17 +2,16 @@
 @model TeacherIdentity.AuthServer.Pages.Account.Email.Confirm
 @{
     ViewBag.Title = "Confirm change";
-
 }
 
 @section BeforeContent
 {
-    <govuk-back-link href="@LinkGenerator.AccountEmail(Model.ReturnUrl)" />
+    <govuk-back-link href="@LinkGenerator.AccountEmail(Model.ClientRedirectInfo)" />
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.AccountEmailConfirm(Model.Email!, Model.ReturnUrl)" method="post" asp-antiforgery="true">
+        <form action="@LinkGenerator.AccountEmailConfirm(Model.Email!, Model.ClientRedirectInfo)" method="post" asp-antiforgery="true">
             <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
 
             <p>A confirmation code has been sent to <span data-testid="email">@Model.Email!.PlainValue</span></p>
@@ -22,7 +21,7 @@
             </govuk-input>
 
             <p>
-                <a href="@LinkGenerator.AccountEmailResend(Model.Email!, Model.ReturnUrl)">I have not received an email</a>
+                <a href="@LinkGenerator.AccountEmailResend(Model.Email!, Model.ClientRedirectInfo)">I have not received an email</a>
             </p>
 
             <govuk-button type="submit">Continue</govuk-button>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Email/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Email/Index.cshtml
@@ -5,12 +5,12 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@Model.SafeReturnUrl" />
+    <govuk-back-link href="@LinkGenerator.Account(Model.ClientRedirectInfo)" />
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.AccountEmail(Model.ReturnUrl)" method="post" asp-antiforgery="true">
+        <form action="@LinkGenerator.AccountEmail(Model.ClientRedirectInfo)" method="post" asp-antiforgery="true">
             <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
 
             <govuk-input asp-for="Email" type="email" autocomplete="email">

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Email/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Email/Index.cshtml.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Pages.Common;
 using TeacherIdentity.AuthServer.Services.UserVerification;
@@ -22,14 +22,13 @@ public class EmailPage : BaseEmailPageModel
         _protectedStringFactory = protectedStringFactory;
     }
 
+    [BindNever]
+    public ClientRedirectInfo? ClientRedirectInfo => HttpContext.GetClientRedirectInfo();
+
     [Display(Name = "Email address", Description = "We’ll use this to send you a code to confirm your email address. Do not use a work or university email that you might lose access to.")]
     [Required(ErrorMessage = "Enter your new email address")]
     [EmailAddress(ErrorMessage = "Enter a valid email address")]
     public string? Email { get; set; }
-
-    [FromQuery(Name = "returnUrl")]
-    public string? ReturnUrl { get; set; }
-    public string? SafeReturnUrl { get; set; }
 
     public void OnGet()
     {
@@ -62,11 +61,6 @@ public class EmailPage : BaseEmailPageModel
 
         var protectedEmail = _protectedStringFactory.CreateFromPlainValue(Email!);
 
-        return Redirect(LinkGenerator.AccountEmailConfirm(protectedEmail, ReturnUrl));
-    }
-
-    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
-    {
-        SafeReturnUrl = !string.IsNullOrEmpty(ReturnUrl) && Url.IsLocalUrl(ReturnUrl) ? ReturnUrl : "/account";
+        return Redirect(LinkGenerator.AccountEmailConfirm(protectedEmail, ClientRedirectInfo));
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Email/Resend.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Email/Resend.cshtml
@@ -5,12 +5,12 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.AccountEmailConfirm(Model.Email!, Model.ReturnUrl)" />
+    <govuk-back-link href="@LinkGenerator.AccountEmailConfirm(Model.Email!, Model.ClientRedirectInfo)" />
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.AccountEmailResend(Model.Email!, Model.ReturnUrl)" method="post" asp-antiforgery="true">
+        <form action="@LinkGenerator.AccountEmailResend(Model.Email!, Model.ClientRedirectInfo)" method="post" asp-antiforgery="true">
             <h1 class="govuk-heading-xl">Request a new email code</h1>
 
             <p>Emails sometimes take a few minutes to arrive. If you do not receive the email, you can request a new one.</p>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Email/Resend.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Email/Resend.cshtml.cs
@@ -21,6 +21,8 @@ public class Resend : BaseEmailPageModel
         _protectedStringFactory = protectedStringFactory;
     }
 
+    public ClientRedirectInfo? ClientRedirectInfo => HttpContext.GetClientRedirectInfo();
+
     [BindProperty]
     [Display(Name = "Email address")]
     [Required(ErrorMessage = "Enter your new email address")]
@@ -29,9 +31,6 @@ public class Resend : BaseEmailPageModel
 
     [FromQuery(Name = "email")]
     public ProtectedString? Email { get; set; }
-
-    [FromQuery(Name = "returnUrl")]
-    public string? ReturnUrl { get; set; }
 
     public void OnGet()
     {
@@ -65,14 +64,14 @@ public class Resend : BaseEmailPageModel
 
         var protectedEmail = _protectedStringFactory.CreateFromPlainValue(NewEmail!);
 
-        return Redirect(LinkGenerator.AccountEmailConfirm(protectedEmail, ReturnUrl));
+        return Redirect(LinkGenerator.AccountEmailConfirm(protectedEmail, ClientRedirectInfo));
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
         if (Email is null)
         {
-            context.Result = new BadRequestResult();
+            context.Result = BadRequest();
         }
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
@@ -4,17 +4,16 @@
 @{
     ViewBag.Title = "DfE Identity account";
 
-    var returnUrl = Request.GetUri().PathAndQuery;
     var dateOfBirthConflict = Model.DqtDateOfBirth is not null && !Model.DqtDateOfBirth.Equals(Model.DateOfBirth);
     var dateOfBirthChangeEnabled = Model.DqtDateOfBirth is null || (dateOfBirthConflict && !Model.PendingDqtDateOfBirthChange);
 }
 
 @section BeforeContent
 {
-    @if (Model.SafeRedirectUri is not null && Model.ClientDisplayName is not null)
+    @if (Model.ClientRedirectInfo is not null && Model.ClientDisplayName is not null)
     {
         <div class="gai-banner-bar">
-            <govuk-back-link href="@Model.SafeRedirectUri" data-testid="BackLink">
+            <govuk-back-link href="@Model.ClientRedirectInfo.RedirectUri" data-testid="BackLink">
                 Back to @Model.ClientDisplayName
             </govuk-back-link>
         </div>
@@ -41,7 +40,7 @@
                 <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
                 <govuk-summary-list-row-value>@Model.Name</govuk-summary-list-row-value>
                 <govuk-summary-list-row-actions>
-                    <govuk-summary-list-row-action href="@LinkGenerator.AccountName(returnUrl)" visually-hidden-text="name">Change</govuk-summary-list-row-action>
+                    <govuk-summary-list-row-action href="@LinkGenerator.AccountName(Model.ClientRedirectInfo)" visually-hidden-text="name">Change</govuk-summary-list-row-action>
                 </govuk-summary-list-row-actions>
             </govuk-summary-list-row>
             @if (Model.Trn is not null)
@@ -84,7 +83,7 @@
                 @if (dateOfBirthChangeEnabled)
                 {
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.AccountDateOfBirth(returnUrl)" visually-hidden-text="date of birth" data-testid="dob-change-link">Change</govuk-summary-list-row-action>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AccountDateOfBirth(Model.ClientRedirectInfo)" visually-hidden-text="date of birth" data-testid="dob-change-link">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 }
             </govuk-summary-list-row>
@@ -130,21 +129,21 @@
                 <govuk-summary-list-row-key>Email</govuk-summary-list-row-key>
                 <govuk-summary-list-row-value>@Model.Email</govuk-summary-list-row-value>
                 <govuk-summary-list-row-actions>
-                    <govuk-summary-list-row-action href="@LinkGenerator.AccountEmail(returnUrl)" visually-hidden-text="email">Change</govuk-summary-list-row-action>
+                    <govuk-summary-list-row-action href="@LinkGenerator.AccountEmail(Model.ClientRedirectInfo)" visually-hidden-text="email">Change</govuk-summary-list-row-action>
                 </govuk-summary-list-row-actions>
             </govuk-summary-list-row>
             <govuk-summary-list-row>
                 <govuk-summary-list-row-key>Mobile number</govuk-summary-list-row-key>
                 <govuk-summary-list-row-value>@Model.MobileNumber</govuk-summary-list-row-value>
                 <govuk-summary-list-row-actions>
-                    <govuk-summary-list-row-action href="@LinkGenerator.AccountPhone(returnUrl)" visually-hidden-text="mobile number">Change</govuk-summary-list-row-action>
+                    <govuk-summary-list-row-action href="@LinkGenerator.AccountPhone(Model.ClientRedirectInfo)" visually-hidden-text="mobile number">Change</govuk-summary-list-row-action>
                 </govuk-summary-list-row-actions>
             </govuk-summary-list-row>
         </govuk-summary-list>
 
-        @if (Model.SafeRedirectUri is not null && Model.ClientDisplayName is not null)
+        @if (Model.ClientRedirectInfo is not null && Model.ClientDisplayName is not null)
         {
-            <govuk-button-link href="@Model.SafeRedirectUri" data-testid="BackButton">
+            <govuk-button-link href="@Model.ClientRedirectInfo.RedirectUri" data-testid="BackButton">
                 Back to @Model.ClientDisplayName
             </govuk-button-link>
         }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Confirm.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Confirm.cshtml
@@ -2,24 +2,23 @@
 @model TeacherIdentity.AuthServer.Pages.Account.Name.Confirm
 @{
     ViewBag.Title = "Confirm change";
-
 }
 
 @section BeforeContent
 {
-    <govuk-back-link href="@LinkGenerator.AccountName(Model.ReturnUrl)" />
+    <govuk-back-link href="@LinkGenerator.AccountName(Model.ClientRedirectInfo)" />
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.AccountNameConfirm(Model.FirstName!, Model.LastName!, Model.ReturnUrl)" method="post" asp-antiforgery="true">
+        <form action="@LinkGenerator.AccountNameConfirm(Model.FirstName!, Model.LastName!, Model.ClientRedirectInfo)" method="post" asp-antiforgery="true">
 
             <govuk-summary-list>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value>@Model.FirstName!.PlainValue @Model.LastName!.PlainValue</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.AccountName(Model.ReturnUrl)" visually-hidden-text="name">Change</govuk-summary-list-row-action>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AccountName(Model.ClientRedirectInfo)" visually-hidden-text="name">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
             </govuk-summary-list>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Index.cshtml
@@ -5,12 +5,12 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@Model.SafeReturnUrl" />
+    <govuk-back-link href="@LinkGenerator.Account(Model.ClientRedirectInfo)" />
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.AccountName(Model.ReturnUrl)" method="post" asp-antiforgery="true">
+        <form action="@LinkGenerator.AccountName(Model.ClientRedirectInfo)" method="post" asp-antiforgery="true">
             <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
 
             <govuk-input asp-for="FirstName" spellcheck="false" autocomplete="given-name">

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Index.cshtml.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace TeacherIdentity.AuthServer.Pages.Account.Name;
@@ -8,7 +8,7 @@ namespace TeacherIdentity.AuthServer.Pages.Account.Name;
 [BindProperties]
 public class Name : PageModel
 {
-    private IIdentityLinkGenerator _linkGenerator;
+    private readonly IIdentityLinkGenerator _linkGenerator;
     private readonly ProtectedStringFactory _protectedStringFactory;
 
     public Name(IIdentityLinkGenerator linkGenerator, ProtectedStringFactory protectedStringFactory)
@@ -16,6 +16,9 @@ public class Name : PageModel
         _linkGenerator = linkGenerator;
         _protectedStringFactory = protectedStringFactory;
     }
+
+    [BindNever]
+    public ClientRedirectInfo? ClientRedirectInfo => HttpContext.GetClientRedirectInfo();
 
     [Display(Name = "First name", Description = "Or given names")]
     [Required(ErrorMessage = "Enter your first name")]
@@ -26,10 +29,6 @@ public class Name : PageModel
     [Required(ErrorMessage = "Enter your last name")]
     [StringLength(200, ErrorMessage = "Last name must be 200 characters or less")]
     public string? LastName { get; set; }
-
-    [FromQuery(Name = "returnUrl")]
-    public string? ReturnUrl { get; set; }
-    public string? SafeReturnUrl { get; set; }
 
     public void OnGet()
     {
@@ -45,11 +44,6 @@ public class Name : PageModel
         var protectedFirstName = _protectedStringFactory.CreateFromPlainValue(FirstName!);
         var protectedLastName = _protectedStringFactory.CreateFromPlainValue(LastName!);
 
-        return Redirect(_linkGenerator.AccountNameConfirm(protectedFirstName, protectedLastName, ReturnUrl));
-    }
-
-    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
-    {
-        SafeReturnUrl = !string.IsNullOrEmpty(ReturnUrl) && Url.IsLocalUrl(ReturnUrl) ? ReturnUrl : "/account";
+        return Redirect(_linkGenerator.AccountNameConfirm(protectedFirstName, protectedLastName, ClientRedirectInfo));
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Confirm.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Confirm.cshtml
@@ -2,17 +2,16 @@
 @model TeacherIdentity.AuthServer.Pages.Account.Phone.Confirm
 @{
     ViewBag.Title = "Confirm change";
-
 }
 
 @section BeforeContent
 {
-    <govuk-back-link href="@LinkGenerator.AccountPhone(Model.ReturnUrl)" />
+    <govuk-back-link href="@LinkGenerator.AccountPhone(Model.ClientRedirectInfo)" />
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.AccountPhoneConfirm(Model.MobileNumber!, Model.ReturnUrl)" method="post" asp-antiforgery="true">
+        <form action="@LinkGenerator.AccountPhoneConfirm(Model.MobileNumber!, Model.ClientRedirectInfo)" method="post" asp-antiforgery="true">
             <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
 
             <p>We’ve sent you a text message with a security code to <b data-testid="mobileNumber">@Model.MobileNumber!.PlainValue</b></p>
@@ -22,11 +21,10 @@
             </govuk-input>
 
             <p>
-                <a href="@LinkGenerator.AccountPhoneResend(Model.MobileNumber!, Model.ReturnUrl)">I have not received an text message</a>
+                <a href="@LinkGenerator.AccountPhoneResend(Model.MobileNumber!, Model.ClientRedirectInfo)">I have not received an text message</a>
             </p>
 
             <govuk-button type="submit">Continue</govuk-button>
         </form>
     </div>
 </div>
-

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Confirm.cshtml.cs
@@ -11,19 +11,24 @@ namespace TeacherIdentity.AuthServer.Pages.Account.Phone;
 
 public class Confirm : BasePinVerificationPageModel
 {
-    private TeacherIdentityServerDbContext _dbContext;
-    private IClock _clock;
+    private readonly TeacherIdentityServerDbContext _dbContext;
+    private readonly IIdentityLinkGenerator _linkGenerator;
+    private readonly IClock _clock;
 
     public Confirm(
         IUserVerificationService userVerificationService,
         PinValidator pinValidator,
         TeacherIdentityServerDbContext dbContext,
+        IIdentityLinkGenerator linkGenerator,
         IClock clock) :
         base(userVerificationService, pinValidator)
     {
         _dbContext = dbContext;
+        _linkGenerator = linkGenerator;
         _clock = clock;
     }
+
+    public ClientRedirectInfo? ClientRedirectInfo => HttpContext.GetClientRedirectInfo();
 
     [BindProperty]
     [Display(Name = "Confirmation code")]
@@ -31,11 +36,6 @@ public class Confirm : BasePinVerificationPageModel
 
     [FromQuery(Name = "mobileNumber")]
     public ProtectedString? MobileNumber { get; set; }
-
-    [FromQuery(Name = "returnUrl")]
-    public string? ReturnUrl { get; set; }
-    public string? SafeReturnUrl { get; set; }
-
 
     public void OnGet()
     {
@@ -59,7 +59,7 @@ public class Confirm : BasePinVerificationPageModel
         }
 
         await UpdateUserPhone(User.GetUserId()!.Value);
-        return Redirect(SafeReturnUrl!);
+        return Redirect(_linkGenerator.Account(ClientRedirectInfo));
     }
 
     private async Task UpdateUserPhone(Guid userId)
@@ -102,11 +102,8 @@ public class Confirm : BasePinVerificationPageModel
     {
         if (MobileNumber is null)
         {
-            context.Result = new BadRequestResult();
-            return;
+            context.Result = BadRequest();
         }
-
-        SafeReturnUrl = !string.IsNullOrEmpty(ReturnUrl) && Url.IsLocalUrl(ReturnUrl) ? ReturnUrl : "/account";
     }
 
     protected override Task<PinGenerationResult> GeneratePin()

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Index.cshtml
@@ -5,12 +5,12 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@Model.SafeReturnUrl" />
+    <govuk-back-link href="@LinkGenerator.Account(Model.ClientRedirectInfo)" />
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.AccountPhone(Model.ReturnUrl)" method="post" asp-antiforgery="true">
+        <form action="@LinkGenerator.AccountPhone(Model.ClientRedirectInfo)" method="post" asp-antiforgery="true">
             <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
 
             <p>We’ll send a security code to this number by text message.</p>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Index.cshtml.cs
@@ -1,6 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Pages.Common;
 using TeacherIdentity.AuthServer.Services.UserVerification;
@@ -11,7 +11,7 @@ namespace TeacherIdentity.AuthServer.Pages.Account.Phone;
 public class PhonePage : BasePhonePageModel
 {
     private readonly ProtectedStringFactory _protectedStringFactory;
-    private IIdentityLinkGenerator _linkGenerator;
+    private readonly IIdentityLinkGenerator _linkGenerator;
 
     public PhonePage(
         IUserVerificationService userVerificationService,
@@ -24,14 +24,13 @@ public class PhonePage : BasePhonePageModel
         _protectedStringFactory = protectedStringFactory;
     }
 
+    [BindNever]
+    public ClientRedirectInfo? ClientRedirectInfo => HttpContext.GetClientRedirectInfo();
+
     [Display(Name = "Mobile number", Description = "For international numbers include the country code")]
     [Required(ErrorMessage = "Enter your new mobile phone number")]
     [Phone(ErrorMessage = "Enter a valid mobile phone number")]
     public new string? MobileNumber { get; set; }
-
-    [FromQuery(Name = "returnUrl")]
-    public string? ReturnUrl { get; set; }
-    public string? SafeReturnUrl { get; set; }
 
     public void OnGet()
     {
@@ -64,11 +63,6 @@ public class PhonePage : BasePhonePageModel
 
         var protectedMobileNumber = _protectedStringFactory.CreateFromPlainValue(MobileNumber!);
 
-        return Redirect(_linkGenerator.AccountPhoneConfirm(protectedMobileNumber, ReturnUrl));
-    }
-
-    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
-    {
-        SafeReturnUrl = !string.IsNullOrEmpty(ReturnUrl) && Url.IsLocalUrl(ReturnUrl) ? ReturnUrl : "/account";
+        return Redirect(_linkGenerator.AccountPhoneConfirm(protectedMobileNumber, ClientRedirectInfo));
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Resend.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Resend.cshtml
@@ -5,12 +5,12 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.AccountPhoneConfirm(Model.MobileNumber!, Model.ReturnUrl)" />
+    <govuk-back-link href="@LinkGenerator.AccountPhoneConfirm(Model.MobileNumber!, Model.ClientRedirectInfo)" />
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.AccountPhoneResend(Model.MobileNumber!, Model.ReturnUrl)" method="post" asp-antiforgery="true">
+        <form action="@LinkGenerator.AccountPhoneResend(Model.MobileNumber!, Model.ClientRedirectInfo)" method="post" asp-antiforgery="true">
             <h1 class="govuk-heading-xl">Send new text message</h1>
 
             <p>Text messages sometimes take a few minutes to arrive. If you do not receive the text message, you can request a new one.</p>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Resend.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Resend.cshtml.cs
@@ -23,6 +23,8 @@ public class Resend : BasePhonePageModel
         _protectedStringFactory = protectedStringFactory;
     }
 
+    public ClientRedirectInfo? ClientRedirectInfo => HttpContext.GetClientRedirectInfo();
+
     [BindProperty]
     [Display(Name = "Mobile number")]
     [Required(ErrorMessage = "Enter your new mobile phone number")]
@@ -31,9 +33,6 @@ public class Resend : BasePhonePageModel
 
     [FromQuery(Name = "mobileNumber")]
     public new ProtectedString? MobileNumber { get; set; }
-
-    [FromQuery(Name = "returnUrl")]
-    public string? ReturnUrl { get; set; }
 
     public void OnGet()
     {
@@ -67,14 +66,14 @@ public class Resend : BasePhonePageModel
 
         var protectedMobileNumber = _protectedStringFactory.CreateFromPlainValue(NewMobileNumber!);
 
-        return Redirect(_linkGenerator.AccountPhoneConfirm(protectedMobileNumber, ReturnUrl));
+        return Redirect(_linkGenerator.AccountPhoneConfirm(protectedMobileNumber, ClientRedirectInfo));
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
         if (MobileNumber is null)
         {
-            context.Result = new BadRequestResult();
+            context.Result = BadRequest();
         }
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
@@ -518,6 +518,7 @@ public class Program
 
         app.UseMiddleware<AuthenticationStateMiddleware>();
         app.UseMiddleware<Infrastructure.Middleware.AppendSessionIdToAnalyticsEventsMiddleware>();
+        app.UseWhen(ctx => ctx.Request.Path.StartsWithSegments("/account"), x => x.UseMiddleware<Infrastructure.Middleware.ClientRedirectInfoMiddleware>());
 
         app.UseRouting();
 

--- a/dotnet-authserver/src/TeacherIdentity.TestClient/Views/Shared/_Layout.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.TestClient/Views/Shared/_Layout.cshtml
@@ -57,7 +57,7 @@
             <ul id="navigation" class="govuk-header__navigation-list">
                 <li class="govuk-header__navigation-item">
                   <a class="govuk-header__link" href="@accountLink">
-                      Account
+                      DfE Identity account
                   </a>
                 </li>
               <li class="govuk-header__navigation-item">

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/DateOfBirth/DateOfBirthTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/DateOfBirth/DateOfBirthTests.cs
@@ -1,6 +1,4 @@
-using System.Text.Encodings.Web;
 using TeacherIdentity.AuthServer.Models;
-
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Account.DateOfBirth;
 
 public class DateOfBirthTests : TestBase
@@ -102,17 +100,14 @@ public class DateOfBirthTests : TestBase
     }
 
     [Fact]
-    public async Task Post_ValidDateOfBirth_RedirectsToConfirmPageWithCorrectReturnUrl()
+    public async Task Post_ValidDateOfBirth_RedirectsToConfirmPageWithClientRedirectInfo()
     {
         // Arrange
         var dateOfBirth = new DateOnly(2000, 1, 1);
 
-        var client = TestClients.Client1;
-        var redirectUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority);
+        var clientRedirectInfo = CreateClientRedirectInfo();
 
-        var returnUrl = UrlEncoder.Default.Encode($"/account?client_id={client.ClientId}&redirect_uri={Uri.EscapeDataString(redirectUri)}");
-
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/date-of-birth?returnUrl={returnUrl}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/date-of-birth?{clientRedirectInfo.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
             {
@@ -127,7 +122,7 @@ public class DateOfBirthTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Contains($"returnUrl={returnUrl}", response.Headers.Location?.OriginalString);
+        Assert.Contains(clientRedirectInfo.ToQueryParam(), response.Headers.Location?.OriginalString);
     }
 
     private void MockDqtApiResponse(User user, bool hasDobConflict, bool hasPendingDobChange)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Email/ConfirmTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Email/ConfirmTests.cs
@@ -235,16 +235,13 @@ public class ConfirmTests : TestBase
     }
 
     [Fact]
-    public async Task Post_ValidForm_UpdatesNameEmitsEventAndRedirects()
+    public async Task Post_ValidForm_UpdatesNameEmitsEventAndRedirectsToAccountPage()
     {
         // Arrange
         var user = await TestData.CreateUser(userType: UserType.Default);
         HostFixture.SetUserId(user.UserId);
 
-        var client = TestClients.Client1;
-        var redirectUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority);
-
-        var returnUrl = $"/account?client_id={client.ClientId}&redirect_uri={Uri.EscapeDataString(redirectUri)}";
+        var clientRedirectInfo = CreateClientRedirectInfo();
 
         var newEmail = Faker.Internet.Email();
         var protectedEmail = HostFixture.Services.GetRequiredService<ProtectedStringFactory>().CreateFromPlainValue(newEmail);
@@ -253,7 +250,7 @@ public class ConfirmTests : TestBase
         var pinResult = await userVerificationService.GenerateEmailPin(newEmail);
         Assert.True(pinResult.Succeeded);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/email/confirm?email={UrlEncode(protectedEmail.EncryptedValue)}&returnUrl={UrlEncode(returnUrl)}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/email/confirm?email={UrlEncode(protectedEmail.EncryptedValue)}&{clientRedirectInfo.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
             {
@@ -266,7 +263,7 @@ public class ConfirmTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(returnUrl, response.Headers.Location?.OriginalString);
+        Assert.Equal($"/account?{clientRedirectInfo.ToQueryParam()}", response.Headers.Location?.OriginalString);
 
         user = await TestData.WithDbContext(dbContext => dbContext.Users.SingleAsync(u => u.UserId == user.UserId));
         Assert.Equal(newEmail, user.EmailAddress);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Email/EmailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Email/EmailTests.cs
@@ -1,4 +1,3 @@
-using System.Text.Encodings.Web;
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Tests.Infrastructure;
@@ -111,15 +110,12 @@ public class EmailTests : TestBase
     }
 
     [Fact]
-    public async Task Post_ValidRequest_RedirectsWithCorrectReturnUrl()
+    public async Task Post_ValidRequest_RedirectsWithClientRedirectInfo()
     {
         // Arrange
-        var client = TestClients.Client1;
-        var redirectUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority);
+        var clientRedirectInfo = CreateClientRedirectInfo();
 
-        var returnUrl = UrlEncoder.Default.Encode($"/account?client_id={client.ClientId}&redirect_uri={Uri.EscapeDataString(redirectUri)}");
-
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/email?returnUrl={returnUrl}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/email?{clientRedirectInfo.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
             {
@@ -132,7 +128,7 @@ public class EmailTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Contains($"returnUrl={returnUrl}", response.Headers.Location?.OriginalString);
+        Assert.Contains(clientRedirectInfo.ToQueryParam(), response.Headers.Location?.OriginalString);
     }
 
     [Fact]

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Email/ResendTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Email/ResendTests.cs
@@ -1,4 +1,3 @@
-using System.Text.Encodings.Web;
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Tests.Infrastructure;
@@ -113,15 +112,12 @@ public class ResendTests : TestBase
     }
 
     [Fact]
-    public async Task Post_ValidRequest_RedirectsWithCorrectReturnUrl()
+    public async Task Post_ValidRequest_RedirectsWithClientRedirectInfo()
     {
         // Arrange
-        var client = TestClients.Client1;
-        var redirectUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority);
+        var clientRedirectInfo = CreateClientRedirectInfo();
 
-        var returnUrl = UrlEncoder.Default.Encode($"/account?client_id={client.ClientId}&redirect_uri={Uri.EscapeDataString(redirectUri)}");
-
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/email/resend?email={_email}&returnUrl={returnUrl}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/email/resend?email={_email}&{clientRedirectInfo.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
             {
@@ -134,7 +130,7 @@ public class ResendTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Contains($"returnUrl={returnUrl}", response.Headers.Location?.OriginalString);
+        Assert.Contains(clientRedirectInfo.ToQueryParam(), response.Headers.Location?.OriginalString);
     }
 
     [Fact]

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Name/NameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Name/NameTests.cs
@@ -1,5 +1,3 @@
-using System.Text.Encodings.Web;
-
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Account.Name;
 
 public class NameTests : TestBase
@@ -109,15 +107,12 @@ public class NameTests : TestBase
     }
 
     [Fact]
-    public async Task Post_ValidName_RedirectsToConfirmPageWithCorrectReturnUrl()
+    public async Task Post_ValidName_RedirectsToConfirmPageWithClientRedirectInfo()
     {
         // Arrange
-        var client = TestClients.Client1;
-        var redirectUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority);
+        var clientRedirectInfo = CreateClientRedirectInfo();
 
-        var returnUrl = UrlEncoder.Default.Encode($"/account?client_id={client.ClientId}&redirect_uri={Uri.EscapeDataString(redirectUri)}");
-
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/name?returnUrl={returnUrl}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/name?{clientRedirectInfo.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
             {
@@ -131,6 +126,6 @@ public class NameTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Contains($"returnUrl={returnUrl}", response.Headers.Location?.OriginalString);
+        Assert.Contains(clientRedirectInfo.ToQueryParam(), response.Headers.Location?.OriginalString);
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Phone/PhoneTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Phone/PhoneTests.cs
@@ -1,4 +1,3 @@
-using System.Text.Encodings.Web;
 using TeacherIdentity.AuthServer.Helpers;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Tests.Infrastructure;
@@ -111,15 +110,12 @@ public class PhoneTests : TestBase
     }
 
     [Fact]
-    public async Task Post_ValidRequest_RedirectsWithCorrectReturnUrl()
+    public async Task Post_ValidRequest_RedirectsWithClientRedirectInfo()
     {
         // Arrange
-        var client = TestClients.Client1;
-        var redirectUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority);
+        var clientRedirectInfo = CreateClientRedirectInfo();
 
-        var returnUrl = UrlEncoder.Default.Encode($"/account?client_id={client.ClientId}&redirect_uri={Uri.EscapeDataString(redirectUri)}");
-
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/phone?returnUrl={returnUrl}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/phone?{clientRedirectInfo.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
             {
@@ -132,7 +128,7 @@ public class PhoneTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Contains($"returnUrl={returnUrl}", response.Headers.Location?.OriginalString);
+        Assert.Contains(clientRedirectInfo.ToQueryParam(), response.Headers.Location?.OriginalString);
     }
 
     [Fact]

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Phone/ResendTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Phone/ResendTests.cs
@@ -1,4 +1,3 @@
-using System.Text.Encodings.Web;
 using TeacherIdentity.AuthServer.Helpers;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Tests.Infrastructure;
@@ -114,15 +113,12 @@ public class ResendTests : TestBase
     }
 
     [Fact]
-    public async Task Post_ValidRequest_RedirectsWithCorrectReturnUrl()
+    public async Task Post_ValidRequest_RedirectsWithCorrectClientRedirectInfo()
     {
         // Arrange
-        var client = TestClients.Client1;
-        var redirectUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority);
+        var clientRedirectInfo = CreateClientRedirectInfo();
 
-        var returnUrl = UrlEncoder.Default.Encode($"/account?client_id={client.ClientId}&redirect_uri={Uri.EscapeDataString(redirectUri)}");
-
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/phone/resend?mobileNumber={_mobileNumber}&returnUrl={returnUrl}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/phone/resend?mobileNumber={_mobileNumber}&{clientRedirectInfo.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
             {
@@ -135,7 +131,7 @@ public class ResendTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Contains($"returnUrl={returnUrl}", response.Headers.Location?.OriginalString);
+        Assert.Contains(clientRedirectInfo.ToQueryParam(), response.Headers.Location?.OriginalString);
     }
 
     [Fact]

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/TestBase.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/TestBase.cs
@@ -1,3 +1,6 @@
+using Flurl;
+using Microsoft.AspNetCore.DataProtection;
+using TeacherIdentity.AuthServer.Oidc;
 using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Account;
@@ -29,4 +32,17 @@ public partial class TestBase
     public HttpClient HttpClient { get; }
 
     public SpyRegistry SpyRegistry => HostFixture.SpyRegistry;
+
+    public ClientRedirectInfo CreateClientRedirectInfo() => CreateClientRedirectInfo(TestClients.Client1);
+
+    public ClientRedirectInfo CreateClientRedirectInfo(TeacherIdentityApplicationDescriptor client)
+    {
+        var dataProtectionProvider = HostFixture.Services.GetRequiredService<IDataProtectionProvider>();
+        var dataProtector = dataProtectionProvider.CreateProtector(nameof(ClientRedirectInfo));
+
+        var clientId = client.ClientId!;
+        string redirectUri = new Url(client.RedirectUris.First()).RemoveQuery();
+
+        return new(dataProtector, clientId, redirectUri);
+    }
 }


### PR DESCRIPTION
The `/account` pages are linked to from a client. The client passes its `client_id` and a `redirect_uri` (and in future, a sign out URI). We use this to link back to the calling service from the account pages.

Up until this point we've used a `returnUrl` callback parameter on all pages to ensure we can always get back to the root `/account` page with all this context intact. However, this is becoming unwieldy, especially now we're looking at adding even more context (sign out URI). Some journeys would need to track multiple return URLs too; one for the success case and another for the cancel (or back button) case.

We have some prior art for dealing with this - the `asid` query parameter we use for passing around the ID for a user's `AuthenticationState`. This works fairly well with `IIdentityLinkGenerator` and in tests so I've opted for something similar here. In this case it's much simpler, since the state is not mutable and can easily fit into the URL.

This change introduces a `ClientRedirectInfo` class to store the client ID and its callback URLs. There's a middleware that looks for the corresponding query parameters, validates them and assigns a `ClientRedirectInfo` if they're valid. It also returns an error if they're not valid. From then on the state is passed around a single string, encrypted using an `IDataProtector`. This ensures it cannot be tampered with. The appropriate methods on `IIdentityLinkGenerator` have been amended to take an optional `ClientRedirectInfo`.

I initially implemented this as a custom model binder but there are situations where we'll want to access this data where we won't have access to model binding (e.g. the nav UI in our layout file).