### PR TITLE
Add nav to account pages

### DIFF
--- a/docs/account-page.md
+++ b/docs/account-page.md
@@ -1,0 +1,24 @@
+# Account page
+
+The Account page in Identity is built so that users can navigate from a client service to the account page and back again seemlessly.
+
+For this to work, the account page needs some additional context passing to it so that it knows which service linked to it.
+That context is provided as three query parameters, detailed below:
+
+## `client_id`
+This is the same `client_id` as used in the OAuth sign in request.
+
+## `redirect_uri`
+The fully-qualified URL to send a user back to when they're done on the account page.
+This domain portion of this `redirect_uri` must match the domain portion of a pre-configured `redirect_uri` in ID for the client.
+(Note that unlike the `redirect_uri` provided for an OAuth request, this does not have to match exactly.)
+
+## `sign_out_uri`
+The fully-qualified URL to send a user to that begins the sign out process. It's important that the sign out process signs the user
+out of both the client and Identity. (See [the OIDC spec](https://openid.net/specs/openid-connect-rpinitiated-1_0.html) for more information.)
+This domain portion of this `sign_out_uri` must match the domain portion of a pre-configured `redirect_uri` in ID for the client.
+(Note that unlike the `redirect_uri` provided for an OAuth request, this does not have to match exactly.)
+
+
+## Example URL
+`https://preprod.teaching-identity.education.gov.uk/account?client_id=testclient&redirect_uri=https%3A%2F%2Fs165t01-getanid-preprod-testc-app.azurewebsites.net&sign_out_uri=https%3A%2F%2Fs165t01-getanid-preprod-testc-app.azurewebsites.net%2Fsign-out`

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/ClientRedirectInfo.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/ClientRedirectInfo.cs
@@ -11,20 +11,22 @@ public sealed record ClientRedirectInfo
 
     private readonly string _encoded;
 
-    public ClientRedirectInfo(IDataProtector dataProtector, string clientId, string redirectUri)
-        : this(Encode(clientId, redirectUri, dataProtector), clientId, redirectUri)
+    public ClientRedirectInfo(IDataProtector dataProtector, string clientId, string redirectUri, string signOutUri)
+        : this(Encode(clientId, redirectUri, signOutUri, dataProtector), clientId, redirectUri, signOutUri)
     {
     }
 
-    private ClientRedirectInfo(string encoded, string clientId, string redirectUri)
+    private ClientRedirectInfo(string encoded, string clientId, string redirectUri, string signOutUri)
     {
         ClientId = clientId;
         RedirectUri = redirectUri;
+        SignOutUri = signOutUri;
         _encoded = encoded;
     }
 
     public string ClientId { get; }
     public string RedirectUri { get; }
+    public string SignOutUri { get; }
 
     public static bool TryDecode(string encoded, IDataProtector dataProtector, [NotNullWhen(true)] out ClientRedirectInfo? clientRedirectInfo)
     {
@@ -42,16 +44,18 @@ public sealed record ClientRedirectInfo
         var asQueryParams = QueryHelpers.ParseQuery(unprotected);
         var clientId = asQueryParams[nameof(ClientId)].ToString();
         var redirectUri = asQueryParams[nameof(RedirectUri)].ToString();
+        var signOutUri = asQueryParams[nameof(SignOutUri)].ToString();
 
-        clientRedirectInfo = new ClientRedirectInfo(encoded, clientId, redirectUri);
+        clientRedirectInfo = new ClientRedirectInfo(encoded, clientId, redirectUri, signOutUri);
         return true;
     }
 
-    private static string Encode(string clientId, string redirectUri, IDataProtector dataProtector)
+    private static string Encode(string clientId, string redirectUri, string signOutUri, IDataProtector dataProtector)
     {
         var asQueryParams = QueryString
            .Create(nameof(ClientId), clientId)
            .Add(nameof(RedirectUri), redirectUri)
+           .Add(nameof(SignOutUri), signOutUri)
            .Value!;
 
         return dataProtector.Protect(asQueryParams);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -15,188 +15,190 @@ public abstract class IdentityLinkGenerator
 
     protected QueryStringSignatureHelper QueryStringSignatureHelper { get; }
 
-    protected abstract string PageWithAuthenticationJourneyId(string pageName, bool authenticationJourneyRequired = true);
+    protected abstract string Page(string pageName, bool authenticationJourneyRequired = true);
 
-    public string CompleteAuthorization() => PageWithAuthenticationJourneyId("/SignIn/Complete");
+    public string CompleteAuthorization() => Page("/SignIn/Complete");
 
-    public string Reset() => PageWithAuthenticationJourneyId("/SignIn/Reset");
+    public string Reset() => Page("/SignIn/Reset");
 
-    public string Email() => PageWithAuthenticationJourneyId("/SignIn/Email");
+    public string Email() => Page("/SignIn/Email");
 
-    public string EmailConfirmation() => PageWithAuthenticationJourneyId("/SignIn/EmailConfirmation");
+    public string EmailConfirmation() => Page("/SignIn/EmailConfirmation");
 
-    public string ResendEmailConfirmation() => PageWithAuthenticationJourneyId("/SignIn/ResendEmailConfirmation");
+    public string ResendEmailConfirmation() => Page("/SignIn/ResendEmailConfirmation");
 
-    public string ResendTrnOwnerEmailConfirmation() => PageWithAuthenticationJourneyId("/SignIn/ResendTrnOwnerEmailConfirmation");
+    public string ResendTrnOwnerEmailConfirmation() => Page("/SignIn/ResendTrnOwnerEmailConfirmation");
 
-    public string Trn() => PageWithAuthenticationJourneyId("/SignIn/Trn");
+    public string Trn() => Page("/SignIn/Trn");
 
-    public string TrnInUse() => PageWithAuthenticationJourneyId("/SignIn/TrnInUse");
+    public string TrnInUse() => Page("/SignIn/TrnInUse");
 
-    public string TrnInUseChooseEmail() => PageWithAuthenticationJourneyId("/SignIn/TrnInUseChooseEmail");
+    public string TrnInUseChooseEmail() => Page("/SignIn/TrnInUseChooseEmail");
 
-    public string TrnInUseCannotAccessEmail() => PageWithAuthenticationJourneyId("/SignIn/TrnInUseCannotAccessEmail");
+    public string TrnInUseCannotAccessEmail() => Page("/SignIn/TrnInUseCannotAccessEmail");
 
-    public string TrnCallback() => PageWithAuthenticationJourneyId("/SignIn/TrnCallback");
+    public string TrnCallback() => Page("/SignIn/TrnCallback");
 
-    public string TrnHasTrn() => PageWithAuthenticationJourneyId("/SignIn/Trn/HasTrnPage");
+    public string TrnHasTrn() => Page("/SignIn/Trn/HasTrnPage");
 
-    public string TrnOfficialName() => PageWithAuthenticationJourneyId("/SignIn/Trn/OfficialName");
+    public string TrnOfficialName() => Page("/SignIn/Trn/OfficialName");
 
-    public string TrnPreferredName() => PageWithAuthenticationJourneyId("/SignIn/Trn/PreferredName");
+    public string TrnPreferredName() => Page("/SignIn/Trn/PreferredName");
 
-    public string TrnDateOfBirth() => PageWithAuthenticationJourneyId("/SignIn/Trn/DateOfBirthPage");
+    public string TrnDateOfBirth() => Page("/SignIn/Trn/DateOfBirthPage");
 
-    public string TrnHasNiNumber() => PageWithAuthenticationJourneyId("/SignIn/Trn/HasNiNumberPage");
+    public string TrnHasNiNumber() => Page("/SignIn/Trn/HasNiNumberPage");
 
-    public string TrnNiNumber() => PageWithAuthenticationJourneyId("/SignIn/Trn/NiNumberPage");
+    public string TrnNiNumber() => Page("/SignIn/Trn/NiNumberPage");
 
-    public string TrnAwardedQts() => PageWithAuthenticationJourneyId("/SignIn/Trn/AwardedQtsPage");
+    public string TrnAwardedQts() => Page("/SignIn/Trn/AwardedQtsPage");
 
-    public string TrnIttProvider() => PageWithAuthenticationJourneyId("/SignIn/Trn/IttProvider");
+    public string TrnIttProvider() => Page("/SignIn/Trn/IttProvider");
 
-    public string TrnCheckAnswers() => PageWithAuthenticationJourneyId("/SignIn/Trn/CheckAnswers");
+    public string TrnCheckAnswers() => Page("/SignIn/Trn/CheckAnswers");
 
-    public string TrnNoMatch() => PageWithAuthenticationJourneyId("/SignIn/Trn/NoMatch");
+    public string TrnNoMatch() => Page("/SignIn/Trn/NoMatch");
 
-    public string Landing() => PageWithAuthenticationJourneyId("/SignIn/Landing");
+    public string Landing() => Page("/SignIn/Landing");
 
-    public string Register() => PageWithAuthenticationJourneyId("/SignIn/Register/Index");
+    public string Register() => Page("/SignIn/Register/Index");
 
-    public string RegisterEmail() => PageWithAuthenticationJourneyId("/SignIn/Register/Email");
+    public string RegisterEmail() => Page("/SignIn/Register/Email");
 
-    public string RegisterEmailConfirmation() => PageWithAuthenticationJourneyId("/SignIn/Register/EmailConfirmation");
+    public string RegisterEmailConfirmation() => Page("/SignIn/Register/EmailConfirmation");
 
-    public string RegisterEmailExists() => PageWithAuthenticationJourneyId("/SignIn/Register/EmailExists");
+    public string RegisterEmailExists() => Page("/SignIn/Register/EmailExists");
 
-    public string RegisterPhone() => PageWithAuthenticationJourneyId("/SignIn/Register/Phone");
+    public string RegisterPhone() => Page("/SignIn/Register/Phone");
 
-    public string RegisterPhoneConfirmation() => PageWithAuthenticationJourneyId("/SignIn/Register/PhoneConfirmation");
+    public string RegisterPhoneConfirmation() => Page("/SignIn/Register/PhoneConfirmation");
 
-    public string RegisterResendPhoneConfirmation() => PageWithAuthenticationJourneyId("/SignIn/Register/ResendPhoneConfirmation");
+    public string RegisterResendPhoneConfirmation() => Page("/SignIn/Register/ResendPhoneConfirmation");
 
-    public string RegisterPhoneExists() => PageWithAuthenticationJourneyId("/SignIn/Register/PhoneExists");
+    public string RegisterPhoneExists() => Page("/SignIn/Register/PhoneExists");
 
-    public string RegisterName() => PageWithAuthenticationJourneyId("/SignIn/Register/Name");
+    public string RegisterName() => Page("/SignIn/Register/Name");
 
-    public string RegisterDateOfBirth() => PageWithAuthenticationJourneyId("/SignIn/Register/DateOfBirthPage");
+    public string RegisterDateOfBirth() => Page("/SignIn/Register/DateOfBirthPage");
 
-    public string RegisterAccountExists() => PageWithAuthenticationJourneyId("/SignIn/Register/AccountExists");
+    public string RegisterAccountExists() => Page("/SignIn/Register/AccountExists");
 
-    public string RegisterExistingAccountEmailConfirmation() => PageWithAuthenticationJourneyId("/SignIn/Register/ExistingAccountEmailConfirmation");
+    public string RegisterExistingAccountEmailConfirmation() => Page("/SignIn/Register/ExistingAccountEmailConfirmation");
 
-    public string RegisterResendEmailConfirmation() => PageWithAuthenticationJourneyId("/SignIn/Register/ResendEmailConfirmation");
+    public string RegisterResendEmailConfirmation() => Page("/SignIn/Register/ResendEmailConfirmation");
 
-    public string RegisterResendExistingAccountEmail() => PageWithAuthenticationJourneyId("/SignIn/Register/ResendExistingAccountEmail");
+    public string RegisterResendExistingAccountEmail() => Page("/SignIn/Register/ResendExistingAccountEmail");
 
-    public string RegisterExistingAccountPhone() => PageWithAuthenticationJourneyId("/SignIn/Register/ExistingAccountPhone");
+    public string RegisterExistingAccountPhone() => Page("/SignIn/Register/ExistingAccountPhone");
 
-    public string RegisterResendExistingAccountPhone() => PageWithAuthenticationJourneyId("/SignIn/Register/ResendExistingAccountPhone");
+    public string RegisterResendExistingAccountPhone() => Page("/SignIn/Register/ResendExistingAccountPhone");
 
-    public string RegisterExistingAccountPhoneConfirmation() => PageWithAuthenticationJourneyId("/SignIn/Register/ExistingAccountPhoneConfirmation");
+    public string RegisterExistingAccountPhoneConfirmation() => Page("/SignIn/Register/ExistingAccountPhoneConfirmation");
 
-    public string RegisterChangeEmailRequest() => PageWithAuthenticationJourneyId("/SignIn/Register/ChangeEmailRequest");
+    public string RegisterChangeEmailRequest() => Page("/SignIn/Register/ChangeEmailRequest");
 
     public string UpdateEmail(string? returnUrl, string? cancelUrl) =>
-        PageWithAuthenticationJourneyId("/Authenticated/UpdateEmail/Index", authenticationJourneyRequired: false)
+        Page("/Authenticated/UpdateEmail/Index", authenticationJourneyRequired: false)
             .SetQueryParam("returnUrl", returnUrl)
             .SetQueryParam("cancelUrl", cancelUrl);
 
     public string UpdateEmailConfirmation(string email, string? returnUrl, string? cancelUrl) =>
-        PageWithAuthenticationJourneyId("/Authenticated/UpdateEmail/Confirmation", authenticationJourneyRequired: false)
+        Page("/Authenticated/UpdateEmail/Confirmation", authenticationJourneyRequired: false)
             .SetQueryParam("email", email)
             .SetQueryParam("returnUrl", returnUrl)
             .SetQueryParam("cancelUrl", cancelUrl)
             .AppendQueryStringSignature(QueryStringSignatureHelper);
 
     public string ResendUpdateEmailConfirmation(string email, string? returnUrl, string? cancelUrl) =>
-        PageWithAuthenticationJourneyId("/Authenticated/UpdateEmail/ResendConfirmation", authenticationJourneyRequired: false)
+        Page("/Authenticated/UpdateEmail/ResendConfirmation", authenticationJourneyRequired: false)
             .SetQueryParam("email", email)
             .SetQueryParam("returnUrl", returnUrl)
             .SetQueryParam("cancelUrl", cancelUrl)
             .AppendQueryStringSignature(QueryStringSignatureHelper);
 
     public string UpdateName(string? returnUrl, string? cancelUrl) =>
-        PageWithAuthenticationJourneyId("/Authenticated/UpdateName", authenticationJourneyRequired: false)
+        Page("/Authenticated/UpdateName", authenticationJourneyRequired: false)
             .SetQueryParam("returnUrl", returnUrl)
             .SetQueryParam("cancelUrl", cancelUrl);
 
     public string Account(ClientRedirectInfo? clientRedirectInfo) =>
-        PageWithAuthenticationJourneyId("/Account/Index", authenticationJourneyRequired: false)
+        Page("/Account/Index", authenticationJourneyRequired: false)
             .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo);
 
+    public string AccountSignOut() =>
+        Page("/Account/SignOut", authenticationJourneyRequired: false);
+
     public string AccountName(ClientRedirectInfo? clientRedirectInfo) =>
-        PageWithAuthenticationJourneyId("/Account/Name/Index", authenticationJourneyRequired: false)
+        Page("/Account/Name/Index", authenticationJourneyRequired: false)
             .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo);
 
     public string AccountNameConfirm(string firstName, string lastName, ClientRedirectInfo? clientRedirectInfo) =>
-        PageWithAuthenticationJourneyId("/Account/Name/Confirm", authenticationJourneyRequired: false)
+        Page("/Account/Name/Confirm", authenticationJourneyRequired: false)
             .SetQueryParam("firstName", firstName)
             .SetQueryParam("lastName", lastName)
             .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo)
             .AppendQueryStringSignature(QueryStringSignatureHelper);
 
     public string AccountDateOfBirth(ClientRedirectInfo? clientRedirectInfo) =>
