### PR TITLE
Add better message when Staff users try to sign in to non-Staff service

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/EmailConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/EmailConfirmation.cshtml.cs
@@ -53,6 +53,16 @@ public class EmailConfirmationModel : BaseEmailConfirmationPageModel
         // If the UserType is not allowed then return an error
         if (user is not null && !permittedUserTypes.Contains(user.UserType))
         {
+            // The most common case is Staff users attempting to sign in to a 'regular' service.
+            if (user.UserType == UserType.Staff)
+            {
+                return new ViewResult()
+                {
+                    ViewName = "StaffUserForbidden",
+                    StatusCode = StatusCodes.Status403Forbidden
+                };
+            }
+
             return new ForbidResult();
         }
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Views/Shared/StaffUserForbidden.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Views/Shared/StaffUserForbidden.cshtml
@@ -1,0 +1,12 @@
+@{
+    ViewBag.Title = "Forbidden";
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-l">Forbidden</h1>
+        <p>
+            Staff users are not allowed to access this resource.
+        </p>
+    </div>
+</div>


### PR DESCRIPTION
When Staff users attempt to sign in to a non-Staff service (as happens somewhat-frequently during development) we were showing a generic Forbidden error. This change adds another view with a better error message for this specific case.