### PR TITLE
Add register nino page

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasNiNumberPage.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasNiNumberPage.cshtml
@@ -10,7 +10,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.TrnHasNiNumber()" method="post" asp-antiforgery="true">
+        <form action="@LinkGenerator.RegisterHasNiNumber()" method="post" asp-antiforgery="true">
             <govuk-radios asp-for="HasNiNumber">
                 <govuk-radios-fieldset>
                     <govuk-radios-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--xl"/>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/NiNumberPage.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/NiNumberPage.cshtml
@@ -1,0 +1,35 @@
+@page "/sign-in/register/ni-number"
+@model TeacherIdentity.AuthServer.Pages.SignIn.Register.NiNumberPage
+@{
+    ViewBag.Title = Html.DisplayNameFor(m => m.NiNumber);
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.RegisterHasNiNumber()" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.RegisterNiNumber()" method="post" asp-antiforgery="true">
+            <govuk-input asp-for="NiNumber" input-class="govuk-input--width-10">
+                <govuk-input-label is-page-heading="true" class="govuk-label--xl"/>
+            </govuk-input>
+
+            <govuk-button type="submit" class="govuk-visually-hidden" name="submit" value="hidden_submit"/>
+
+            <govuk-details>
+                <govuk-details-summary>I don’t know my National Insurance number</govuk-details-summary>
+                <govuk-details-text>
+                    <p>You can <a href="https://www.gov.uk/lost-national-insurance-number" target="_blank">find a lost National Insurance number</a>.</p>
+                    <p>Or you can continue without it, but we are less likely to find your TRN.</p>
+                    <govuk-button type="submit" class="govuk-button--secondary" name="submit" value="ni_number_not_known">
+                        Continue without it
+                    </govuk-button>
+                </govuk-details-text>
+            </govuk-details>
+
+            <govuk-button type="submit" name="submit" value="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>
+

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/NiNumberPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/NiNumberPage.cshtml.cs
@@ -1,0 +1,54 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using TeacherIdentity.AuthServer.Pages.SignIn.Trn;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
+
+[BindProperties]
+[RequiresTrnLookup]
+public class NiNumberPage : TrnLookupPageModel
+{
+    public NiNumberPage(IdentityLinkGenerator linkGenerator, TrnLookupHelper trnLookupHelper)
+        : base(linkGenerator, trnLookupHelper)
+    {
+    }
+
+    [Display(Name = "What is your National Insurance number?", Description = "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.")]
+    [Required(ErrorMessage = "Enter a National Insurance number")]
+    [RegularExpression(@"(?i)\A[a-z]{2}(?: [0-9]{2}){3} [a-d]{1}|[a-z]{2}[0-9]{6}[a-d]{1}\Z", ErrorMessage = "Enter a National Insurance number in the correct format")]
+    public string? NiNumber { get; set; }
+
+    public void OnGet()
+    {
+    }
+
+    public IActionResult OnPost(string submit)
+    {
+        if (submit == "ni_number_not_known")
+        {
+            HttpContext.GetAuthenticationState().OnHasNationalInsuranceNumberSet(false);
+        }
+        else
+        {
+            if (!ModelState.IsValid)
+            {
+                return this.PageWithErrors();
+            }
+
+            HttpContext.GetAuthenticationState().OnNationalInsuranceNumberSet(NiNumber!);
+        }
+
+        return Redirect(LinkGenerator.RegisterHasTrn());
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var authenticationState = context.HttpContext.GetAuthenticationState();
+
+        if (!authenticationState.HasNationalInsuranceNumberSet)
+        {
+            context.Result = new RedirectResult(LinkGenerator.RegisterHasNiNumber());
+        }
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
@@ -173,6 +173,19 @@ public sealed class AuthenticationStateHelper
                 s.OnDateOfBirthSet(dateOfBirth ?? DateOnly.FromDateTime(Faker.Identification.DateOfBirth()));
             };
 
+        public Func<AuthenticationState, Task> RegisterHasNiNumberSet(
+            DateOnly? dateOfBirth = null,
+            string? firstName = null,
+            string? lastName = null,
+            string? mobileNumber = null,
+            string? email = null,
+            User? user = null) =>
+            async s =>
+            {
+                await RegisterDateOfBirthSet(dateOfBirth, firstName, lastName, mobileNumber, email, user)(s);
+                s.OnHasNationalInsuranceNumberSet(true);
+            };
+
         public Func<AuthenticationState, Task> RegisterExistingUserAccountMatch(
             User? existingUserAccount = null,
             DateOnly? dateOfBirth = null,

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/HasNiNumberPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/HasNiNumberPageTests.cs
@@ -102,12 +102,13 @@ public class HasNiNumberPageTests : TestBase
     public async Task Post_RequiresTrnLookupFalse_ReturnsBadRequest()
     {
         // Arrange
-
-        // ApplyForQts client does not require TRN lookup
         var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/has-nino?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
+            {
+                { "HasNiNumber", true },
+            }
         };
 
         // Act
@@ -158,7 +159,28 @@ public class HasNiNumberPageTests : TestBase
         Assert.Equal(hasNiNumber, authStateHelper.AuthenticationState.HasNationalInsuranceNumber);
     }
 
+    [Fact]
+    public async Task Post_HasNiNumberTrue_RedirectsToNiNumberPage()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), CustomScopes.DqtRead);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/has-nino?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "HasNiNumber", true },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/register/ni-number", response.Headers.Location?.OriginalString);
+    }
+
     private readonly AuthenticationStateConfigGenerator _currentPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.HasNiNumber);
     private readonly AuthenticationStateConfigGenerator _previousPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.DateOfBirth);