-        PageWithAuthenticationJourneyId("/Account/DateOfBirth/Index", authenticationJourneyRequired: false)
+        Page("/Account/DateOfBirth/Index", authenticationJourneyRequired: false)
             .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo);
 
     public string AccountDateOfBirthConfirm(DateOnly dateOfBirth, ClientRedirectInfo? clientRedirectInfo) =>
-        PageWithAuthenticationJourneyId("/Account/DateOfBirth/Confirm", authenticationJourneyRequired: false)
+        Page("/Account/DateOfBirth/Confirm", authenticationJourneyRequired: false)
             .SetQueryParam("dateOfBirth", dateOfBirth.ToString(DateOfBirthFormat))
             .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo)
             .AppendQueryStringSignature(QueryStringSignatureHelper);
 
     public string AccountEmail(ClientRedirectInfo? clientRedirectInfo) =>
-        PageWithAuthenticationJourneyId("/Account/Email/Index", authenticationJourneyRequired: false)
+        Page("/Account/Email/Index", authenticationJourneyRequired: false)
             .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo);
 
     public string AccountEmailResend(string email, ClientRedirectInfo? clientRedirectInfo) =>
-        PageWithAuthenticationJourneyId("/Account/Email/Resend", authenticationJourneyRequired: false)
+        Page("/Account/Email/Resend", authenticationJourneyRequired: false)
             .SetQueryParam("email", email)
             .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo)
             .AppendQueryStringSignature(QueryStringSignatureHelper);
 
     public string AccountEmailConfirm(string email, ClientRedirectInfo? clientRedirectInfo) =>
