### PR TITLE
Make update name request to DQT on official name change form submit

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -197,12 +197,11 @@ public abstract class IdentityLinkGenerator
             .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo)
             .AppendQueryStringSignature(QueryStringSignatureHelper);
 
-    public string AccountOfficialNameConfirm(string firstName, string? middleName, string lastName, string fileId, string fileName, ClientRedirectInfo? clientRedirectInfo) =>
+    public string AccountOfficialNameConfirm(string firstName, string? middleName, string lastName, string fileName, ClientRedirectInfo? clientRedirectInfo) =>
         Page("/Account/OfficialName/Confirm", authenticationJourneyRequired: false)
             .SetQueryParam("firstName", firstName)
             .SetQueryParam("middleName", middleName)
             .SetQueryParam("lastName", lastName)
-            .SetQueryParam("fileId", fileId)
             .SetQueryParam("fileName", fileName)
             .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo)
             .AppendQueryStringSignature(QueryStringSignatureHelper);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Confirm.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Confirm.cshtml
@@ -11,7 +11,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.AccountOfficialNameConfirm(Model.FirstName!, Model.MiddleName, Model.LastName!, Model.FileId!, Model.FileName!, Model.ClientRedirectInfo)" method="post" asp-antiforgery="true">
+        <form action="@LinkGenerator.AccountOfficialNameConfirm(Model.FirstName!, Model.MiddleName, Model.LastName!, Model.FileName!, Model.ClientRedirectInfo)" method="post" asp-antiforgery="true">
             <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
 
             <govuk-summary-list>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Confirm.cshtml.cs
@@ -37,9 +37,6 @@ public class Confirm : PageModel
     [FromQuery(Name = "lastName")]
     public string? LastName { get; set; }
 
-    [FromQuery(Name = "fileId")]
-    public string? FileId { get; set; }
-
     [FromQuery(Name = "fileName")]
     public string? FileName { get; set; }
 
@@ -72,7 +69,7 @@ public class Confirm : PageModel
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (FirstName is null || LastName is null || FileId is null || FileName is null)
+        if (FirstName is null || LastName is null || FileName is null)
         {
             context.Result = BadRequest();
         }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Confirm.cshtml.cs
@@ -2,6 +2,8 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeacherIdentity.AuthServer.Infrastructure.Filters;
+using TeacherIdentity.AuthServer.Services.DqtApi;
+using TeacherIdentity.AuthServer.Services.DqtEvidence;
 
 namespace TeacherIdentity.AuthServer.Pages.Account.OfficialName;
 
@@ -9,12 +11,19 @@ namespace TeacherIdentity.AuthServer.Pages.Account.OfficialName;
 [CheckOfficialNameChangeIsEnabled]
 public class Confirm : PageModel
 {
+    private const int SasTokenValidMinutes = 15;
     private readonly IdentityLinkGenerator _linkGenerator;
+    private readonly IDqtApiClient _dqtApiClient;
+    private readonly IDqtEvidenceStorageService _dqtEvidenceStorage;
 
     public Confirm(
-        IdentityLinkGenerator linkGenerator)
+        IdentityLinkGenerator linkGenerator,
+        IDqtApiClient dqtApiClient,
+        IDqtEvidenceStorageService dqtEvidenceStorage)
     {
         _linkGenerator = linkGenerator;
+        _dqtApiClient = dqtApiClient;
+        _dqtEvidenceStorage = dqtEvidenceStorage;
     }
 
     public ClientRedirectInfo? ClientRedirectInfo => HttpContext.GetClientRedirectInfo();
@@ -38,11 +47,25 @@ public class Confirm : PageModel
     {
     }
 
