### PR TITLE
Add DQT dob change update API call to Confirm page

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialDateOfBirth/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialDateOfBirth/Confirm.cshtml.cs
@@ -2,6 +2,8 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeacherIdentity.AuthServer.Infrastructure.Filters;
+using TeacherIdentity.AuthServer.Services.DqtApi;
+using TeacherIdentity.AuthServer.Services.DqtEvidence;
 
 namespace TeacherIdentity.AuthServer.Pages.Account.OfficialDateOfBirth;
 
@@ -9,11 +11,19 @@ namespace TeacherIdentity.AuthServer.Pages.Account.OfficialDateOfBirth;
 [CheckOfficialDateOfBirthChangeIsEnabled]
 public class Confirm : PageModel
 {
+    private const int SasTokenValidMinutes = 15;
     private readonly IdentityLinkGenerator _linkGenerator;
+    private readonly IDqtEvidenceStorageService _dqtEvidenceStorage;
+    private readonly IDqtApiClient _dqtApiClient;
 
-    public Confirm(IdentityLinkGenerator linkGenerator)
+    public Confirm(
+        IdentityLinkGenerator linkGenerator,
+        IDqtEvidenceStorageService dqtEvidenceStorage,
+        IDqtApiClient dqtApiClient)
     {
         _linkGenerator = linkGenerator;
+        _dqtEvidenceStorage = dqtEvidenceStorage;
+        _dqtApiClient = dqtApiClient;
     }
 
     public ClientRedirectInfo? ClientRedirectInfo => HttpContext.GetClientRedirectInfo();
@@ -28,8 +38,20 @@ public class Confirm : PageModel
     {
     }
 
-    public IActionResult OnPost()
+    public async Task<IActionResult> OnPost()
     {
+        var sasUri = await _dqtEvidenceStorage.GetSasConnectionString(FileName!, SasTokenValidMinutes);
+
+        var teacherDobChangeRequest = new TeacherDateOfBirthChangeRequest()
+        {
+            DateOfBirth = DateOfBirth!.Value,
+            EvidenceFileName = FileName!,
+            EvidenceFileUrl = sasUri,
+            Trn = User.GetTrn()!
+        };
+
+        await _dqtApiClient.PostTeacherDateOfBirthChange(teacherDobChangeRequest);
+
         TempData.SetFlashSuccess(
         "We’ve received your request to change your date of birth",
         "We’ll review it and get back to you within 5 working days.");

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/DqtApiClient.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/DqtApiClient.cs
@@ -56,4 +56,12 @@ public class DqtApiClient : IDqtApiClient
         var response = await _client.PostAsync("/v3/teachers/name-changes", content, cancellationToken);
         response.EnsureSuccessStatusCode();
     }
+
+    public async Task PostTeacherDateOfBirthChange(TeacherDateOfBirthChangeRequest request,
+        CancellationToken cancellationToken = default)
+    {
+        HttpContent content = JsonContent.Create(request);
+        var response = await _client.PostAsync("/v3/teachers/date-of-birth-changes", content, cancellationToken);
+        response.EnsureSuccessStatusCode();
+    }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/IDqtApiClient.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/IDqtApiClient.cs
@@ -6,4 +6,5 @@ public interface IDqtApiClient
     public Task<TeacherInfo?> GetTeacherByTrn(string trn, CancellationToken cancellationToken = default);
     public Task<GetIttProvidersResponse> GetIttProviders(CancellationToken cancellationToken = default);
     public Task PostTeacherNameChange(TeacherNameChangeRequest request, CancellationToken cancellationToken = default);
+    public Task PostTeacherDateOfBirthChange(TeacherDateOfBirthChangeRequest request, CancellationToken cancellationToken = default);
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/TeacherDateOfBirthChangeRequest.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/TeacherDateOfBirthChangeRequest.cs
@@ -1,0 +1,9 @@
+namespace TeacherIdentity.AuthServer.Services.DqtApi;
+
+public record TeacherDateOfBirthChangeRequest
+{
+    public required DateOnly DateOfBirth { get; init; }
+    public required string EvidenceFileName { get; init; }
+    public required string EvidenceFileUrl { get; init; }
+    public required string Trn { get; init; }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialDateOfBirth/ConfirmTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialDateOfBirth/ConfirmTests.cs
@@ -1,4 +1,5 @@
 using System.Text.RegularExpressions;
+using TeacherIdentity.AuthServer.Services.DqtApi;
 using User = TeacherIdentity.AuthServer.Models.User;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Account.OfficialDateOfBirth;
@@ -95,6 +96,9 @@ public class ConfirmTests : TestBase
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
         Assert.Equal($"/account?{_clientRedirectInfo.ToQueryParam()}", response.Headers.Location?.OriginalString);
+
+        HostFixture.DqtEvidenceStorageService.Verify(s => s.GetSasConnectionString(It.IsAny<string>(), It.IsAny<int>()));
+        HostFixture.DqtApiClient.Verify(s => s.PostTeacherDateOfBirthChange(It.IsAny<TeacherDateOfBirthChangeRequest>(), It.IsAny<CancellationToken>()));
 
         var redirectedResponse = await response.FollowRedirect(HttpClient);
         var redirectedDoc = await redirectedResponse.GetDocument();


### PR DESCRIPTION
### Context

We’ve added the DQT change DOB process but it’s not currently hooked up to the API (that actually creates the incident).

### Changes proposed in this pull request

When the final form is submitted call the `POST /v3/teachers/date-of-birth-changes/` endpoint, passing over the data from the form. The evidenceUrl should be a fully-qualified URL to the blob in blob storage, including a short-lived read-only SAS token.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
