### PR TITLE
Add e2e tests for new core journey

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -208,12 +208,14 @@ public class AuthenticationState
             return AuthenticationJourneyType.StaffSignIn;
         }
 
+#pragma warning disable CS0618 // Type or member is obsolete
         if (TryGetOAuthState(out var oAuthState) &&
             oAuthState.RequiresTrnLookup &&
-            oAuthState.TrnRequirementType == TrnRequirementType.Legacy)
+            (oAuthState.TrnRequirementType == TrnRequirementType.Legacy || oAuthState.HasScope(CustomScopes.Trn)))
         {
             return AuthenticationJourneyType.LegacyTrn;
         }
+#pragma warning restore CS0618 // Type or member is obsolete
 
         return AuthenticationJourneyType.Core;
     }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Oidc/CustomScopes.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Oidc/CustomScopes.cs
@@ -6,7 +6,6 @@ public static class CustomScopes
     public const string UserRead = "user:read";
     public const string UserWrite = "user:write";
     public const string DqtRead = "dqt:read";
-    [Obsolete("Use DqtRead instead.")]
     public const string Trn = "trn";
 
     public static string[] All => StaffUserTypeScopes.Concat(DefaultUserTypesScopes).ToArray();
@@ -21,8 +20,6 @@ public static class CustomScopes
     public static string[] DefaultUserTypesScopes { get; } = new[]
     {
         DqtRead,
-#pragma warning disable CS0618 // Type or member is obsolete
         Trn
-#pragma warning restore CS0618 // Type or member is obsolete
     };
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Email.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Email.cshtml
@@ -11,10 +11,8 @@
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <form action="@LinkGenerator.RegisterEmail()" method="post" asp-antiforgery="true">
-            <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
-
             <govuk-input asp-for="Email" type="email" autocomplete="email">
-                <govuk-input-label class="govuk-label--s" />
+                <govuk-input-label class="govuk-label--xl" />
             </govuk-input>
 
             <govuk-button type="submit">Continue</govuk-button>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Email.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Email.cshtml.cs
@@ -17,7 +17,7 @@ public class EmailModel : BaseEmailPageModel
     {
     }
 
-    [Display(Name = "Email address", Description = "We’ll use this to send you a code to confirm your email address. Do not use a work or university email that you might lose access to.")]
+    [Display(Name = "Your email address", Description = "We’ll use this to send you a code to confirm your email address. Do not use a work or university email that you might lose access to.")]
     [Required(ErrorMessage = "Enter your email address")]
     [EmailAddress(ErrorMessage = "Enter a valid email address")]
     public string? Email { get; set; }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
@@ -224,6 +224,7 @@ public class Program
             options.AddPolicy(
                 AuthorizationPolicies.Authenticated,
                 policy => policy
+                    .AddAuthenticationSchemes("Delegated")
                     .AddAuthenticationSchemes(CookieAuthenticationDefaults.AuthenticationScheme)
                     .RequireAuthenticatedUser());
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Account.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Account.cs
@@ -26,7 +26,7 @@ public class Account : IClassFixture<HostFixture>
 
         await page.SubmitEmailPage(user.EmailAddress);
 
-        await page.SubmitEmailConfirmationPage(HostFixture.UserVerificationPin);
+        await page.SubmitEmailConfirmationPage();
 
         await page.AssertOnAccountPage();
     }
@@ -45,7 +45,7 @@ public class Account : IClassFixture<HostFixture>
 
         await page.SubmitEmailPage(user.EmailAddress);
 
-        await page.SubmitEmailConfirmationPage(HostFixture.UserVerificationPin);
+        await page.SubmitEmailConfirmationPage();
 
         await page.SubmitCompletePageForExistingUser();
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/HostFixture.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/HostFixture.cs
@@ -120,6 +120,22 @@ public class HostFixture : IAsyncLifetime
         EventObserver.Clear();
     }
 