-    public IActionResult OnPost()
+    public async Task<IActionResult> OnPost()
     {
+        var sasUri = await _dqtEvidenceStorage.GetSasConnectionString(FileName!, SasTokenValidMinutes);
+
+        var teacherNameChangeRequest = new TeacherNameChangeRequest()
+        {
+            FirstName = FirstName!,
+            MiddleName = MiddleName,
+            LastName = LastName!,
+            EvidenceFileName = FileName!,
+            EvidenceFileUrl = sasUri,
+            Trn = User.GetTrn()!
+        };
+
+        await _dqtApiClient.PostTeacherNameChange(teacherNameChangeRequest);
+
         TempData.SetFlashSuccess(
-            "We’ve received your request to change your official name",
-            "We’ll review it and get back to you within 5 working days.");
+        "We’ve received your request to change your official name",
+        "We’ll review it and get back to you within 5 working days.");
 
         return Redirect(_linkGenerator.Account(ClientRedirectInfo));
     }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Evidence.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Evidence.cshtml.cs
@@ -53,11 +53,12 @@ public class Evidence : PageModel
         }
 
         var fileId = Guid.NewGuid();
-        var fileName = $"{User.GetUserId()}/{fileId}";
+        var extension = Path.GetExtension(EvidenceFile!.FileName);
 
+        var fileName = $"{User.GetUserId()}/{fileId}{extension}";
         await _dqtEvidenceStorage.Upload(EvidenceFile!, fileName);
 
-        return Redirect(_linkGenerator.AccountOfficialNameConfirm(FirstName!, MiddleName ?? String.Empty, LastName!, fileId.ToString(), fileName, ClientRedirectInfo));
+        return Redirect(_linkGenerator.AccountOfficialNameConfirm(FirstName!, MiddleName, LastName!, fileName, ClientRedirectInfo));
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/DqtApiClient.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/DqtApiClient.cs
@@ -54,9 +54,7 @@ public class DqtApiClient : IDqtApiClient
 
     public async Task PostTeacherNameChange(TeacherNameChangeRequest request, CancellationToken cancellationToken = default)
     {
-        string json = JsonSerializer.Serialize(request);
-        HttpContent content = new StringContent(json, Encoding.UTF8, "application/json");
-
+        HttpContent content = JsonContent.Create(request);
         var response = await _client.PostAsync("/v3/teachers/name-changes", content, cancellationToken);
         response.EnsureSuccessStatusCode();
     }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/DqtApiClient.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/DqtApiClient.cs
@@ -1,5 +1,3 @@
-using System.Text;
-using System.Text.Json;
 using Flurl;
 
 namespace TeacherIdentity.AuthServer.Services.DqtApi;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/DqtApiClient.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/DqtApiClient.cs
@@ -1,3 +1,5 @@
+using System.Text;
+using System.Text.Json;
 using Flurl;
 
 namespace TeacherIdentity.AuthServer.Services.DqtApi;
@@ -48,5 +50,14 @@ public class DqtApiClient : IDqtApiClient
         var response = await _client.GetAsync($"/v2/itt-providers", cancellationToken);
         response.EnsureSuccessStatusCode();
         return (await response.Content.ReadFromJsonAsync<GetIttProvidersResponse>(cancellationToken: cancellationToken))!;