-        PageWithAuthenticationJourneyId("/Account/Email/Confirm", authenticationJourneyRequired: false)
+        Page("/Account/Email/Confirm", authenticationJourneyRequired: false)
             .SetQueryParam("email", email)
             .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo)
             .AppendQueryStringSignature(QueryStringSignatureHelper);
 
     public string AccountPhone(ClientRedirectInfo? clientRedirectInfo) =>
-        PageWithAuthenticationJourneyId("/Account/Phone/Index", authenticationJourneyRequired: false)
+        Page("/Account/Phone/Index", authenticationJourneyRequired: false)
             .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo);
 
     public string AccountPhoneResend(string mobileNumber, ClientRedirectInfo? clientRedirectInfo) =>
-        PageWithAuthenticationJourneyId("/Account/Phone/Resend", authenticationJourneyRequired: false)
+        Page("/Account/Phone/Resend", authenticationJourneyRequired: false)
             .SetQueryParam("mobileNumber", mobileNumber)
             .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo)
             .AppendQueryStringSignature(QueryStringSignatureHelper);
 
     public string AccountPhoneConfirm(string mobileNumber, ClientRedirectInfo? clientRedirectInfo) =>
-        PageWithAuthenticationJourneyId("/Account/Phone/Confirm", authenticationJourneyRequired: false)
+        Page("/Account/Phone/Confirm", authenticationJourneyRequired: false)
             .SetQueryParam("mobileNumber", mobileNumber)
             .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo)
             .AppendQueryStringSignature(QueryStringSignatureHelper);
 
     public string AccountOfficialName(ClientRedirectInfo? clientRedirectInfo) =>