+    public void AssertEventIsUserSignedIn(
+        Events.EventBase @event,
+        Guid userId,
+        bool expectOAuthProperties = true)
+    {
+        var userSignedIn = Assert.IsType<Events.UserSignedInEvent>(@event);
+        Assert.Equal(DateTime.UtcNow, userSignedIn.CreatedUtc, TimeSpan.FromSeconds(10));
+        Assert.Equal(userId, userSignedIn.User.UserId);
+
+        if (expectOAuthProperties)
+        {
+            Assert.Equal(TestClientId, userSignedIn.ClientId);
+            Assert.NotNull(userSignedIn.Scope);
+        }
+    }
+
     private Host<TeacherIdentity.AuthServer.Program> CreateAuthServerHost(IConfiguration testConfiguration) =>
         Host<TeacherIdentity.AuthServer.Program>.CreateHost(
             AuthServerBaseUrl,

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/LegacyTrnJourney.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/LegacyTrnJourney.cs
@@ -1,0 +1,261 @@
+using Microsoft.Playwright;
+using Moq;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Oidc;
+using TeacherIdentity.AuthServer.Services.DqtApi;
+
+namespace TeacherIdentity.AuthServer.EndToEndTests;
+
+public class LegacyTrnJourney : IClassFixture<HostFixture>
+{
+    private readonly HostFixture _hostFixture;
+
+    public LegacyTrnJourney(HostFixture hostFixture)
+    {
+        _hostFixture = hostFixture;
+        _hostFixture.OnTestStarting();
+    }
+
+    [Fact]
+    public async Task ExistingTeacherUser_CanSignInSuccessfullyWithEmailAndPin()
+    {
+        var user = await _hostFixture.TestData.CreateUser(userType: UserType.Default);
+
+        await using var context = await _hostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.StartOAuthJourney(CustomScopes.Trn);
+
+        await page.SubmitEmailPage(user.EmailAddress);
+
+        await page.SubmitEmailConfirmationPage();
+
+        await page.SubmitCompletePageForExistingUser();
+
+        await page.AssertSignedInOnTestClient(user);
+
+        _hostFixture.EventObserver.AssertEventsSaved(
+            e => _hostFixture.AssertEventIsUserSignedIn(e, user.UserId));
+    }
+
+    [Fact]
+    public async Task NewTeacherUser_WithFoundTrn_CreatesUserAndCompletesFlow()
+    {
+        var email = Faker.Internet.Email();
+        var officialFirstName = Faker.Name.First();
+        var officialLastName = Faker.Name.Last();
+        var dateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
+        var trn = _hostFixture.TestData.GenerateTrn();
+
+        await using var context = await _hostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await SignInAsNewTeacherUserWithTrnScope(page, email, officialFirstName, officialLastName, trn, dateOfBirth);
+    }
+
+    [Fact]
+    public async Task NewTeacherUser_WithoutFoundTrn_CreatesUserAndCompletesFlow()
+    {
+        var email = Faker.Internet.Email();
+        var officialFirstName = Faker.Name.First();
+        var officialLastName = Faker.Name.Last();
+        var dateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
+        var nino = Faker.Identification.UkNationalInsuranceNumber();
+        var ittProvider = Faker.Company.Name();
+
+        ConfigureDqtApiFindTeachersRequest(result: null);
+
+        _hostFixture.DqtApiClient
+            .Setup(mock => mock.GetIttProviders(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetIttProvidersResponse()
+            {
+                IttProviders = new[]
+                {
+                    new IttProvider()
+                    {
+                        ProviderName = "Provider 1",
+                        Ukprn = "123"
+                    },
+                    new IttProvider()
+                    {
+                        ProviderName = ittProvider,
+                        Ukprn = "234"
+                    }
+                }
+            });
+
+        await using var context = await _hostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.StartOAuthJourney(additionalScope: CustomScopes.Trn);
+
+        await page.SubmitEmailPage(email);
+
+        await page.SubmitEmailConfirmationPage();
+
+        await page.SubmitTrnBookendPage();
+
+        await page.SubmitTrnHasTrnPageWithoutTrn();
+
+        await page.SubmitTrnOfficialNamePage(officialFirstName, officialLastName);
+
+        await page.SubmitTrnPreferredNamePageWithoutPreferredName();
+
+        await page.SubmitTrnDateOfBirthPage(dateOfBirth);
+
+        await page.SubmitTrnHasNinoPage(hasNino: true);
+
+        await page.SubmitTrnNiNumberPage(nino);
+
+        await page.SubmitTrnAwardedQtsPage(awardedQts: true);
+
+        await page.SubmitTrnIttProviderPageWithIttProvider(ittProvider);
+
+        await page.SubmitTrnCheckAnswersPage();
+
+        await page.SubmitTrnNoMatchPage();
+
+        await page.SubmitCompletePageForNewUserInLegacyTrnJourney();
+
+        await page.AssertSignedInOnTestClient(email, trn: null, officialFirstName, officialLastName);
+    }
+
+    [Fact]
+    public async Task NewTeacherUser_WithTrnMatchingExistingAccount_VerifiesExistingAccountEmailAndCanSignInSuccessfully()
+    {
+        var existingTrnOwner = await _hostFixture.TestData.CreateUser(hasTrn: true);
+
+        var trn = existingTrnOwner.Trn!;
+        var trnOwnerEmailAddress = existingTrnOwner.EmailAddress;
+        var email = Faker.Internet.Email();
+        var officialFirstName = Faker.Name.First();
+        var officialLastName = Faker.Name.Last();
+        var dateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
+
+        ConfigureDqtApiFindTeachersRequest(result: null);
+
+        await using var context = await _hostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.StartOAuthJourney(additionalScope: CustomScopes.Trn);
+
+        await page.SubmitEmailPage(email);
+
+        await page.SubmitEmailConfirmationPage();
+
+        await page.SubmitTrnBookendPage();
+
+        await page.SubmitTrnHasTrnPageWithTrn(trn);
+
+        await page.SubmitTrnOfficialNamePage(officialFirstName, officialLastName);
+
+        await page.SubmitTrnPreferredNamePageWithoutPreferredName();
+
+        // Simulate DQT API returning result when next page submitted
+
+        ConfigureDqtApiFindTeachersRequest(result: new()
+        {
+            DateOfBirth = dateOfBirth,
+            FirstName = officialFirstName,
+            LastName = officialLastName,
+            EmailAddresses = new[] { email },
+            HasActiveSanctions = false,
+            NationalInsuranceNumber = null,
+            Trn = trn,
+            Uid = Guid.NewGuid().ToString()
+        });
+
+        await page.SubmitTrnDateOfBirthPage(dateOfBirth);
+
+        await page.SubmitTrnCheckAnswersPage();
+
+        await page.SubmitTrnTrnInUsePage();
+
+        await page.SubmitTrnChooseEmailPage(trnOwnerEmailAddress);
+
+        await page.SubmitCompletePageForNewUserInLegacyTrnJourney();
+
+        await page.AssertSignedInOnTestClient(existingTrnOwner);
+
+        _hostFixture.EventObserver.AssertEventsSaved(
+            e => _hostFixture.AssertEventIsUserSignedIn(e, existingTrnOwner.UserId));
+    }
+
+    [Fact]
+    public async Task TeacherUser_WithTrnAssignedViaApi_CanSignInSuccessfully()
+    {
+        var user = await _hostFixture.TestData.CreateUser(hasTrn: true, haveCompletedTrnLookup: false);
+
+        await using var context = await _hostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.StartOAuthJourney(CustomScopes.Trn);
+
+        await page.SubmitEmailPage(user.EmailAddress);
+
+        await page.SubmitEmailConfirmationPage();
+
+        await page.SubmitCompletePageForExistingUser();
+
+        await page.AssertSignedInOnTestClient(user);
+    }
+
+    private async Task SignInAsNewTeacherUserWithTrnScope(
+        IPage page,
+        string email,
+        string officialFirstName,
+        string officialLastName,
+        string trn,
+        DateOnly dateOfBirth)
+    {
+        ConfigureDqtApiFindTeachersRequest(result: null);
+
+        await page.StartOAuthJourney(additionalScope: CustomScopes.Trn);
+
+        await page.SubmitEmailPage(email);
+
+        await page.SubmitEmailConfirmationPage();
+
+        await page.SubmitTrnBookendPage();
+
+        await page.SubmitTrnHasTrnPageWithTrn(trn);
+
+        await page.SubmitTrnOfficialNamePage(officialFirstName, officialLastName);
+
+        await page.SubmitTrnPreferredNamePageWithoutPreferredName();
+
+        // Simulate DQT API returning result when next page submitted
+
+        ConfigureDqtApiFindTeachersRequest(result: new()
+        {
+            DateOfBirth = dateOfBirth,
+            FirstName = officialFirstName,
+            LastName = officialLastName,
+            EmailAddresses = new[] { email },
+            HasActiveSanctions = false,
+            NationalInsuranceNumber = null,
+            Trn = trn,
+            Uid = Guid.NewGuid().ToString()
+        });
+
+        await page.SubmitTrnDateOfBirthPage(dateOfBirth);
+
+        await page.SubmitTrnCheckAnswersPage();
+
+        await page.SubmitCompletePageForNewUserInLegacyTrnJourney();
+
+        await page.AssertSignedInOnTestClient(email, trn, officialFirstName, officialLastName);
+    }
+
+    private void ConfigureDqtApiFindTeachersRequest(FindTeachersResponseResult? result)
+    {
+        var results = result is not null ? new[] { result } : Array.Empty<FindTeachersResponseResult>();
+
+        _hostFixture.DqtApiClient
+            .Setup(mock => mock.FindTeachers(It.IsAny<FindTeachersRequest>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new FindTeachersResponse()
+            {
+                Results = results
+            });
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
@@ -233,4 +233,74 @@ public static class PageExtensions
         await page.ClickAsync($"text={email}");
         await page.ClickAsync("button:text-is('Continue')");
     }
+
+    public static async Task RegisterFromLandingPage(this IPage page)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/landing");
+        await page.ClickAsync("a:text-is('Create an account')");
+    }
+
+    public static async Task SubmitRegisterEmailPage(this IPage page, string email)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/register/email");
+        await page.FillAsync("text=Your email address", email);
+        await page.ClickAsync("button:text-is('Continue')");
+    }
+
+    public static async Task SubmitRegisterEmailConfirmationPage(this IPage page)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/register/email-confirmation");
+        await page.FillAsync("label:text-is('Confirmation code')", HostFixture.UserVerificationPin);
+        await page.ClickAsync("button:text-is('Continue')");
+    }
+
+    public static async Task SubmitRegisterPhonePage(this IPage page, string mobileNumber)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/register/phone");
+        await page.FillAsync("label:text-is('Mobile number')", mobileNumber);
+        await page.ClickAsync("button:text-is('Continue')");
+    }
+
+    public static async Task SubmitRegisterPhoneConfirmationPage(this IPage page)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/register/phone-confirmation");
+        await page.FillAsync("label:text-is('Security code')", HostFixture.UserVerificationPin);
+        await page.ClickAsync("button:text-is('Continue')");
+    }
+
+    public static async Task SubmitRegisterNamePage(this IPage page, string firstName, string lastName)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/register/name");
+        await page.FillAsync("label:text-is('First name')", firstName);
+        await page.FillAsync("label:text-is('Last name')", lastName);
+        await page.ClickAsync("button:text-is('Continue')");
+    }
+
+    public static async Task SubmitDateOfBirthPage(this IPage page, DateOnly dateOfBirth)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/register/date-of-birth");
+        await page.FillAsync("label:text-is('Day')", dateOfBirth.Day.ToString());
+        await page.FillAsync("label:text-is('Month')", dateOfBirth.Month.ToString());
+        await page.FillAsync("label:text-is('Year')", dateOfBirth.Year.ToString());
+        await page.ClickAsync("button:text-is('Continue')");
+    }
+
+    public static async Task SubmitCompletePageForNewUser(this IPage page)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/complete");
+        Assert.Equal(1, await page.Locator("data-testid=first-time-user-content").CountAsync());
+        await page.ClickAsync("button:text-is('Continue')");
+    }
+
+    public static async Task SignInFromRegisterEmailExistsPage(this IPage page)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/register/email-exists");
+        await page.ClickAsync("a:text-is('Sign in')");
+    }
+
+    public static async Task SignInFromRegisterPhoneExistsPage(this IPage page)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/register/phone-exists");
+        await page.ClickAsync("a:text-is('Sign in')");
+    }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
@@ -5,6 +5,13 @@ namespace TeacherIdentity.AuthServer.EndToEndTests;
 
 public static class PageExtensions
 {
+    public static Task WaitForUrlPathAsync(this IPage page, string path) =>
+        page.WaitForURLAsync(url =>
+        {
+            var asUri = new Uri(url);
+            return asUri.LocalPath == path;
+        });
+
     public static async Task StartOAuthJourney(this IPage page, string? additionalScope = null)
     {
         await page.GotoAsync($"/profile?scope=email+openid+profile{(additionalScope is not null ? "+" + Uri.EscapeDataString(additionalScope) : string.Empty)}");
@@ -39,27 +46,34 @@ public static class PageExtensions
 
     public static async Task SignInFromLandingPage(this IPage page)
     {
-        await page.WaitForSelectorAsync("h1:text-is('Create a DfE Identity account')");
+        await page.WaitForUrlPathAsync("/sign-in/landing");
         await page.ClickAsync("a:text-is('Sign in')");
     }
 
     public static async Task SubmitEmailPage(this IPage page, string email)
     {
-        await page.WaitForSelectorAsync(":text-is('Your email address')");
+        await page.WaitForUrlPathAsync("/sign-in/email");
         await page.FillAsync("input[type='email']", email);
         await page.ClickAsync("button:text-is('Continue')");
     }
 
-    public static async Task SubmitEmailConfirmationPage(this IPage page, string pin)
+    public static async Task SubmitEmailConfirmationPage(this IPage page)
     {
-        await page.WaitForSelectorAsync("h1:text-is('Confirm your email address')");
-        await page.FillAsync("text=Enter your code", pin);
+        await page.WaitForUrlPathAsync("/sign-in/email-confirmation");
+        await page.FillAsync("text=Enter your code", HostFixture.UserVerificationPin);
         await page.ClickAsync("button:text-is('Continue')");
     }
 
     public static async Task SubmitCompletePageForExistingUser(this IPage page)
     {
-        Assert.Equal(1, await page.GetByText("Your details").CountAsync());
+        await page.WaitForUrlPathAsync("/sign-in/complete");
+        await page.ClickAsync("button:text-is('Continue')");
+    }
+
+    public static async Task SubmitCompletePageForNewUserInLegacyTrnJourney(this IPage page)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/complete");
+        Assert.Equal(1, await page.Locator("data-testid=first-time-user-content").CountAsync());
         await page.ClickAsync("button:text-is('Continue')");
     }
 
@@ -77,7 +91,7 @@ public static class PageExtensions
 
     public static async Task AssertOnAccountPage(this IPage page)
     {
-        await page.WaitForSelectorAsync("h1:text-is('Your details')");
+        await page.WaitForURLAsync(url => url.StartsWith($"{HostFixture.AuthServerBaseUrl}/account"));
     }
 
     public static async Task SignOutFromAccountPageWithoutClientContext(this IPage page)
@@ -114,5 +128,109 @@ public static class PageExtensions
         await page.ClickAsync("a:text-is('Back to Development test client')");
 
         await page.AssertOnTestClient();
+    }
+
+    public static async Task SubmitTrnBookendPage(this IPage page)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/trn");
+        await page.ClickAsync("button:text-is('Continue')");
+    }
+
+    public static async Task SubmitTrnHasTrnPageWithoutTrn(this IPage page)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/trn/has-trn");
+        await page.ClickAsync("label:text-is('No, I need to continue without my TRN')");
+        await page.ClickAsync("button:text-is('Continue')");
+    }
+
+    public static async Task SubmitTrnHasTrnPageWithTrn(this IPage page, string trn)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/trn/has-trn");
+        await page.ClickAsync("label:text-is('Yes, I know my TRN')");
+        await page.FillAsync("text=What is your TRN?", trn);
+        await page.ClickAsync("button:text-is('Continue')");
+    }
+
+    public static async Task SubmitTrnOfficialNamePage(this IPage page, string officialFirstName, string officialLastName)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/trn/official-name");
+        await page.FillAsync("text=First name", officialFirstName);
+        await page.FillAsync("text=Last name", officialLastName);
+        await page.ClickAsync("label:text-is('No')");  // Have you ever changed your name?
+        await page.ClickAsync("button:text-is('Continue')");
+    }
+
+    public static async Task SubmitTrnPreferredNamePageWithoutPreferredName(this IPage page)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/trn/preferred-name");
+        await page.ClickAsync("label:text-is('Yes')");  // Is x y your preferred name?
+        await page.ClickAsync("button:text-is('Continue')");
+    }
+
+    public static async Task SubmitTrnDateOfBirthPage(this IPage page, DateOnly dateOfBirth)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/trn/date-of-birth");
+        await page.FillAsync("label:text-is('Day')", dateOfBirth.Day.ToString());
+        await page.FillAsync("label:text-is('Month')", dateOfBirth.Month.ToString());
+        await page.FillAsync("label:text-is('Year')", dateOfBirth.Year.ToString());
+        await page.ClickAsync("button:text-is('Continue')");
+    }
+
+    public static async Task SubmitTrnHasNinoPage(this IPage page, bool hasNino)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/trn/has-nino");
+        await page.ClickAsync($"label:text-is('{(hasNino ? "Yes" : "No")}')");  // Do you have a National Insurance number?
+        await page.ClickAsync("button:text-is('Continue')");
+    }
+
+    public static async Task SubmitTrnNiNumberPage(this IPage page, string nationalInsuranceNumber)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/trn/ni-number");
+        await page.FillAsync("text='What is your National Insurance number?'", nationalInsuranceNumber);
+        await page.ClickAsync("button:text-is('Continue')");
+    }
+
+    public static async Task SubmitTrnAwardedQtsPage(this IPage page, bool awardedQts)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/trn/awarded-qts");
+        await page.ClickAsync($"label:text-is('{(awardedQts ? "Yes" : "No")}')");  // Have you been awarded qualified teacher status (QTS)?
+        await page.ClickAsync("button:text-is('Continue')");
+    }
+
+    public static async Task SubmitTrnIttProviderPageWithIttProvider(this IPage page, string ittProviderName)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/trn/itt-provider");
+        await page.ClickAsync("label:text-is('Yes')");  // Did a university, SCITT or school award your QTS?
+        await page.FillAsync("label:text-is('Where did you get your QTS?')", ittProviderName);
+        await page.FocusAsync("button:text-is('Continue')");  // Un-focus accessible autocomplete
+        await page.ClickAsync("button:text-is('Continue')");
+    }
+
+    public static async Task SubmitTrnCheckAnswersPage(this IPage page)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/trn/check-answers");
+        await page.WaitForSelectorAsync("h1:text-is('Check your answers')");
+        await page.ClickAsync("button:text-is('Continue')");
+    }
+
+    public static async Task SubmitTrnNoMatchPage(this IPage page)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/trn/no-match");
+        await page.ClickAsync("label:text-is('No, use these details, they are correct')");
+        await page.ClickAsync("button:text-is('Continue')");
+    }
+
+    public static async Task SubmitTrnTrnInUsePage(this IPage page)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/trn/different-email");
+        await page.FillAsync("text=Enter your code", HostFixture.UserVerificationPin);
+        await page.ClickAsync("button:text-is('Continue')");
+    }
+
+    public static async Task SubmitTrnChooseEmailPage(this IPage page, string email)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/trn/choose-email");
+        await page.ClickAsync($"text={email}");
+        await page.ClickAsync("button:text-is('Continue')");
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Register.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Register.cs
@@ -1,0 +1,94 @@
+using TeacherIdentity.AuthServer.Events;
+
+namespace TeacherIdentity.AuthServer.EndToEndTests;
+
+public class Register : IClassFixture<HostFixture>
+{
+    private readonly HostFixture _hostFixture;
+
+    public Register(HostFixture hostFixture)
+    {
+        _hostFixture = hostFixture;
+        _hostFixture.OnTestStarting();
+    }
+
+    [Fact]
+    public async Task NewUserCanRegister()
+    {
+        var email = Faker.Internet.Email();
+        var mobileNumber = _hostFixture.TestData.GenerateUniqueMobileNumber();
+        var firstName = Faker.Name.First();
+        var lastName = Faker.Name.Last();
+        var dateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
+
+        await using var context = await _hostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.StartOAuthJourney(additionalScope: null);
+
+        await page.RegisterFromLandingPage();
+
+        await page.SubmitRegisterEmailPage(email);
+
+        await page.SubmitRegisterEmailConfirmationPage();
+
+        await page.SubmitRegisterPhonePage(mobileNumber);
+
+        await page.SubmitRegisterPhoneConfirmationPage();
+
+        await page.SubmitRegisterNamePage(firstName, lastName);
+
+        await page.SubmitDateOfBirthPage(dateOfBirth);
+
+        await page.SubmitCompletePageForNewUser();
+
+        await page.AssertSignedInOnTestClient(email, trn: null, firstName, lastName);
+
+        Guid createdUserId = default;
+
+        _hostFixture.EventObserver.AssertEventsSaved(
+            e =>
+            {
+                var userRegisteredEvent = Assert.IsType<UserRegisteredEvent>(e);
+                Assert.Equal(_hostFixture.TestClientId, userRegisteredEvent.ClientId);
+                Assert.Equal(email, userRegisteredEvent.User.EmailAddress);
+                Assert.Equal(mobileNumber, userRegisteredEvent.User.MobileNumber);
+                Assert.Equal(firstName, userRegisteredEvent.User.FirstName);
+                Assert.Equal(lastName, userRegisteredEvent.User.LastName);
+                Assert.Equal(dateOfBirth, userRegisteredEvent.User.DateOfBirth);
+
+                createdUserId = userRegisteredEvent.User.UserId;
+            },
+            e =>
+            {
+                var userSignedInEvent = Assert.IsType<UserSignedInEvent>(e);
+                Assert.Equal(createdUserId, userSignedInEvent.User.UserId);
+            });
+    }
+
+    [Fact]
+    public async Task UserWithEmailAlreadyExists_SignsInExistingUser()
+    {
+        var existingUser = await _hostFixture.TestData.CreateUser();
+
+        await using var context = await _hostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.StartOAuthJourney(additionalScope: null);
+
+        await page.RegisterFromLandingPage();
+
+        await page.SubmitRegisterEmailPage(existingUser.EmailAddress);
+
+        await page.SubmitRegisterEmailConfirmationPage();
+
+        await page.SignInFromRegisterEmailExistsPage();
+
+        await page.SubmitCompletePageForExistingUser();
+
+        await page.AssertSignedInOnTestClient(existingUser);
+
+        _hostFixture.EventObserver.AssertEventsSaved(
+            e => _hostFixture.AssertEventIsUserSignedIn(e, existingUser.UserId, expectOAuthProperties: true));
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignIn.StaffUser.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignIn.StaffUser.cs
@@ -31,7 +31,8 @@ public partial class SignIn
 
         await page.WaitForUrlPathAsync("/admin/staff");
 
-        _hostFixture.EventObserver.AssertEventsSaved(e => AssertEventIsUserSignedIn(e, user.UserId, expectOAuthProperties: false));
+        _hostFixture.EventObserver.AssertEventsSaved(
+            e => _hostFixture.AssertEventIsUserSignedIn(e, user.UserId, expectOAuthProperties: false));
     }
 
     [Fact]
@@ -65,7 +66,8 @@ public partial class SignIn
 
         await page.AssertSignedInOnTestClient(user);
 
-        _hostFixture.EventObserver.AssertEventsSaved(e => AssertEventIsUserSignedIn(e, user.UserId));
+        _hostFixture.EventObserver.AssertEventsSaved(
+            e => _hostFixture.AssertEventIsUserSignedIn(e, user.UserId));
 
         return user.UserId;
     }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignIn.StaffUser.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignIn.StaffUser.cs
