### PR TITLE
Add has Nino page to register journey

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -97,6 +97,12 @@ public abstract class IdentityLinkGenerator
 
     public string RegisterChangeEmailRequest() => Page("/SignIn/Register/ChangeEmailRequest");
 
+    public string RegisterHasNiNumber() => Page("/SignIn/Register/HasNiNumberPage");
+
+    public string RegisterNiNumber() => Page("/SignIn/Register/NiNumberPage");
+
+    public string RegisterHasTrn() => Page("/SignIn/Register/HasTrnPage");
+
     public string UpdateEmail(string? returnUrl, string? cancelUrl) =>
         Page("/Authenticated/UpdateEmail/Index", authenticationJourneyRequired: false)
             .SetQueryParam("returnUrl", returnUrl)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/DateOfBirthPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/DateOfBirthPage.cshtml.cs
@@ -54,6 +54,11 @@ public class DateOfBirthPage : PageModel
             return Redirect(_linkGenerator.RegisterAccountExists());
         }
 
+        if (authenticationState.OAuthState?.RequiresTrnLookup == true)
+        {
+            return Redirect(_linkGenerator.RegisterHasNiNumber());
+        }
+
         var user = await CreateUser();
 
         authenticationState.OnUserRegistered(user);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasNiNumberPage.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasNiNumberPage.cshtml