-        PageWithAuthenticationJourneyId("/Account/OfficialName/Index", authenticationJourneyRequired: false)
+        Page("/Account/OfficialName/Index", authenticationJourneyRequired: false)
             .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo);
 
     public string AccountOfficialNameDetails(ClientRedirectInfo? clientRedirectInfo) =>
-        PageWithAuthenticationJourneyId("/Account/OfficialName/Details", authenticationJourneyRequired: false)
+        Page("/Account/OfficialName/Details", authenticationJourneyRequired: false)
             .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo);
 
     public string AccountOfficialNameEvidence(string firstName, string? middleName, string lastName, ClientRedirectInfo? clientRedirectInfo) =>
-        PageWithAuthenticationJourneyId("/Account/OfficialName/Evidence", authenticationJourneyRequired: false)
+        Page("/Account/OfficialName/Evidence", authenticationJourneyRequired: false)
             .SetQueryParam("firstName", firstName)
             .SetQueryParam("middleName", middleName)
             .SetQueryParam("lastName", lastName)
             .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo)
             .AppendQueryStringSignature(QueryStringSignatureHelper);
 
-    // refactor this!
     public string AccountOfficialNameConfirm(string firstName, string? middleName, string lastName, string fileId, string fileName, ClientRedirectInfo? clientRedirectInfo) =>
