### PR TITLE
Fix Email page content for Core journey

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Email.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Email.cshtml
@@ -4,20 +4,41 @@
     ViewBag.Title = "Your email address";
 }
 
+@if (Model.JourneyType == AuthenticationJourneyType.Core)
+{
+    @section BeforeContent {
+        <govuk-back-link href="@LinkGenerator.Landing()">Back</govuk-back-link>
+    }
+}
+
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <form action="@LinkGenerator.Email()" method="post" asp-antiforgery="true">
-            <h1 class="govuk-heading-xl">Your email address</h1>
+            @if (Model.JourneyType == AuthenticationJourneyType.LegacyTrn)
+            {
+                <h1 class="govuk-heading-xl">Your email address</h1>
 
-            <p>We use your email address to find your details in our records.</p>
+                <p>We use your email address to find your details in our records.</p>
 
-            <p>If we do not recognise your email, we’ll ask you for a few details instead.</p>
+                <p>If we do not recognise your email, we’ll ask you for a few details instead.</p>
 
-            <p>You’ll receive a code by email to confirm your email address.</p>
+                <p>You’ll receive a code by email to confirm your email address.</p>
 
-            <govuk-input asp-for="Email" type="email" autocomplete="email">
-                <govuk-input-label class="govuk-label--s" />
-            </govuk-input>
+                <govuk-input asp-for="Email" type="email" autocomplete="email">
+                    <govuk-input-label class="govuk-label--s">
+                        Enter your email address
+                    </govuk-input-label>
+                    <govuk-input-hint>
+                        Use your personal email address. This is so you can keep these sign in details should you change jobs.
+                    </govuk-input-hint>
+                </govuk-input>
+            }
+            else
+            {
+                <govuk-input asp-for="Email" type="email" autocomplete="email">
+                    <govuk-input-label class="govuk-label--xl" />
+                </govuk-input>
+            }
 
             <govuk-button type="submit">Continue</govuk-button>
         </form>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Email.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Email.cshtml.cs
@@ -6,7 +6,6 @@ using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn;
 
-[BindProperties]
 [RequireAuthenticationMilestone(AuthenticationState.AuthenticationMilestone.None)]
 public class EmailModel : BaseEmailPageModel
 {
@@ -18,10 +17,13 @@ public class EmailModel : BaseEmailPageModel
     {
     }
 
-    [Display(Name = "Enter your email address", Description = "Use your personal email address. This is so you can keep these sign in details should you change jobs.")]
+    [BindProperty]
+    [Display(Name = "Your email address", Description = "Enter the email you used when creating your DfE Identity account.")]
     [Required(ErrorMessage = "Enter your email address")]
     [EmailAddress(ErrorMessage = "Enter a valid email address")]
     public string? Email { get; set; }
+
+    public AuthenticationJourneyType JourneyType => HttpContext.GetAuthenticationState().GetJourneyType();
 
     public void OnGet()
     {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Api.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Api.cs
@@ -27,7 +27,7 @@ public class Api : IClassFixture<HostFixture>
 
         // Fill in the sign in form (email + PIN)
 
-        await page.FillAsync("text=Enter your email address", adminUser.EmailAddress);
+        await page.FillAsync("text=Your email address", adminUser.EmailAddress);
         await page.ClickAsync("button:text-is('Continue')");
 
         var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
@@ -89,7 +89,7 @@ public class Api : IClassFixture<HostFixture>
 
         // Fill in the sign in form (email + PIN)
 
-        await page.FillAsync("text=Enter your email address", adminUser.EmailAddress);
+        await page.FillAsync("text=Your email address", adminUser.EmailAddress);
         await page.ClickAsync("button:text-is('Continue')");
 
         var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
@@ -45,8 +45,8 @@ public static class PageExtensions
 
     public static async Task SubmitEmailPage(this IPage page, string email)
     {
-        await page.WaitForSelectorAsync("h1:text-is('Your email address')");
-        await page.FillAsync("text=Enter your email address", email);
+        await page.WaitForSelectorAsync(":text-is('Your email address')");
+        await page.FillAsync("input[type='email']", email);
         await page.ClickAsync("button:text-is('Continue')");
     }
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignIn.StaffUser.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignIn.StaffUser.cs
@@ -29,7 +29,7 @@ public partial class SignIn
 
         // Fill in the sign in form (email + PIN)
 
-        await page.FillAsync("text=Enter your email address", staffUser.EmailAddress);
+        await page.FillAsync("text=Your email address", staffUser.EmailAddress);
         await page.ClickAsync("button:text-is('Continue')");
 
         var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
@@ -60,7 +60,7 @@ public partial class SignIn
 
         // Fill in the sign in form (email + PIN)
 
-        await page.FillAsync("text=Enter your email address", staffUser.EmailAddress);
+        await page.FillAsync("text=Your email address", staffUser.EmailAddress);
         await page.ClickAsync("button:text-is('Continue')");
 
         var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
@@ -82,7 +82,7 @@ public partial class SignIn
 
         // Fill in the sign in form (email + PIN)
 
-        await page.FillAsync("text=Enter your email address", user.EmailAddress);
+        await page.FillAsync("text=Your email address", user.EmailAddress);
         await page.ClickAsync("button:text-is('Continue')");
 
         var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;


### PR DESCRIPTION
The Email page is used in multiple journeys but its different content should be different depending on the journey type.

This makes the default content that for the `Core` journey and special cases the `LegacyTrn` journey.