+    }
+
+    public async Task PostTeacherNameChange(TeacherNameChangeRequest request, CancellationToken cancellationToken = default)
+    {
+        string json = JsonSerializer.Serialize(request);
+        HttpContent content = new StringContent(json, Encoding.UTF8, "application/json");
+
+        var response = await _client.PostAsync("/v3/teachers/name-changes", content, cancellationToken);
+        response.EnsureSuccessStatusCode();
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/IDqtApiClient.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/IDqtApiClient.cs
@@ -5,4 +5,5 @@ public interface IDqtApiClient
     Task<FindTeachersResponse> FindTeachers(FindTeachersRequest request, CancellationToken cancellationToken = default);
     public Task<TeacherInfo?> GetTeacherByTrn(string trn, CancellationToken cancellationToken = default);
     public Task<GetIttProvidersResponse> GetIttProviders(CancellationToken cancellationToken = default);
+    public Task PostTeacherNameChange(TeacherNameChangeRequest request, CancellationToken cancellationToken = default);
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/TeacherNameChangeRequest.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/TeacherNameChangeRequest.cs
@@ -3,7 +3,7 @@ namespace TeacherIdentity.AuthServer.Services.DqtApi;
 public record TeacherNameChangeRequest
 {
     public required string FirstName { get; init; }
-    public string? MiddleName { get; init; }
+    public required string? MiddleName { get; init; }
     public required string LastName { get; init; }
     public required string EvidenceFileName { get; init; }
     public required string EvidenceFileUrl { get; init; }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/TeacherNameChangeRequest.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/TeacherNameChangeRequest.cs
@@ -1,0 +1,11 @@
+namespace TeacherIdentity.AuthServer.Services.DqtApi;
+
+public record TeacherNameChangeRequest
+{
+    public required string FirstName { get; init; }
+    public string? MiddleName { get; init; }
+    public required string LastName { get; init; }
+    public required string EvidenceFileName { get; init; }
+    public required string EvidenceFileUrl { get; init; }
+    public required string Trn { get; init; }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtEvidence/IDqtEvidenceStorageService.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtEvidence/IDqtEvidenceStorageService.cs
@@ -3,4 +3,5 @@ namespace TeacherIdentity.AuthServer.Services.DqtEvidence;
 public interface IDqtEvidenceStorageService
 {
     Task Upload(IFormFile file, string targetFilename);
+    Task<string> GetSasConnectionString(string blobName, int minutes);
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Development.json
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Development.json
@@ -68,8 +68,5 @@
   "DqtEvidence": {
     "StorageContainerName": "dqt-evidence"
   },
-  "ConnectionStrings": {
-    "DataProtectionBlobStorage": "UseDevelopmentStorage=true"
-  },
   "QueryStringSignatureKey": "qskey"
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialName/ConfirmTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialName/ConfirmTests.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using TeacherIdentity.AuthServer.Services.DqtApi;
 using User = TeacherIdentity.AuthServer.Models.User;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Account.OfficialName;
@@ -95,6 +96,9 @@ public class ConfirmTests : TestBase
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/account?{_clientRedirectInfo.ToQueryParam()}", response.Headers.Location?.OriginalString);
+
+        HostFixture.DqtEvidenceStorageService.Verify(s => s.GetSasConnectionString(It.IsAny<string>(), It.IsAny<int>()));
+        HostFixture.DqtApiClient.Verify(s => s.PostTeacherNameChange(It.IsAny<TeacherNameChangeRequest>(), It.IsAny<CancellationToken>()));
 
         var redirectedResponse = await response.FollowRedirect(HttpClient);
         var redirectedDoc = await redirectedResponse.GetDocument();

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialName/ConfirmTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialName/ConfirmTests.cs
@@ -53,7 +53,6 @@ public class ConfirmTests : TestBase
     [Theory]
     [InlineData("firstName")]
     [InlineData("lastName")]
-    [InlineData("fileId")]
     [InlineData("fileName")]
     public async Task Get_MissingQueryParameter_ReturnsBadRequest(string missingQueryParameter)
     {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialName/EvidenceTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialName/EvidenceTests.cs
@@ -153,7 +153,6 @@ public class EvidenceTests : TestBase
         Assert.StartsWith($"/account/official-name/confirm", response.Headers.Location?.OriginalString);
 
         Assert.Contains(_clientRedirectInfo.ToQueryParam(), response.Headers.Location?.OriginalString);
-        Assert.Contains("fileId=", response.Headers.Location?.OriginalString);
         Assert.Contains("fileName=", response.Headers.Location?.OriginalString);
 
         HostFixture.DqtEvidenceStorageService.Verify(s => s.Upload(It.IsAny<IFormFile>(), It.Is<string>(arg => arg.StartsWith($"{user.UserId}/"))));


### PR DESCRIPTION
### Context

We’ve added the DQT change name process but it’s not currently hooked up to the API (that actually creates the incident).

### Changes proposed in this pull request

When the final form is submitted call the https://qualified-teachers-api-tech-docs.london.cloudapps.digital/#v3-teachers-name-changes endpoint, passing over the data from the form. The evidenceUrl should be a fully-qualified URL to the blob in blob storage, including a short-lived read-only SAS token.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