-        PageWithAuthenticationJourneyId("/Account/OfficialName/Confirm", authenticationJourneyRequired: false)
+        Page("/Account/OfficialName/Confirm", authenticationJourneyRequired: false)
             .SetQueryParam("firstName", firstName)
             .SetQueryParam("middleName", middleName)
             .SetQueryParam("lastName", lastName)
@@ -206,13 +208,13 @@ public abstract class IdentityLinkGenerator
             .AppendQueryStringSignature(QueryStringSignatureHelper);
 
     public string Cookies() =>
-        PageWithAuthenticationJourneyId("/Cookies", authenticationJourneyRequired: false);
+        Page("/Cookies", authenticationJourneyRequired: false);
 
     public string Privacy() =>
-        PageWithAuthenticationJourneyId("/Privacy", authenticationJourneyRequired: false);
+        Page("/Privacy", authenticationJourneyRequired: false);
 
     public string Accessibility() =>
-        PageWithAuthenticationJourneyId("/Accessibility", authenticationJourneyRequired: false);
+        Page("/Accessibility", authenticationJourneyRequired: false);
 }
 
 public class MvcIdentityLinkGenerator : IdentityLinkGenerator
@@ -230,7 +232,7 @@ public class MvcIdentityLinkGenerator : IdentityLinkGenerator
         _httpContextAccessor = httpContextAccessor;
     }
 