@@ -18,56 +18,35 @@ public partial class SignIn
     [Fact]
     public async Task StaffUser_CanSignInToAdminPageSuccessfullyWithEmailAndPin()
     {
-        var staffUser = await _hostFixture.TestData.CreateUser(userType: UserType.Staff, staffRoles: StaffRoles.All);
+        var user = await _hostFixture.TestData.CreateUser(userType: UserType.Staff, staffRoles: StaffRoles.All);
 
         await using var context = await _hostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();
 
-        // Try to access protected admin area on auth server
-
         await page.GotoAsync($"{HostFixture.AuthServerBaseUrl}/admin/staff");
 
-        // Fill in the sign in form (email + PIN)
+        await page.SubmitEmailPage(user.EmailAddress);
 
-        await page.FillAsync("text=Your email address", staffUser.EmailAddress);
-        await page.ClickAsync("button:text-is('Continue')");
+        await page.SubmitEmailConfirmationPage();
 
-        var pin = HostFixture.UserVerificationPin;
-        await page.FillAsync("text=Enter your code", pin);
-        await page.ClickAsync("button:text-is('Continue')");
+        await page.WaitForUrlPathAsync("/admin/staff");
 
-        // Should now be on the originally request URL, /admin/staff
-
-        var clientAppHost = new Uri(HostFixture.ClientBaseUrl).Host;
-        Assert.EndsWith("/admin/staff", page.Url);
-
-        // Check events have been emitted
-
-        _hostFixture.EventObserver.AssertEventsSaved(e => AssertEventIsUserSignedIn(e, staffUser.UserId, expectOAuthProperties: false));
+        _hostFixture.EventObserver.AssertEventsSaved(e => AssertEventIsUserSignedIn(e, user.UserId, expectOAuthProperties: false));
     }
 
     [Fact]
     public async Task StaffUser_MissingPermission_GetsForbiddenError()
     {
-        var staffUser = await _hostFixture.TestData.CreateUser(userType: UserType.Staff, staffRoles: Array.Empty<string>());
+        var user = await _hostFixture.TestData.CreateUser(userType: UserType.Staff, staffRoles: Array.Empty<string>());
 
         await using var context = await _hostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();
 
-        // Start on the client app and try to access a protected area with admin scope
+        await page.StartOAuthJourney(CustomScopes.UserRead);
 
-        await page.GotoAsync($"/profile?scope={CustomScopes.UserRead}");
+        await page.SubmitEmailPage(user.EmailAddress);
 
-        // Fill in the sign in form (email + PIN)
-
-        await page.FillAsync("text=Your email address", staffUser.EmailAddress);
-        await page.ClickAsync("button:text-is('Continue')");
-
-        var pin = HostFixture.UserVerificationPin;
-        await page.FillAsync("text=Enter your code", pin);
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Should get a Forbidden error
+        await page.SubmitEmailConfirmationPage();
 
         await page.WaitForSelectorAsync("h1:text-is('Forbidden')");
     }
