### PR TITLE
Add DOB conflict tag to analytics event

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
@@ -1,11 +1,9 @@
 @page "/account"
-@using Microsoft.ApplicationInsights.AspNetCore.Extensions
 @model TeacherIdentity.AuthServer.Pages.Account.IndexModel
 @{
     ViewBag.Title = "DfE Identity account";
 
-    var dateOfBirthConflict = Model.DqtDateOfBirth is not null && !Model.DqtDateOfBirth.Equals(Model.DateOfBirth);
-    var dateOfBirthChangeEnabled = Model.DqtDateOfBirth is null || (dateOfBirthConflict && !Model.PendingDqtDateOfBirthChange);
+    var dateOfBirthChangeEnabled = Model.DqtDateOfBirth is null || (Model.DateOfBirthConflict && !Model.PendingDqtDateOfBirthChange);
 }
 
 @section BeforeContent
@@ -22,7 +20,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        @if (dateOfBirthConflict && !Model.PendingDqtDateOfBirthChange)
+        @if (Model.DateOfBirthConflict && !Model.PendingDqtDateOfBirthChange)
         {
             <govuk-notification-banner data-testid="dob-conflict-notification-banner">
                 <h3 class="govuk-notification-banner__heading">Confirm your correct date of birth</h3>
@@ -71,7 +69,7 @@
                 <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
                 <govuk-summary-list-row-value>
                     @Model.DateOfBirth?.ToString("dd MMMM yyyy")
-                    @if (dateOfBirthConflict)
+                    @if (Model.DateOfBirthConflict)
                     {
                         <p class="govuk-hint govuk-!-font-size-14" data-testid="dob-hint-text">Entered when creating account</p>
                     }
@@ -87,7 +85,7 @@
                     </govuk-summary-list-row-actions>
                 }
             </govuk-summary-list-row>
-            @if (dateOfBirthConflict)
+            @if (Model.DateOfBirthConflict)
             {
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml.cs
@@ -1,3 +1,4 @@
+using Dfe.Analytics.AspNetCore;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Models;
@@ -34,6 +35,7 @@ public class IndexModel : PageModel
     public DateOnly? DqtDateOfBirth { get; set; }
     public bool PendingDqtNameChange { get; set; }
     public bool PendingDqtDateOfBirthChange { get; set; }
+    public bool DateOfBirthConflict { get; set; }
 
     public async Task OnGet()
     {
@@ -67,6 +69,12 @@ public class IndexModel : PageModel
             DqtDateOfBirth = dqtUser.DateOfBirth;
             PendingDqtNameChange = dqtUser.PendingNameChange;
             PendingDqtDateOfBirthChange = dqtUser.PendingDateOfBirthChange;
+
+            if (!DqtDateOfBirth.Equals(DateOfBirth))
+            {
+                DateOfBirthConflict = true;
+                HttpContext.Features.Get<WebRequestEventFeature>()?.Event.AddTag("DateOfBirthConflict");
+            }
         }
 
         if (ClientRedirectInfo is not null)


### PR DESCRIPTION
### Context

We want to track when a user visits the account page and has a different DOB in ID to their DQT record.

### Changes proposed in this pull request

Amend the /account page to add a DateOfBirthConflict tag to the analytics event when user’s account is linked to a TRN and the ID DOB does not match the DQT DOB.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