-
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/NiNumberPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/NiNumberPageTests.cs
@@ -1,0 +1,194 @@
+using TeacherIdentity.AuthServer.Oidc;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
+
+public class NiNumberPageTests : TestBase
+{
+    public NiNumberPageTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register/ni-number");
+    }
+
+    [Fact]
+    public async Task Get_MissingAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register/ni-number");
+    }
+
+    [Fact]
+    public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/register/ni-number");
+    }
+
+    [Fact]
+    public async Task Get_HaveNationalInsuranceNumberNotSet_RedirectsToHasNiNumberPage()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_previousPageAuthenticationState(), CustomScopes.DqtRead);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/ni-number?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/register/has-nino", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_RequiresTrnLookupFalse_ReturnsBadRequest()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/ni-number?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_RendersContent()
+    {
+        await ValidRequest_RendersContent(_currentPageAuthenticationState(), "/sign-in/register/ni-number", CustomScopes.DqtRead);
+    }
+
+    [Fact]
+    public async Task Post_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Post, "/sign-in/register/ni-number");
+    }
+
+    [Fact]
+    public async Task Post_MissingAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Post, "/sign-in/register/ni-number");
+    }
+
+    [Fact]
+    public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/register/ni-number");
+    }
+
+    [Fact]
+    public async Task Post_HaveNationalInsuranceNumberNotSet_RedirectsToHasNiNumberPage()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.DateOfBirthSet(), CustomScopes.DqtRead);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/ni-number?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/register/has-nino", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_EmptyNiNumber_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), CustomScopes.DqtRead);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/ni-number?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "NiNumber", "Enter a National Insurance number");
+    }
+
+    [Theory]
+    [InlineData("QQ 123456C")]
+    [InlineData("123456")]
+    [InlineData("QQ12345C")]
+    public async Task Post_InvalidNiNumber_ReturnsError(string niNumber)
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), CustomScopes.DqtRead);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/ni-number?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "NiNumber", niNumber },
+                { "submit", "submit" },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "NiNumber", "Enter a National Insurance number in the correct format");
+    }
+
+    [Fact]
+    public async Task Post_RequiresTrnLookupFalse_ReturnsBadRequest()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/ni-number?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "NiNumber", "QQ123456C" },
+                { "submit", "submit" },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData("QQ 12 34 56 C")]
+    [InlineData("QQ123456C")]
+    [InlineData("qQ123456c")]
+    public async Task Post_ValidNiNumber_SetsNiNumberOnAuthenticationState(string niNumber)
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), CustomScopes.DqtRead);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/ni-number?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "NiNumber", niNumber },
+                { "submit", "submit" },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        Assert.Equal(niNumber, authStateHelper.AuthenticationState.NationalInsuranceNumber);
+    }
+
+
+    private readonly AuthenticationStateConfigGenerator _currentPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.NiNumber);
+    private readonly AuthenticationStateConfigGenerator _previousPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.HasNiNumber);
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/RegisterJourneyAuthenticationStateHelper.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/RegisterJourneyAuthenticationStateHelper.cs
@@ -36,6 +36,9 @@ public static class RegisterJourneyAuthenticationStateHelper
                 case RegisterJourneyPage.HasNiNumber:
                     return c => c.RegisterDateOfBirthSet();
 
+                case RegisterJourneyPage.NiNumber:
+                    return c => c.RegisterHasNiNumberSet();
+
                 case RegisterJourneyPage.AccountExists:
                     return c => c.RegisterExistingUserAccountMatch(user);
 
@@ -78,4 +81,5 @@ public enum RegisterJourneyPage
     ExistingAccountPhoneConfirmation,
     ResendExistingAccountPhone,
     HasNiNumber,
+    NiNumber,
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/NiNumberPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/NiNumberPageTests.cs
@@ -182,7 +182,7 @@ public class NiNumberPageTests : TestBase
     }
 
     [Fact]
-    public async Task Post_NiNumberNotKnown_Returns302Found()
+    public async Task Post_NiNumberNotKnown_SetsHasNiNumberFalseAndRedirectsToAwardedQtsPage()
     {
         // Arrange
         var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.DqtRead);
@@ -199,6 +199,9 @@ public class NiNumberPageTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/trn/awarded-qts", response.Headers.Location?.OriginalString);
+
+        Assert.False(authStateHelper.AuthenticationState.HasNationalInsuranceNumber);
     }
 
     [Fact]


### PR DESCRIPTION
### Context

The core ID journey is being extended to include matching a TRN so that we can use the core journey everywhere.

### Changes proposed in this pull request

Add a new page at /sign-in/register/ni-number following the designs at https://get-an-identity-prototype.herokuapp.com/auth/nino

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
