### PR TITLE
Remove redundant middleware

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
@@ -532,7 +532,6 @@ public class Program
         {
             app.UseForwardedHeaders();
             app.UseHsts();
-            app.UseHttpsRedirection();
         }
 
         app.UseStaticFiles();


### PR DESCRIPTION
HTTPS enforcement is done by App Service in production.

This removes the ` Failed to determine the https port for redirect.` we're getting on app start up.