@@ -76,35 +55,15 @@ public partial class SignIn
     {
         var user = await _hostFixture.TestData.CreateUser(userType: UserType.Staff, staffRoles: StaffRoles.All);
 
-        // Start on the client app and try to access a protected area with admin scope
+        await page.StartOAuthJourney(CustomScopes.UserRead);
 
-        await page.GotoAsync($"/profile?scope=email+openid+profile+{CustomScopes.UserRead}");
+        await page.SubmitEmailPage(user.EmailAddress);
 
-        // Fill in the sign in form (email + PIN)
+        await page.SubmitEmailConfirmationPage();
 
-        await page.FillAsync("text=Your email address", user.EmailAddress);
-        await page.ClickAsync("button:text-is('Continue')");
+        await page.SubmitCompletePageForExistingUser();
 
-        var pin = HostFixture.UserVerificationPin;
-        await page.FillAsync("text=Enter your code", pin);
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Should now be on the confirmation page
-
-        Assert.Equal(1, await page.Locator("data-testid=known-user-content").CountAsync());
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Should now be back at the client, signed in
-
-        var clientAppHost = new Uri(HostFixture.ClientBaseUrl).Host;
-        var pageUrlHost = new Uri(page.Url).Host;
-        Assert.Equal(clientAppHost, pageUrlHost);
-
-        var signedInEmail = await page.InnerTextAsync("data-testid=email");
-        Assert.Equal(string.Empty, await page.InnerTextAsync("data-testid=trn"));
-        Assert.Equal(user.EmailAddress, signedInEmail);
-
-        // Check events have been emitted
+        await page.AssertSignedInOnTestClient(user);
 
         _hostFixture.EventObserver.AssertEventsSaved(e => AssertEventIsUserSignedIn(e, user.UserId));
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignIn.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignIn.cs
@@ -28,35 +28,15 @@ public partial class SignIn : IClassFixture<HostFixture>
         await using var context = await _hostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();
 
-        // Start on the client app and try to access a protected area
+        await page.StartOAuthJourney(additionalScope);
 
-        await page.GotoAsync($"/profile?scope=email+openid+profile+{Uri.EscapeDataString(additionalScope)}");
+        await page.SubmitEmailPage(user.EmailAddress);
 
-        // Fill in the sign in form (email + PIN)
+        await page.SubmitEmailConfirmationPage();
 
-        await page.FillAsync("text=Enter your email address", user.EmailAddress);
-        await page.ClickAsync("button:text-is('Continue')");
+        await page.SubmitCompletePageForExistingUser();
 
-        var pin = HostFixture.UserVerificationPin;
-        await page.FillAsync("text=Enter your code", pin);
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Should now be on the confirmation page
-
-        Assert.Equal(1, await page.Locator("data-testid=known-user-content").CountAsync());
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Should now be back at the client, signed in
-
-        var clientAppHost = new Uri(HostFixture.ClientBaseUrl).Host;
-        var pageUrlHost = new Uri(page.Url).Host;
-        Assert.Equal(clientAppHost, pageUrlHost);
-
-        var signedInEmail = await page.InnerTextAsync("data-testid=email");
-        Assert.Equal(user.Trn ?? string.Empty, await page.InnerTextAsync("data-testid=trn"));
-        Assert.Equal(user.EmailAddress, signedInEmail);
-
-        // Check events have been emitted
+        await page.AssertSignedInOnTestClient(user);
 
         _hostFixture.EventObserver.AssertEventsSaved(e => AssertEventIsUserSignedIn(e, user.UserId));
     }
@@ -70,103 +50,10 @@ public partial class SignIn : IClassFixture<HostFixture>
         var dateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
         var trn = _hostFixture.TestData.GenerateTrn();
 