@@ -1,0 +1,27 @@
+@page "/sign-in/register/has-nino"
+@model TeacherIdentity.AuthServer.Pages.SignIn.Register.HasNiNumberPage
+@{
+    ViewBag.Title = Html.DisplayNameFor(m => m.HasNiNumber);
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.TrnDateOfBirth()" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.TrnHasNiNumber()" method="post" asp-antiforgery="true">
+            <govuk-radios asp-for="HasNiNumber">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--xl"/>
+
+                    <govuk-radios-item value="True">Yes</govuk-radios-item>
+                    <govuk-radios-item value="False">No</govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>
+

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasNiNumberPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasNiNumberPage.cshtml.cs
@@ -1,0 +1,48 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using TeacherIdentity.AuthServer.Pages.SignIn.Trn;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
+
+[BindProperties]
+[RequiresTrnLookup]
+public class HasNiNumberPage : TrnLookupPageModel
+{
+    public HasNiNumberPage(IdentityLinkGenerator linkGenerator, TrnLookupHelper trnLookupHelper)
+        : base(linkGenerator, trnLookupHelper)
+    {
+    }
+
+    [Display(Name = "Do you have a National Insurance number?")]
+    [Required(ErrorMessage = "Tell us if you have a National Insurance number")]
+    public bool? HasNiNumber { get; set; }
+
+    public void OnGet()
+    {
+    }
+
+    public IActionResult OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        HttpContext.GetAuthenticationState().OnHasNationalInsuranceNumberSet((bool)HasNiNumber!);
+
+        return (bool)HasNiNumber!
+            ? Redirect(LinkGenerator.RegisterNiNumber())
+            : Redirect(LinkGenerator.RegisterHasTrn());
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var authenticationState = context.HttpContext.GetAuthenticationState();
+
+        if (!authenticationState.DateOfBirthSet)
+        {
+            context.Result = new RedirectResult(LinkGenerator.RegisterDateOfBirth());
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/RequiresTrnLookupAttribute.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/RequiresTrnLookupAttribute.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc.Filters;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
 
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
 public class RequiresTrnLookupAttribute : Attribute, IPageFilter
 {
     public void OnPageHandlerSelected(PageHandlerSelectedContext context)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/RequiresTrnLookupFilter.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/RequiresTrnLookupFilter.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
+
+public class RequiresTrnLookupAttribute : Attribute, IPageFilter
+{
+    public void OnPageHandlerSelected(PageHandlerSelectedContext context)
+    {
+    }
+
+    public void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var authenticationState = context.HttpContext.GetAuthenticationState();
+
+        if (authenticationState.OAuthState?.RequiresTrnLookup != true)
+        {
+            context.Result = new BadRequestResult();
+        }
+    }
+
+    public void OnPageHandlerExecuted(PageHandlerExecutedContext context)
+    {
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/HasNiNumberPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/HasNiNumberPageTests.cs
@@ -1,0 +1,164 @@
+using TeacherIdentity.AuthServer.Oidc;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
+
+public class HasNiNumberPageTests : TestBase
+{
+    public HasNiNumberPageTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, $"/sign-in/register/has-nino");
+    }
+
+    [Fact]
+    public async Task Get_NoAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await MissingAuthenticationState_ReturnsBadRequest(HttpMethod.Get, $"/sign-in/register/has-nino");
+    }
+
+    [Fact]
+    public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/register/has-nino");
+    }
+
+    [Fact]
+    public async Task Get_DateOfBirthNotSet_RedirectsToRegisterDateOfBirthPage()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_previousPageAuthenticationState(), CustomScopes.DqtRead);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/has-nino?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/register/date-of-birth", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_RequiresTrnLookupFalse_ReturnsBadRequest()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/has-nino?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_RendersContent()
+    {
+        await ValidRequest_RendersContent(_currentPageAuthenticationState(), "/sign-in/register/has-nino", CustomScopes.DqtRead);
+    }
+
+    [Fact]
+    public async Task Post_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Post, $"/sign-in/register/has-nino");
+    }
+
+    [Fact]
+    public async Task Post_NoAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await MissingAuthenticationState_ReturnsBadRequest(HttpMethod.Post, $"/sign-in/register/has-nino");
+    }
+
+    [Fact]
+    public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/register/has-nino");
+    }
+
+    [Fact]
+    public async Task Post_DateOfBirthNotSet_RedirectsToDateOfBirthPage()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_previousPageAuthenticationState(), CustomScopes.DqtRead);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/has-nino?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/register/date-of-birth", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_RequiresTrnLookupFalse_ReturnsBadRequest()
+    {
+        // Arrange
+
+        // ApplyForQts client does not require TRN lookup
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/has-nino?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_NullHasNiNumber_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), CustomScopes.DqtRead);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/has-nino?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "HasNiNumber", "Tell us if you have a National Insurance number");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Post_ValidForm_SetsHasNiNumberOnAuthenticationState(bool hasNiNumber)
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), CustomScopes.DqtRead);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/has-nino?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "HasNiNumber", hasNiNumber },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal(hasNiNumber, authStateHelper.AuthenticationState.HasNationalInsuranceNumber);
+    }
+
+    private readonly AuthenticationStateConfigGenerator _currentPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.HasNiNumber);
+    private readonly AuthenticationStateConfigGenerator _previousPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.DateOfBirth);
+
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/RegisterJourneyAuthenticationStateHelper.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/RegisterJourneyAuthenticationStateHelper.cs
@@ -33,6 +33,9 @@ public static class RegisterJourneyAuthenticationStateHelper
                 case RegisterJourneyPage.DateOfBirth:
                     return c => c.RegisterNameSet();
 
+                case RegisterJourneyPage.HasNiNumber:
+                    return c => c.RegisterDateOfBirthSet();
+
                 case RegisterJourneyPage.AccountExists:
                     return c => c.RegisterExistingUserAccountMatch(user);
 
@@ -73,5 +76,6 @@ public enum RegisterJourneyPage
     ResendExistingAccountEmail,
     ExistingAccountPhone,
     ExistingAccountPhoneConfirmation,
-    ResendExistingAccountPhone
+    ResendExistingAccountPhone,
+    HasNiNumber,
 }


### PR DESCRIPTION
### Context

The core ID journey is being extended to include matching a TRN so that we can use the core journey everywhere.

### Changes proposed in this pull request

Add the new page at /sign-in/register/has-trn following the design at https://get-an-identity-prototype.herokuapp.com/auth/have-nino

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
