### PR TITLE
Don't run lint or tests for pushes to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,7 @@ jobs:
           dotnet-version: '7.0.202'
 
       - name: Lint
+        if: github.event_name != 'push'
         run: |
           #https://github.com/dotnet/format/issues/1433
           dotnet tool install -g dotnet-format --version "7.*" --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json
@@ -74,6 +75,7 @@ jobs:
 
       - name: Unit tests
         uses: ./.github/workflows/actions/test
+        if: github.event_name != 'push'
         with:
           test_project_path: dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests
           report_name: "Unit test results"
@@ -81,10 +83,12 @@ jobs:
 
       - name: Install Playwright
         run: pwsh ./tests/TeacherIdentity.AuthServer.EndToEndTests/bin/Release/net7.0/playwright.ps1 install
+        if: github.event_name != 'push'
         working-directory: dotnet-authserver
 
       - name: End-to-end tests
         uses: ./.github/workflows/actions/test
+        if: github.event_name != 'push'
         with:
           test_project_path: dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests
           report_name: "End-to-end test results"


### PR DESCRIPTION
Given that we require PRs for merging into main and we enforce linear history, there's no value in running linting or tests again on pushes to main since any issues would have been caught in the PR run.

This mirrors a recent change done in the DQT API repo.