-        _hostFixture.DqtApiClient
-            .Setup(mock => mock.FindTeachers(It.IsAny<FindTeachersRequest>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new FindTeachersResponse()
-            {
-                Results = Array.Empty<FindTeachersResponseResult>()
-            });
-
         await using var context = await _hostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();
 
-        // Start on the client app and try to access a protected area
-
-        await page.GotoAsync($"/profile?scope=email+openid+profile+{Uri.EscapeDataString(CustomScopes.DqtRead)}");
-
-        // Fill in the sign in form (email + PIN)
-
-        await page.FillAsync("text=Enter your email address", email);
-        await page.ClickAsync("button:text-is('Continue')");
-
-        var pin = HostFixture.UserVerificationPin;
-        await page.FillAsync("text=Enter your code", pin);
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Should now be at the first bookend page
-
-        var urlPath = new Uri(page.Url).LocalPath;
-        Assert.EndsWith("/trn", urlPath);
-
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Has TRN page
-
-        await page.ClickAsync("label:text-is('Yes, I know my TRN')");
-        await page.FillAsync("text=What is your TRN?", trn);
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Official name page
-
-        await page.FillAsync("text=First name", officialFirstName);
-        await page.FillAsync("text=Last name", officialLastName);
-        await page.ClickAsync("label:text-is('No')");  // Have you ever changed your name?
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Preferred name page
-
-        await page.ClickAsync("label:text-is('Yes')");  // Is x y your preferred name?
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Simulate DQT API returning result when next page submitted
-
-        _hostFixture.DqtApiClient
-            .Setup(mock => mock.FindTeachers(It.IsAny<FindTeachersRequest>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new FindTeachersResponse()
-            {
-                Results = new FindTeachersResponseResult[]
-                {
-                    new()
-                    {
-                        DateOfBirth = dateOfBirth,
-                        FirstName = officialFirstName,
-                        LastName = officialLastName,
-                        EmailAddresses = new[] { email },
-                        HasActiveSanctions = false,
-                        NationalInsuranceNumber = null,
-                        Trn = trn,
-                        Uid = Guid.NewGuid().ToString()
-                    }
-                }
-            });
-
-        // Date of birth page
-
-        await page.FillAsync("label:text-is('Day')", dateOfBirth.Day.ToString());
-        await page.FillAsync("label:text-is('Month')", dateOfBirth.Month.ToString());
-        await page.FillAsync("label:text-is('Year')", dateOfBirth.Year.ToString());
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Check answers page
-
-        await page.WaitForSelectorAsync("h1:text-is('Check your answers')");
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Should now be on the confirmation page
-
-        Assert.Equal(1, await page.Locator("data-testid=first-time-user-content").CountAsync());
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Should now be back on the client, signed in
-
-        var clientAppHost = new Uri(HostFixture.ClientBaseUrl).Host;
-        var pageUrlHost = new Uri(page.Url).Host;
-        Assert.Equal(clientAppHost, pageUrlHost);
-
-        Assert.Equal(officialFirstName, await page.InnerTextAsync("data-testid=first-name"));
-        Assert.Equal(officialLastName, await page.InnerTextAsync("data-testid=last-name"));
-        Assert.Equal(email, await page.InnerTextAsync("data-testid=email"));
-        Assert.Equal(trn ?? string.Empty, await page.InnerTextAsync("data-testid=trn"));
+        await SignInAsNewTeacherUserWithDqtReadScope(page, email, officialFirstName, officialLastName, trn, dateOfBirth);
     }
 
     [Fact]
@@ -179,12 +66,7 @@ public partial class SignIn : IClassFixture<HostFixture>
         var nino = Faker.Identification.UkNationalInsuranceNumber();
         var ittProvider = Faker.Company.Name();
 
-        _hostFixture.DqtApiClient
-            .Setup(mock => mock.FindTeachers(It.IsAny<FindTeachersRequest>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new FindTeachersResponse()
-            {
-                Results = Array.Empty<FindTeachersResponseResult>()
-            });
+        ConfigureDqtApiFindTeachersRequest(result: null);
 
         _hostFixture.DqtApiClient
             .Setup(mock => mock.GetIttProviders(It.IsAny<CancellationToken>()))
@@ -208,97 +90,37 @@ public partial class SignIn : IClassFixture<HostFixture>
         await using var context = await _hostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();
 
-        // Start on the client app and try to access a protected area
+        await page.StartOAuthJourney(additionalScope: CustomScopes.DqtRead);
 
-        await page.GotoAsync($"/profile?scope=email+openid+profile+{Uri.EscapeDataString(CustomScopes.DqtRead)}");
+        await page.SubmitEmailPage(email);
 
-        // Fill in the sign in form (email + PIN)
+        await page.SubmitEmailConfirmationPage();
 
-        await page.FillAsync("text=Enter your email address", email);
-        await page.ClickAsync("button:text-is('Continue')");
+        await page.SubmitTrnBookendPage();
 
-        var pin = HostFixture.UserVerificationPin;
-        await page.FillAsync("text=Enter your code", pin);
-        await page.ClickAsync("button:text-is('Continue')");
+        await page.SubmitTrnHasTrnPageWithoutTrn();
 
-        // Should now be at the first bookend page
+        await page.SubmitTrnOfficialNamePage(officialFirstName, officialLastName);
 
-        var urlPath = new Uri(page.Url).LocalPath;
-        Assert.EndsWith("/trn", urlPath);
+        await page.SubmitTrnPreferredNamePageWithoutPreferredName();
 
-        await page.ClickAsync("button:text-is('Continue')");
+        await page.SubmitTrnDateOfBirthPage(dateOfBirth);
 
-        // Has TRN page
+        await page.SubmitTrnHasNinoPage(hasNino: true);
 
-        await page.ClickAsync("label:text-is('No, I need to continue without my TRN')");
-        await page.ClickAsync("button:text-is('Continue')");
+        await page.SubmitTrnNiNumberPage(nino);
 
-        // Official name page
+        await page.SubmitTrnAwardedQtsPage(awardedQts: true);
 
-        await page.FillAsync("text=First name", officialFirstName);
-        await page.FillAsync("text=Last name", officialLastName);
-        await page.ClickAsync("label:text-is('No')");  // Have you ever changed your name?
-        await page.ClickAsync("button:text-is('Continue')");
+        await page.SubmitTrnIttProviderPageWithIttProvider(ittProvider);
 
-        // Preferred name page
+        await page.SubmitTrnCheckAnswersPage();
 
-        await page.ClickAsync("label:text-is('Yes')");  // Is x y your preferred name?
-        await page.ClickAsync("button:text-is('Continue')");
+        await page.SubmitTrnNoMatchPage();
 
-        // Date of birth page
+        await page.SubmitCompletePageForNewUserInLegacyTrnJourney();
 
-        await page.FillAsync("label:text-is('Day')", dateOfBirth.Day.ToString());
-        await page.FillAsync("label:text-is('Month')", dateOfBirth.Month.ToString());
-        await page.FillAsync("label:text-is('Year')", dateOfBirth.Year.ToString());
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Has NI number page
-
-        await page.ClickAsync("label:text-is('Yes')");  // Do you have a National Insurance number?
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // NI number page
-
-        await page.FillAsync("text='What is your National Insurance number?'", nino);
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Awarded QTS page
-
-        await page.ClickAsync("label:text-is('Yes')");  // Have you been awarded qualified teacher status (QTS)?
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // ITT Provider page
-
-        await page.ClickAsync("label:text-is('Yes')");  // Did a university, SCITT or school award your QTS?
-        await page.FillAsync("label:text-is('Where did you get your QTS?')", ittProvider);
-        await page.FocusAsync("button:text-is('Continue')");  // Un-focus accessible autocomplete
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Check answers page
-
-        await page.WaitForSelectorAsync("h1:text-is('Check your answers')");
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // No match page
-
-        await page.ClickAsync("label:text-is('No, use these details, they are correct')");
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Should now be on the confirmation page
-
-        Assert.Equal(1, await page.Locator("data-testid=first-time-user-content").CountAsync());
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Should now be back on the client, signed in
-
-        var clientAppHost = new Uri(HostFixture.ClientBaseUrl).Host;
-        var pageUrlHost = new Uri(page.Url).Host;
-        Assert.Equal(clientAppHost, pageUrlHost);
-
-        Assert.Equal(officialFirstName, await page.InnerTextAsync("data-testid=first-name"));
-        Assert.Equal(officialLastName, await page.InnerTextAsync("data-testid=last-name"));
-        Assert.Equal(email, await page.InnerTextAsync("data-testid=email"));
-        Assert.Equal(string.Empty, await page.InnerTextAsync("data-testid=trn"));
+        await page.AssertSignedInOnTestClient(email, trn: null, officialFirstName, officialLastName);
     }
 
     [Fact]
@@ -307,33 +129,21 @@ public partial class SignIn : IClassFixture<HostFixture>
         var email = Faker.Internet.Email();
         var firstName = Faker.Name.First();
         var lastName = Faker.Name.Last();
-        var trn = (string?)null;
+        var trn = _hostFixture.TestData.GenerateTrn();
         var dateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
 
         await using var context = await _hostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();
 
-        await SignInAsNewTeacherUserWithDqtReadScope(page, email, firstName, lastName, trn, dateOfBirth, preferredFirstName: null, preferredLastName: null);
+        await SignInAsNewTeacherUserWithDqtReadScope(page, email, firstName, lastName, trn, dateOfBirth);
 
         await ClearCookiesForTestClient();
 
-        // Start on the client app and try to access a protected area
+        await page.StartOAuthJourney(additionalScope: CustomScopes.DqtRead);
 
-        await page.GotoAsync($"/profile?scope=email+openid+profile+{Uri.EscapeDataString(CustomScopes.DqtRead)}");
+        await page.SubmitCompletePageForExistingUser();
 
-        // Should have jumped straight to confirmation page as the auth server knows who we are
-
-        Assert.Equal(1, await page.Locator("data-testid=known-user-content").CountAsync());
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Should now be back at the client, signed in
-
-        var clientAppHost = new Uri(HostFixture.ClientBaseUrl).Host;
-        var pageUrlHost = new Uri(page.Url).Host;
-        Assert.Equal(clientAppHost, pageUrlHost);
-
-        var signedInEmail = await page.InnerTextAsync("data-testid=email");
-        Assert.Equal(email, signedInEmail);
+        await page.AssertSignedInOnTestClient(email, trn, firstName, lastName);
 
         async Task ClearCookiesForTestClient()
         {
@@ -371,117 +181,50 @@ public partial class SignIn : IClassFixture<HostFixture>
         var officialLastName = Faker.Name.Last();
         var dateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
 
-        _hostFixture.DqtApiClient
-            .Setup(mock => mock.FindTeachers(It.IsAny<FindTeachersRequest>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new FindTeachersResponse()
-            {
-                Results = Array.Empty<FindTeachersResponseResult>()
-            });
+        ConfigureDqtApiFindTeachersRequest(result: null);
 
         await using var context = await _hostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();
 
-        // Start on the client app and try to access a protected area
+        await page.StartOAuthJourney(additionalScope: CustomScopes.DqtRead);
 
-        await page.GotoAsync($"/profile?scope=email+openid+profile+{Uri.EscapeDataString(CustomScopes.DqtRead)}");
+        await page.SubmitEmailPage(email);
 
-        // Fill in the sign in form (email + PIN)
+        await page.SubmitEmailConfirmationPage();
 
-        await page.FillAsync("text=Enter your email address", email);
-        await page.ClickAsync("button:text-is('Continue')");
+        await page.SubmitTrnBookendPage();
 
-        var pin = HostFixture.UserVerificationPin;
-        await page.FillAsync("text=Enter your code", pin);
-        await page.ClickAsync("button:text-is('Continue')");
+        await page.SubmitTrnHasTrnPageWithTrn(trn);
 
-        // Should now be at the first bookend page
+        await page.SubmitTrnOfficialNamePage(officialFirstName, officialLastName);
 
-        var urlPath = new Uri(page.Url).LocalPath;
-        Assert.EndsWith("/trn", urlPath);
-
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Has TRN page
-
-        await page.ClickAsync("label:text-is('Yes, I know my TRN')");
-        await page.FillAsync("text=What is your TRN?", trn);
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Official name page
-
-        await page.FillAsync("text=First name", officialFirstName);
-        await page.FillAsync("text=Last name", officialLastName);
-        await page.ClickAsync("label:text-is('No')");  // Have you ever changed your name?
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Preferred name page
-
-        await page.ClickAsync("label:text-is('Yes')");  // Is x y your preferred name?
-        await page.ClickAsync("button:text-is('Continue')");
+        await page.SubmitTrnPreferredNamePageWithoutPreferredName();
 
         // Simulate DQT API returning result when next page submitted
 
-        _hostFixture.DqtApiClient
-            .Setup(mock => mock.FindTeachers(It.IsAny<FindTeachersRequest>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new FindTeachersResponse()
-            {
-                Results = new FindTeachersResponseResult[]
-                {
-                    new()
-                    {
-                        DateOfBirth = dateOfBirth,
-                        FirstName = officialFirstName,
-                        LastName = officialLastName,
-                        EmailAddresses = new[] { trnOwnerEmailAddress },
-                        HasActiveSanctions = false,
-                        NationalInsuranceNumber = null,
-                        Trn = trn,
-                        Uid = Guid.NewGuid().ToString()
-                    }
-                }
-            });
+        ConfigureDqtApiFindTeachersRequest(result: new()
+        {
+            DateOfBirth = dateOfBirth,
+            FirstName = officialFirstName,
+            LastName = officialLastName,
+            EmailAddresses = new[] { email },
+            HasActiveSanctions = false,
+            NationalInsuranceNumber = null,
+            Trn = trn,
+            Uid = Guid.NewGuid().ToString()
+        });
 
-        // Date of birth page
+        await page.SubmitTrnDateOfBirthPage(dateOfBirth);
 
-        await page.FillAsync("label:text-is('Day')", dateOfBirth.Day.ToString());
-        await page.FillAsync("label:text-is('Month')", dateOfBirth.Month.ToString());
-        await page.FillAsync("label:text-is('Year')", dateOfBirth.Year.ToString());
-        await page.ClickAsync("button:text-is('Continue')");
+        await page.SubmitTrnCheckAnswersPage();
 
-        // Check answers page
+        await page.SubmitTrnTrnInUsePage();
 
-        await page.WaitForSelectorAsync("h1:text-is('Check your answers')");
-        await page.ClickAsync("button:text-is('Continue')");
+        await page.SubmitTrnChooseEmailPage(trnOwnerEmailAddress);
 
-        // Should now be on 'TRN in use' page
+        await page.SubmitCompletePageForNewUserInLegacyTrnJourney();
 
-        pin = HostFixture.UserVerificationPin;
-        await page.FillAsync("text=Enter your code", pin);
-
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Should now be on 'Choose email' page
-
-        await page.ClickAsync($"text={trnOwnerEmailAddress}");
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Should now be on the confirmation page
-
-        Assert.Equal(1, await page.Locator("data-testid=first-time-user-content").CountAsync());
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Should now be back on the client, signed in
-
-        var clientAppHost = new Uri(HostFixture.ClientBaseUrl).Host;
-        var pageUrlHost = new Uri(page.Url).Host;
-        Assert.Equal(clientAppHost, pageUrlHost);
-
-        Assert.Equal(existingTrnOwner.FirstName, await page.InnerTextAsync("data-testid=first-name"));
-        Assert.Equal(existingTrnOwner.LastName, await page.InnerTextAsync("data-testid=last-name"));
-        Assert.Equal(existingTrnOwner.EmailAddress, await page.InnerTextAsync("data-testid=email"));
-        Assert.Equal(trn, await page.InnerTextAsync("data-testid=trn"));
-
-        // Check events have been emitted
+        await page.AssertSignedInOnTestClient(existingTrnOwner);
 
         _hostFixture.EventObserver.AssertEventsSaved(e => AssertEventIsUserSignedIn(e, existingTrnOwner.UserId));
     }
@@ -489,20 +232,28 @@ public partial class SignIn : IClassFixture<HostFixture>
     [Fact]
     public async Task FirstRequestToProtectedAreaOfSiteForUserAlreadySignedInViaOAuth_IssuesUserSignedInEvent()
     {
+        var user = await _hostFixture.TestData.CreateUser(userType: UserType.Default);
+
         await using var context = await _hostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();
 
-        var userId = await SignInExistingStaffUserWithTestClient(page);
+        await page.StartOAuthJourney(additionalScope: null);
+
+        await page.SignInFromLandingPage();
+
+        await page.SubmitEmailPage(user.EmailAddress);
+
+        await page.SubmitEmailConfirmationPage();
+
+        await page.SubmitCompletePageForExistingUser();
+
+        await page.AssertSignedInOnTestClient(user);
+
         _hostFixture.EventObserver.Clear();
 
-        // Try to access protected admin area on auth server, should be authenticated already
+        await page.GoToAccountPage();
 
-        await page.GotoAsync($"{HostFixture.AuthServerBaseUrl}/admin/staff");
-        await page.WaitForSelectorAsync("caption:text-is('Staff users')");
-
-        // Should have a second signed in event emitted
-
-        _hostFixture.EventObserver.AssertEventsSaved(e => AssertEventIsUserSignedIn(e, userId, expectOAuthProperties: false));
+        _hostFixture.EventObserver.AssertEventsSaved(e => AssertEventIsUserSignedIn(e, user.UserId, expectOAuthProperties: false));
     }
 
     [Fact]
@@ -513,33 +264,15 @@ public partial class SignIn : IClassFixture<HostFixture>
         await using var context = await _hostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();
 
-        // Start on the client app and try to access a protected area
+        await page.StartOAuthJourney(CustomScopes.DqtRead);
 
-        await page.GotoAsync($"/profile?scope=email+openid+profile+{Uri.EscapeDataString(CustomScopes.DqtRead)}");
+        await page.SubmitEmailPage(user.EmailAddress);
 
-        // Fill in the sign in form (email + PIN)
+        await page.SubmitEmailConfirmationPage();
 
-        await page.FillAsync("text=Enter your email address", user.EmailAddress);
-        await page.ClickAsync("button:text-is('Continue')");
+        await page.SubmitCompletePageForExistingUser();
 
-        var pin = HostFixture.UserVerificationPin;
-        await page.FillAsync("text=Enter your code", pin);
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Should now be on the confirmation page
-
-        Assert.Equal(1, await page.Locator("data-testid=known-user-content").CountAsync());
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Should now be back at the client, signed in
-
-        var clientAppHost = new Uri(HostFixture.ClientBaseUrl).Host;
-        var pageUrlHost = new Uri(page.Url).Host;
-        Assert.Equal(clientAppHost, pageUrlHost);
-
-        var signedInEmail = await page.InnerTextAsync("data-testid=email");
-        Assert.Equal(user.Trn, await page.InnerTextAsync("data-testid=trn"));
-        Assert.Equal(user.EmailAddress, signedInEmail);
+        await page.AssertSignedInOnTestClient(user);
     }
 
     private void AssertEventIsUserSignedIn(
@@ -563,108 +296,57 @@ public partial class SignIn : IClassFixture<HostFixture>
         string email,
         string officialFirstName,
         string officialLastName,
-        string? trn,
-        DateOnly dateOfBirth,
-        string? preferredFirstName,
-        string? preferredLastName)
+        string trn,
+        DateOnly dateOfBirth)
     {
-        _hostFixture.DqtApiClient
-            .Setup(mock => mock.FindTeachers(It.IsAny<FindTeachersRequest>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new FindTeachersResponse()
-            {
-                Results = Array.Empty<FindTeachersResponseResult>()
-            });
+        ConfigureDqtApiFindTeachersRequest(result: null);
 
-        // Start on the client app and try to access a protected area
+        await page.StartOAuthJourney(additionalScope: CustomScopes.DqtRead);
 
-        await page.GotoAsync($"/profile?scope=email+openid+profile+{Uri.EscapeDataString(CustomScopes.DqtRead)}");
+        await page.SubmitEmailPage(email);
 
-        // Fill in the sign in form (email + PIN)
+        await page.SubmitEmailConfirmationPage();
 
-        await page.FillAsync("text=Enter your email address", email);
-        await page.ClickAsync("button:text-is('Continue')");
+        await page.SubmitTrnBookendPage();
 
-        var pin = HostFixture.UserVerificationPin;
-        await page.FillAsync("text=Enter your code", pin);
-        await page.ClickAsync("button:text-is('Continue')");
+        await page.SubmitTrnHasTrnPageWithTrn(trn);
 
-        // Should now be at the first bookend page
+        await page.SubmitTrnOfficialNamePage(officialFirstName, officialLastName);
 
-        var urlPath = new Uri(page.Url).LocalPath;
-        Assert.EndsWith("/trn", urlPath);
-
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Has TRN page
-
-        if (trn is null)
-        {
-            await page.ClickAsync("label:text-is('No, I need to continue without my TRN')");
-        }
-        else
-        {
-            await page.ClickAsync("label:text-is('Yes, I know my TRN')");
-            await page.FillAsync("text=What is your TRN?", trn ?? string.Empty);
-        }
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Official name page
-
-        await page.FillAsync("text=First name", officialFirstName);
-        await page.FillAsync("text=Last name", officialLastName);
-        await page.ClickAsync("label:text-is('No')");  // Have you ever changed your name?
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Preferred name page
-
-        await page.ClickAsync("label:text-is('Yes')");  // Is x y your preferred name?
-        await page.ClickAsync("button:text-is('Continue')");
+        await page.SubmitTrnPreferredNamePageWithoutPreferredName();
 
         // Simulate DQT API returning result when next page submitted
 
+        ConfigureDqtApiFindTeachersRequest(result: new()
+        {
+            DateOfBirth = dateOfBirth,
+            FirstName = officialFirstName,
+            LastName = officialLastName,
+            EmailAddresses = new[] { email },
+            HasActiveSanctions = false,
+            NationalInsuranceNumber = null,
+            Trn = trn,
+            Uid = Guid.NewGuid().ToString()
+        });
+
+        await page.SubmitTrnDateOfBirthPage(dateOfBirth);
+
+        await page.SubmitTrnCheckAnswersPage();
+
+        await page.SubmitCompletePageForNewUserInLegacyTrnJourney();
+
+        await page.AssertSignedInOnTestClient(email, trn, officialFirstName, officialLastName);
+    }
+
+    private void ConfigureDqtApiFindTeachersRequest(FindTeachersResponseResult? result)
+    {
+        var results = result is not null ? new[] { result } : Array.Empty<FindTeachersResponseResult>();
+
         _hostFixture.DqtApiClient
             .Setup(mock => mock.FindTeachers(It.IsAny<FindTeachersRequest>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new FindTeachersResponse()
             {
-                Results = new FindTeachersResponseResult[]
-                {
-                    new()
-                    {
-                        DateOfBirth = dateOfBirth,
-                        FirstName = officialFirstName,
-                        LastName = officialLastName,
-                        EmailAddresses = new[] { email },
-                        HasActiveSanctions = false,
-                        NationalInsuranceNumber = null,
-                        Trn = trn ?? "9123456",
-                        Uid = Guid.NewGuid().ToString()
-                    }
-                }
+                Results = results
             });
-
-        // Date of birth page
-
-        await page.FillAsync("label:text-is('Day')", dateOfBirth.Day.ToString());
-        await page.FillAsync("label:text-is('Month')", dateOfBirth.Month.ToString());
-        await page.FillAsync("label:text-is('Year')", dateOfBirth.Year.ToString());
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Check answers page
-
-        await page.WaitForSelectorAsync("h1:text-is('Check your answers')");
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Should now be on the confirmation page
-
-        Assert.Equal(1, await page.Locator("data-testid=first-time-user-content").CountAsync());
-        await page.ClickAsync("button:text-is('Continue')");
-
-        // Should now be back on the client, signed in
-
-        var clientAppHost = new Uri(HostFixture.ClientBaseUrl).Host;
-        var pageUrlHost = new Uri(page.Url).Host;
-        Assert.Equal(clientAppHost, pageUrlHost);
-
-        Assert.Equal(email, await page.InnerTextAsync("data-testid=email"));
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignIn.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignIn.cs
@@ -1,8 +1,6 @@
 using Microsoft.Playwright;
-using Moq;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Oidc;
-using TeacherIdentity.AuthServer.Services.DqtApi;
 
 namespace TeacherIdentity.AuthServer.EndToEndTests;
 
@@ -16,19 +14,17 @@ public partial class SignIn : IClassFixture<HostFixture>
         _hostFixture.OnTestStarting();
     }
 
-    [Theory]
-    [InlineData(CustomScopes.DqtRead)]
-#pragma warning disable CS0618 // Type or member is obsolete
-    [InlineData(CustomScopes.Trn)]
-#pragma warning restore CS0618 // Type or member is obsolete
-    public async Task ExistingTeacherUser_CanSignInSuccessfullyWithEmailAndPin(string additionalScope)
+    [Fact]
+    public async Task ExistingTeacherUser_AlreadySignedIn_SkipsEmailAndPinAndShowsCorrectConfirmationPage()
     {
         var user = await _hostFixture.TestData.CreateUser(userType: UserType.Default);
 
         await using var context = await _hostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();
 
-        await page.StartOAuthJourney(additionalScope);
+        await page.StartOAuthJourney(additionalScope: null);
+
+        await page.SignInFromLandingPage();
 
         await page.SubmitEmailPage(user.EmailAddress);
 
@@ -38,112 +34,13 @@ public partial class SignIn : IClassFixture<HostFixture>
 
         await page.AssertSignedInOnTestClient(user);
 
-        _hostFixture.EventObserver.AssertEventsSaved(e => AssertEventIsUserSignedIn(e, user.UserId));
-    }
-
-    [Fact]
-    public async Task NewTeacherUser_WithFoundTrn_CreatesUserAndCompletesFlow()
-    {
-        var email = Faker.Internet.Email();
-        var officialFirstName = Faker.Name.First();
-        var officialLastName = Faker.Name.Last();
-        var dateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
-        var trn = _hostFixture.TestData.GenerateTrn();
-
-        await using var context = await _hostFixture.CreateBrowserContext();
-        var page = await context.NewPageAsync();
-
-        await SignInAsNewTeacherUserWithDqtReadScope(page, email, officialFirstName, officialLastName, trn, dateOfBirth);
-    }
-
-    [Fact]
-    public async Task NewTeacherUser_WithoutFoundTrn_CreatesUserAndCompletesFlow()
-    {
-        var email = Faker.Internet.Email();
-        var officialFirstName = Faker.Name.First();
-        var officialLastName = Faker.Name.Last();
-        var dateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
-        var nino = Faker.Identification.UkNationalInsuranceNumber();
-        var ittProvider = Faker.Company.Name();
-
-        ConfigureDqtApiFindTeachersRequest(result: null);
-
-        _hostFixture.DqtApiClient
-            .Setup(mock => mock.GetIttProviders(It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new GetIttProvidersResponse()
-            {
-                IttProviders = new[]
-                {
-                    new IttProvider()
-                    {
-                        ProviderName = "Provider 1",
-                        Ukprn = "123"
-                    },
-                    new IttProvider()
-                    {
-                        ProviderName = ittProvider,
-                        Ukprn = "234"
-                    }
-                }
-            });
-
-        await using var context = await _hostFixture.CreateBrowserContext();
-        var page = await context.NewPageAsync();
-
-        await page.StartOAuthJourney(additionalScope: CustomScopes.DqtRead);
-
-        await page.SubmitEmailPage(email);
-
-        await page.SubmitEmailConfirmationPage();
-
-        await page.SubmitTrnBookendPage();
-
-        await page.SubmitTrnHasTrnPageWithoutTrn();
-
-        await page.SubmitTrnOfficialNamePage(officialFirstName, officialLastName);
-
-        await page.SubmitTrnPreferredNamePageWithoutPreferredName();
-
-        await page.SubmitTrnDateOfBirthPage(dateOfBirth);
-
-        await page.SubmitTrnHasNinoPage(hasNino: true);
-
-        await page.SubmitTrnNiNumberPage(nino);
-
-        await page.SubmitTrnAwardedQtsPage(awardedQts: true);
-
-        await page.SubmitTrnIttProviderPageWithIttProvider(ittProvider);
-
-        await page.SubmitTrnCheckAnswersPage();
-
-        await page.SubmitTrnNoMatchPage();
-
-        await page.SubmitCompletePageForNewUserInLegacyTrnJourney();
-
-        await page.AssertSignedInOnTestClient(email, trn: null, officialFirstName, officialLastName);
-    }
-
-    [Fact]
-    public async Task ExistingTeacherUser_SignsInWithinSameSessionTheyRegisteredWith_SkipsEmailAndPinAndShowsCorrectConfirmationPage()
-    {
-        var email = Faker.Internet.Email();
-        var firstName = Faker.Name.First();
-        var lastName = Faker.Name.Last();
-        var trn = _hostFixture.TestData.GenerateTrn();
-        var dateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
-
-        await using var context = await _hostFixture.CreateBrowserContext();
-        var page = await context.NewPageAsync();
-
-        await SignInAsNewTeacherUserWithDqtReadScope(page, email, firstName, lastName, trn, dateOfBirth);
-
         await ClearCookiesForTestClient();
 
         await page.StartOAuthJourney(additionalScope: CustomScopes.DqtRead);
 
         await page.SubmitCompletePageForExistingUser();
 
-        await page.AssertSignedInOnTestClient(email, trn, firstName, lastName);
+        await page.AssertSignedInOnTestClient(user);
 
         async Task ClearCookiesForTestClient()
         {
@@ -170,66 +67,6 @@ public partial class SignIn : IClassFixture<HostFixture>
     }
 
     [Fact]
-    public async Task NewTeacherUser_WithTrnMatchingExistingAccount_VerifiesExistingAccountEmailAndCanSignInSuccessfully()
-    {
-        var existingTrnOwner = await _hostFixture.TestData.CreateUser(hasTrn: true);
-
-        var trn = existingTrnOwner.Trn!;
-        var trnOwnerEmailAddress = existingTrnOwner.EmailAddress;
-        var email = Faker.Internet.Email();
-        var officialFirstName = Faker.Name.First();
-        var officialLastName = Faker.Name.Last();
-        var dateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
-
-        ConfigureDqtApiFindTeachersRequest(result: null);
-
-        await using var context = await _hostFixture.CreateBrowserContext();
-        var page = await context.NewPageAsync();
-
-        await page.StartOAuthJourney(additionalScope: CustomScopes.DqtRead);
-
-        await page.SubmitEmailPage(email);
-
-        await page.SubmitEmailConfirmationPage();
-
-        await page.SubmitTrnBookendPage();
-
-        await page.SubmitTrnHasTrnPageWithTrn(trn);
-
-        await page.SubmitTrnOfficialNamePage(officialFirstName, officialLastName);
-
-        await page.SubmitTrnPreferredNamePageWithoutPreferredName();
-
-        // Simulate DQT API returning result when next page submitted
-
-        ConfigureDqtApiFindTeachersRequest(result: new()
-        {
-            DateOfBirth = dateOfBirth,
-            FirstName = officialFirstName,
-            LastName = officialLastName,
-            EmailAddresses = new[] { email },
-            HasActiveSanctions = false,
-            NationalInsuranceNumber = null,
-            Trn = trn,
-            Uid = Guid.NewGuid().ToString()
-        });
-
-        await page.SubmitTrnDateOfBirthPage(dateOfBirth);
-
-        await page.SubmitTrnCheckAnswersPage();
-
-        await page.SubmitTrnTrnInUsePage();
-
-        await page.SubmitTrnChooseEmailPage(trnOwnerEmailAddress);
-
-        await page.SubmitCompletePageForNewUserInLegacyTrnJourney();
-
-        await page.AssertSignedInOnTestClient(existingTrnOwner);
-
-        _hostFixture.EventObserver.AssertEventsSaved(e => AssertEventIsUserSignedIn(e, existingTrnOwner.UserId));
-    }
-
-    [Fact]
     public async Task FirstRequestToProtectedAreaOfSiteForUserAlreadySignedInViaOAuth_IssuesUserSignedInEvent()
     {
         var user = await _hostFixture.TestData.CreateUser(userType: UserType.Default);
@@ -253,100 +90,7 @@ public partial class SignIn : IClassFixture<HostFixture>
 
         await page.GoToAccountPage();
 
-        _hostFixture.EventObserver.AssertEventsSaved(e => AssertEventIsUserSignedIn(e, user.UserId, expectOAuthProperties: false));
-    }
-
-    [Fact]
-    public async Task TeacherUser_WithTrnAssignedViaApi_CanSignInSuccessfully()
-    {
-        var user = await _hostFixture.TestData.CreateUser(hasTrn: true, haveCompletedTrnLookup: false);
-
-        await using var context = await _hostFixture.CreateBrowserContext();
-        var page = await context.NewPageAsync();
-
-        await page.StartOAuthJourney(CustomScopes.DqtRead);
-
-        await page.SubmitEmailPage(user.EmailAddress);
-
-        await page.SubmitEmailConfirmationPage();
-
-        await page.SubmitCompletePageForExistingUser();
-
-        await page.AssertSignedInOnTestClient(user);
-    }
-
-    private void AssertEventIsUserSignedIn(
-        Events.EventBase @event,
-        Guid userId,
-        bool expectOAuthProperties = true)
-    {
-        var userSignedIn = Assert.IsType<Events.UserSignedInEvent>(@event);
-        Assert.Equal(DateTime.UtcNow, userSignedIn.CreatedUtc, TimeSpan.FromSeconds(10));
-        Assert.Equal(userId, userSignedIn.User.UserId);
-
-        if (expectOAuthProperties)
-        {
-            Assert.Equal(_hostFixture.TestClientId, userSignedIn.ClientId);
-            Assert.NotNull(userSignedIn.Scope);
-        }
-    }
-
-    private async Task SignInAsNewTeacherUserWithDqtReadScope(
-        IPage page,
-        string email,
-        string officialFirstName,
-        string officialLastName,
-        string trn,
-        DateOnly dateOfBirth)
-    {
-        ConfigureDqtApiFindTeachersRequest(result: null);
-
-        await page.StartOAuthJourney(additionalScope: CustomScopes.DqtRead);
-
-        await page.SubmitEmailPage(email);
-
-        await page.SubmitEmailConfirmationPage();
-
-        await page.SubmitTrnBookendPage();
-
-        await page.SubmitTrnHasTrnPageWithTrn(trn);
-
-        await page.SubmitTrnOfficialNamePage(officialFirstName, officialLastName);
-
-        await page.SubmitTrnPreferredNamePageWithoutPreferredName();
-
-        // Simulate DQT API returning result when next page submitted
-
-        ConfigureDqtApiFindTeachersRequest(result: new()
-        {
-            DateOfBirth = dateOfBirth,
-            FirstName = officialFirstName,
-            LastName = officialLastName,
-            EmailAddresses = new[] { email },
-            HasActiveSanctions = false,
-            NationalInsuranceNumber = null,
-            Trn = trn,
-            Uid = Guid.NewGuid().ToString()
-        });
-
-        await page.SubmitTrnDateOfBirthPage(dateOfBirth);
-
-        await page.SubmitTrnCheckAnswersPage();
-
-        await page.SubmitCompletePageForNewUserInLegacyTrnJourney();
-
-        await page.AssertSignedInOnTestClient(email, trn, officialFirstName, officialLastName);
-    }
-
-    private void ConfigureDqtApiFindTeachersRequest(FindTeachersResponseResult? result)
-    {
-        var results = result is not null ? new[] { result } : Array.Empty<FindTeachersResponseResult>();
-
-        _hostFixture.DqtApiClient
-            .Setup(mock => mock.FindTeachers(It.IsAny<FindTeachersRequest>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new FindTeachersResponse()
-            {
-                Results = results
-            });
+        _hostFixture.EventObserver.AssertEventsSaved(
+            e => _hostFixture.AssertEventIsUserSignedIn(e, user.UserId, expectOAuthProperties: false));
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignOut.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignOut.cs
@@ -26,7 +26,7 @@ public class SignOut : IClassFixture<HostFixture>
 
         await page.SubmitEmailPage(user.EmailAddress);
 
-        await page.SubmitEmailConfirmationPage(HostFixture.UserVerificationPin);
+        await page.SubmitEmailConfirmationPage();
 
         await page.SubmitCompletePageForExistingUser();
 
@@ -61,12 +61,12 @@ public class SignOut : IClassFixture<HostFixture>
 
         await page.SubmitEmailPage(user.EmailAddress);
 
-        await page.SubmitEmailConfirmationPage(HostFixture.UserVerificationPin);
+        await page.SubmitEmailConfirmationPage();
 
         await page.SignOutFromAccountPageWithoutClientContext();
 
         _hostFixture.EventObserver.AssertEventsSaved(
-            //e => Assert.IsType<Events.UserSignedInEvent>(e),
+            e => Assert.IsType<Events.UserSignedInEvent>(e),
             e =>
             {
                 var userSignedOut = Assert.IsType<Events.UserSignedOutEvent>(e);
@@ -90,7 +90,7 @@ public class SignOut : IClassFixture<HostFixture>
 
         await page.SubmitEmailPage(user.EmailAddress);
 
-        await page.SubmitEmailConfirmationPage(HostFixture.UserVerificationPin);
+        await page.SubmitEmailConfirmationPage();
 
         await page.SubmitCompletePageForExistingUser();
 
@@ -103,7 +103,8 @@ public class SignOut : IClassFixture<HostFixture>
         await page.AssertSignedOutOnTestClient();
 
         _hostFixture.EventObserver.AssertEventsSaved(
-            e => Assert.IsType<Events.UserSignedInEvent>(e),
+            e => Assert.IsType<Events.UserSignedInEvent>(e),  // OAuth sign in with a client
+            e => Assert.IsType<Events.UserSignedInEvent>(e),  // Account page sign in
             e =>
             {
                 var userSignedOut = Assert.IsType<Events.UserSignedOutEvent>(e);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/appsettings.json
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/appsettings.json
@@ -36,7 +36,8 @@
       "PostLogoutRedirectUris": [
         "http://localhost:55342/oidc/signout-callback"
       ],
-      "Scopes": [ "trn", "user:read", "user:write", "dqt:read" ]
+      "Scopes": [ "trn", "user:read", "user:write", "dqt:read" ],
+      "TrnRequirementType": "Required"
     },
     {
       "ClientId": "testcc",


### PR DESCRIPTION
This adds end-to-end tests for the core registration journey. It also completes the refactor of the existing e2e tests to use the extension methods on `IPage`.

I noticed a difference on our email page to the prototype so I fixed that up too.