-    protected override string PageWithAuthenticationJourneyId(string pageName, bool authenticationJourneyRequired = true)
+    protected override string Page(string pageName, bool authenticationJourneyRequired = true)
     {
         var httpContext = _httpContextAccessor.HttpContext ?? throw new InvalidOperationException("No HttpContext.");
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/SignOut.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/SignOut.cshtml
@@ -1,0 +1,15 @@
+@page "/account/sign-out"
+@addTagHelper *, Joonasw.AspNetCore.SecurityHeaders
+@model TeacherIdentity.AuthServer.Pages.Account.SignOutModel
+@{
+    ViewBag.Title = "Sign out";
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.AccountSignOut()" method="post" asp-antiforgery="true">
+            <govuk-button type="submit">Sign out</govuk-button>
+        </form>
+        <script asp-add-nonce="true">document.forms[0].submit();</script>
+    </div>
+</div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/SignOut.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/SignOut.cshtml.cs
@@ -1,0 +1,19 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeacherIdentity.AuthServer.Pages.Account;
+
+public class SignOutModel : PageModel
+{
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
+        return Redirect("/");
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/_Layout.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/_Layout.cshtml
@@ -1,0 +1,38 @@
+@using Microsoft.AspNetCore.Http.Extensions
+@{
+    ViewBag.ServiceName = "DfE Identity account";
+    ViewBag.ServiceUrl = LinkGenerator.Account(Context.GetClientRedirectInfo());
+    Layout = "/Views/Shared/_Layout.cshtml";
+
+    var signOutUrl = Context.GetClientRedirectInfo()?.SignOutUri ?? LinkGenerator.AccountSignOut();
+}
+
+@section HeaderNav {
+    <nav aria-label="Menu" class="govuk-header__navigation">
+        <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide menu" hidden>Menu</button>
+        <ul id="navigation" class="govuk-header__navigation-list">
+            <li class="govuk-header__navigation-item @(Context.Request.Path.StartsWithSegments("/account") ? "govuk-header__navigation-item--active" : "")">
+                <a class="govuk-header__link" href="@LinkGenerator.Account(Context.GetClientRedirectInfo())">DfE Identity account</a>
+            </li>
+            <li class="govuk-header__navigation-item @(Context.Request.Path.StartsWithSegments("/sign-out") ? "govuk-header__navigation-item--active" : "")">
+                <a class="govuk-header__link" href="@signOutUrl">Sign out</a>
+            </li>
+        </ul>
+    </nav>
+}
+
+@section BeforeContent {
+    @RenderSection("BeforeContent", required: false)
+}
+
+@section Styles
+{
+    @RenderSection("Styles", required: false)
+}
+
+@section Scripts
+{
+    @RenderSection("Scripts", required: false)
+}
+
+@RenderBody()

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/_ViewStart.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/_ViewStart.cshtml
@@ -1,0 +1,3 @@
+@{
+    Layout = "./_Layout";
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
@@ -164,13 +164,21 @@ public class Program
                     ClaimsPrincipal? user = null;
                     string? clientId = null;
 
-                    var oidcAuthenticateResult = await httpContext.AuthenticateAsync(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
-                    if (oidcAuthenticateResult.Succeeded)
+                    try
                     {
-                        user = oidcAuthenticateResult.Principal;
-                        clientId = user.FindFirstValue(Claims.Audience);
+                        var oidcAuthenticateResult = await httpContext.AuthenticateAsync(OpenIddictServerAspNetCoreDefaults.AuthenticationScheme);
+                        if (oidcAuthenticateResult.Succeeded)
+                        {
+                            user = oidcAuthenticateResult.Principal;
+                            clientId = user.FindFirstValue(Claims.Audience);
+                        }
                     }
-                    else
+                    catch (InvalidOperationException)
+                    {
+                        // OIDC handler will throw when AuthenticateAsync is called if it's not an endpoint it manages
+                    }
+
+                    if (user is null)
                     {
                         var cookiesAuthenticateResult = await httpContext.AuthenticateAsync(CookieAuthenticationDefaults.AuthenticationScheme);
                         if (cookiesAuthenticateResult.Succeeded)

--- a/dotnet-authserver/src/TeacherIdentity.TestClient/Controllers/HomeController.cs
+++ b/dotnet-authserver/src/TeacherIdentity.TestClient/Controllers/HomeController.cs
@@ -27,13 +27,16 @@ public class HomeController : Controller
     }
 
     [HttpGet("sign-out")]
-    public async Task<IActionResult> SignOut(string returnUrl)
+    public new IActionResult SignOut() => View();
+
+    [HttpPost("sign-out")]
+    public async Task<IActionResult> SignOutPost()
     {
         await HttpContext.SignOutAsync(scheme: "Cookies");
 
         var properties = new AuthenticationProperties()
         {
-            RedirectUri = Url.IsLocalUrl(returnUrl) ? returnUrl : "/"
+            RedirectUri = "/"
         };
 
         return SignOut(properties, "oidc");

--- a/dotnet-authserver/src/TeacherIdentity.TestClient/Views/Home/SignOut.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.TestClient/Views/Home/SignOut.cshtml
@@ -1,0 +1,4 @@
+<form asp-action="SignOutPost">
+    <govuk-button type="submit">Sign out</govuk-button>
+</form>
+<script>document.forms[0].submit()</script>

--- a/dotnet-authserver/src/TeacherIdentity.TestClient/Views/Shared/_Layout.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.TestClient/Views/Shared/_Layout.cshtml
@@ -33,6 +33,8 @@
 <body class="govuk-template__body ">
   <govuk-skip-link />
 
+  <span data-testid="SignedIn" style="display:none">@(User.Identity?.IsAuthenticated ?? false)</span>
+
   <header class="govuk-header " role="banner" data-module="govuk-header">
     <div class="govuk-header__container govuk-width-container">
       <div class="govuk-header__logo">

--- a/dotnet-authserver/src/TeacherIdentity.TestClient/Views/Shared/_Layout.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.TestClient/Views/Shared/_Layout.cshtml
@@ -1,7 +1,14 @@
 @using Microsoft.AspNetCore.Http.Extensions;
 @inject IConfiguration Configuration
 @{
-    var accountLink = $"{Configuration["SignInAuthority"]}/account?client_id={Uri.EscapeDataString(Configuration["ClientId"]!)}&redirect_uri={Uri.EscapeDataString(Context.Request.GetEncodedUrl())}";
+    var clientId = Configuration["ClientId"]!;
+    var redirectUri = $"{Context.Request.Scheme}://{Context.Request.Host.Value}{Url.Action("Profile", "Home")}";
+    var signOutUri = $"{Context.Request.Scheme}://{Context.Request.Host.Value}{Url.Action("SignOut", "Home")}";
+
+    var accountLink = $"{Configuration["SignInAuthority"]}/account" +
+        $"?client_id={Uri.EscapeDataString(clientId)}" +
+        $"&redirect_uri={Uri.EscapeDataString(redirectUri)}" +
+        $"&sign_out_uri={Uri.EscapeDataString(signOutUri)}";
 }
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Account.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Account.cs
@@ -1,0 +1,58 @@
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.EndToEndTests;
+
+public class Account : IClassFixture<HostFixture>
+{
+    private readonly HostFixture _hostFixture;
+
+    public Account(HostFixture hostFixture)
+    {
+        _hostFixture = hostFixture;
+        _hostFixture.OnTestStarting();
+    }
+
+    [Fact]
+    public async Task AccessAccountPageDirectlyWithoutClientSignIn()
+    {
+        var user = await _hostFixture.TestData.CreateUser(userType: UserType.Default);
+
+        await using var context = await _hostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.GoToAccountPage();
+
+        await page.SignInFromLandingPage();
+
+        await page.SubmitEmailPage(user.EmailAddress);
+
+        await page.SubmitEmailConfirmationPage(_hostFixture.CapturedEmailConfirmationPins.Last().Pin);
+
+        await page.AssertOnAccountPage();
+    }
+
+    [Fact]
+    public async Task AccessAccountPageFromClient()
+    {
+        var user = await _hostFixture.TestData.CreateUser(userType: UserType.Default);
+
+        await using var context = await _hostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.StartOAuthJourney();
+
+        await page.SignInFromLandingPage();
+
+        await page.SubmitEmailPage(user.EmailAddress);
+
+        await page.SubmitEmailConfirmationPage(_hostFixture.CapturedEmailConfirmationPins.Last().Pin);
+
+        await page.SubmitCompletePageForExistingUser();
+
+        await page.AssertSignedInOnTestClient(user);
+
+        await page.GoToAccountPageFromTestClient();
+
+        await page.ReturnToTestClientFromAccountPage();
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
@@ -29,6 +29,14 @@ public static class PageExtensions
         Assert.Equal(lastName, await page.InnerTextAsync("data-testid=last-name"));
     }
 
+    public static async Task AssertSignedOutOnTestClient(this IPage page)
+    {
+        await page.AssertOnTestClient();
+
+        var signedInMarker = await page.GetByTestId("SignedIn").InnerTextAsync();
+        Assert.Equal(bool.FalseString, signedInMarker);
+    }
+
     public static async Task SignInFromLandingPage(this IPage page)
     {
         await page.WaitForSelectorAsync("h1:text-is('Create a Teaching services account')");

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
@@ -1,0 +1,110 @@
+using Microsoft.Playwright;
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.EndToEndTests;
+
+public static class PageExtensions
+{
+    public static async Task StartOAuthJourney(this IPage page, string? additionalScope = null)
+    {
+        await page.GotoAsync($"/profile?scope=email+openid+profile{(additionalScope is not null ? "+" + Uri.EscapeDataString(additionalScope) : string.Empty)}");
+    }
+
+    public static async Task AssertOnTestClient(this IPage page)
+    {
+        await page.WaitForURLAsync(url => url.StartsWith(HostFixture.ClientBaseUrl));
+    }
+
+    public static Task AssertSignedInOnTestClient(this IPage page, User user) =>
+        AssertSignedInOnTestClient(page, user.EmailAddress, user.Trn, user.FirstName, user.LastName);
+
+    public static async Task AssertSignedInOnTestClient(this IPage page, string email, string? trn, string firstName, string lastName)
+    {
+        await page.AssertOnTestClient();
+
+        var signedInEmail = await page.InnerTextAsync("data-testid=email");
+        Assert.Equal(email, signedInEmail);
+        Assert.Equal(trn ?? string.Empty, await page.InnerTextAsync("data-testid=trn"));
+        Assert.Equal(firstName, await page.InnerTextAsync("data-testid=first-name"));
+        Assert.Equal(lastName, await page.InnerTextAsync("data-testid=last-name"));
+    }
+
+    public static async Task SignInFromLandingPage(this IPage page)
+    {
+        await page.WaitForSelectorAsync("h1:text-is('Create a Teaching services account')");
+        await page.ClickAsync("a:text-is('Sign in')");
+    }
+
+    public static async Task SubmitEmailPage(this IPage page, string email)
+    {
+        await page.WaitForSelectorAsync("h1:text-is('Your email address')");
+        await page.FillAsync("text=Enter your email address", email);
+        await page.ClickAsync("button:text-is('Continue')");
+    }
+
+    public static async Task SubmitEmailConfirmationPage(this IPage page, string pin)
+    {
+        await page.WaitForSelectorAsync("h1:text-is('Confirm your email address')");
+        await page.FillAsync("text=Enter your code", pin);
+        await page.ClickAsync("button:text-is('Continue')");
+    }
+
+    public static async Task SubmitCompletePageForExistingUser(this IPage page)
+    {
+        Assert.Equal(1, await page.GetByText("Your details").CountAsync());
+        await page.ClickAsync("button:text-is('Continue')");
+    }
+
+    public static async Task SignOutFromTestClient(this IPage page)
+    {
+        await page.ClickAsync("a:text-is('Sign out')");
+
+        await page.WaitForURLAsync($"{HostFixture.ClientBaseUrl}/");
+    }
+
+    public static async Task GoToAccountPage(this IPage page)
+    {
+        await page.GotoAsync($"{HostFixture.AuthServerBaseUrl}/account");
+    }
+
+    public static async Task AssertOnAccountPage(this IPage page)
+    {
+        await page.WaitForSelectorAsync("h1:text-is('Your details')");
+    }
+
+    public static async Task SignOutFromAccountPageWithoutClientContext(this IPage page)
+    {
+        await page.AssertOnAccountPage();
+
+        await page.RunAndWaitForResponseAsync(
+            () => page.ClickAsync("a:text-is('Sign out')"),
+            resp => resp.Url == $"{HostFixture.AuthServerBaseUrl}/" && resp.Status == 404);
+    }
+
+    public static async Task SignOutFromAccountPageWithClientContext(this IPage page)
+    {
+        await page.AssertOnAccountPage();
+
+        await page.ClickAsync("a:text-is('Sign out')");
+
+        await page.WaitForURLAsync($"{HostFixture.ClientBaseUrl}/");
+
+        await page.AssertOnTestClient();
+    }
+
+    public static async Task GoToAccountPageFromTestClient(this IPage page)
+    {
+        await page.ClickAsync("a:text-is('DfE Identity account')");
+
+        await page.AssertOnAccountPage();
+    }
+
+    public static async Task ReturnToTestClientFromAccountPage(this IPage page)
+    {
+        await page.AssertOnAccountPage();
+
+        await page.ClickAsync("a:text-is('Back to Development test client')");
+
+        await page.AssertOnTestClient();
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignOut.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignOut.cs
@@ -34,7 +34,7 @@ public class SignOut : IClassFixture<HostFixture>
 
         await page.SignOutFromTestClient();
 
-        await page.AssertOnTestClient();
+        await page.AssertSignedOutOnTestClient();
 
         _hostFixture.EventObserver.AssertEventsSaved(
             e => Assert.IsType<Events.UserSignedInEvent>(e),
@@ -99,6 +99,8 @@ public class SignOut : IClassFixture<HostFixture>
         await page.GoToAccountPageFromTestClient();
 
         await page.SignOutFromAccountPageWithClientContext();
+
+        await page.AssertSignedOutOnTestClient();
 
         _hostFixture.EventObserver.AssertEventsSaved(
             e => Assert.IsType<Events.UserSignedInEvent>(e),

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateTests.cs
@@ -228,7 +228,7 @@ public partial class AuthenticationStateTests
 
         void ConfigureMockForPage(string pageName, string returnsPath)
         {
-            linkGenerator.Protected().Setup<string>("PageWithAuthenticationJourneyId", pageName, /* authenticationJourneyRequired: */ true)
+            linkGenerator.Protected().Setup<string>("Page", pageName, /* authenticationJourneyRequired: */ true)
                 .Returns(returnsPath.SetQueryParam("asid", authenticationState.JourneyId.ToString()));
         }
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/IndexTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/IndexTests.cs
@@ -17,7 +17,13 @@ public class IndexTests : TestBase
         var user = await TestData.CreateUser();
         HostFixture.SetUserId(user.UserId);
 
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/account?client_id=not_a_real_client_id&redirect_uri={{Uri.EscapeDataString(\"https://google.com\")");
+        var client = TestClients.Client1;
+        var redirectUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority);
+        var signOutUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority) + "/sign-out";
+
+        var request = new HttpRequestMessage(
+        HttpMethod.Get,
+            $"/account?client_id=not_a_real_client_id&redirect_uri={Uri.EscapeDataString(redirectUri)}&sign_out_uri={Uri.EscapeDataString(signOutUri)}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -34,7 +40,32 @@ public class IndexTests : TestBase
         HostFixture.SetUserId(user.UserId);
 
         var client = TestClients.Client1;
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/account?client_id={client.ClientId}&redirect_uri={Uri.EscapeDataString("https://google.com")}");
+        var signOutUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority) + "/sign-out";
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/account?client_id={client.ClientId}&redirect_uri={Uri.EscapeDataString("https://google.com")}&sign_out_uri={Uri.EscapeDataString(signOutUri)}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_InvalidSignOutUriDomain_ReturnsBadRequest()
+    {
+        // Arrange
+        var user = await TestData.CreateUser();
+        HostFixture.SetUserId(user.UserId);
+
+        var client = TestClients.Client1;
+        var redirectUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority);
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/account?client_id={client.ClientId}&redirect_uri={Uri.EscapeDataString(redirectUri)}&sign_out_uri={Uri.EscapeDataString("https://google.com")}");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -229,7 +260,7 @@ public class IndexTests : TestBase
     }
 
     [Fact]
-    public async Task Get_ValidRequestWithClientIdAndRedirectUri_RendersBackLinks()
+    public async Task Get_ValidRequestWithClientIdRedirectUriAndSignOutUri_RendersBackLinks()
     {
         // Arrange
         var user = await TestData.CreateUser();
@@ -237,7 +268,11 @@ public class IndexTests : TestBase
 
         var client = TestClients.Client1;
         var redirectUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority);
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/account?client_id={client.ClientId}&redirect_uri={Uri.EscapeDataString(redirectUri)}");
+        var signOutUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority) + "/sign-out";
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            $"/account?client_id={client.ClientId}&redirect_uri={Uri.EscapeDataString(redirectUri)}&sign_out_uri={Uri.EscapeDataString(signOutUri)}");
 
         // Act
         var response = await HttpClient.SendAsync(request);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/TestBase.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/TestBase.cs
@@ -42,9 +42,11 @@ public partial class TestBase
         var dataProtector = dataProtectionProvider.CreateProtector(nameof(ClientRedirectInfo));
 
         var clientId = client.ClientId!;
-        string redirectUri = new Url(client.RedirectUris.First()).RemoveQuery();
+        string clientDomain = new Url(client.RedirectUris.First()).RemoveQuery();
+        var redirectUri = clientDomain;
+        var signOutUri = redirectUri + "/sign-out";
 
-        return new(dataProtector, clientId, redirectUri);
+        return new(dataProtector, clientId, redirectUri, signOutUri);
     }
 
     public string AppendQueryParameterSignature(Url url)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Infrastructure/TestIdentityLinkGenerator.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Infrastructure/TestIdentityLinkGenerator.cs
@@ -19,7 +19,7 @@ public class TestIdentityLinkGenerator : IdentityLinkGenerator
         _linkGenerator = linkGenerator;
     }
 
-    protected override string PageWithAuthenticationJourneyId(string pageName, bool authenticationJourneyRequired = true)
+    protected override string Page(string pageName, bool authenticationJourneyRequired = true)
     {
         return new Url(_linkGenerator.GetPathByPage(pageName))
             .SetQueryParam(AuthenticationStateMiddleware.IdQueryParameterName, _authenticationState.JourneyId);


### PR DESCRIPTION
This change adds the nav UI for the account pages. It has a link to the root account page and a sign out page. The sign out link is back to the client's `sign_out_uri`, where one is provided. Otherwise, it links to a local `/account/sign-out` page.

I've amended TestClient so it has an account link and sign out process that mirrors the type of thing we'll see for real services. 

I've also added e2e tests to cover signing out and accessing the root account page, both with and without this client context.