### PR TITLE
Add register has trn page

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -621,7 +621,19 @@ public class AuthenticationState
         AwardedQts = awardedQts;
     }
 
-    public void OnHasTrnSet(string? trn)
+    public void OnHasTrnSet(bool hasTrn)
+    {
+        ThrowOnInvalidAuthenticationMilestone(AuthenticationMilestone.EmailVerified);
+
+        if (!hasTrn)
+        {
+            StatedTrn = null;
+        }
+
+        HasTrn = hasTrn;
+    }
+
+    public void OnTrnSet(string? trn)
     {
         ThrowOnInvalidAuthenticationMilestone(AuthenticationMilestone.EmailVerified);
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -103,6 +103,10 @@ public abstract class IdentityLinkGenerator
 
     public string RegisterHasTrn() => Page("/SignIn/Register/HasTrnPage");
 
+    public string RegisterTrn() => Page("/SignIn/Register/TrnPage");
+
+    public string RegisterHaveQts() => Page("/SignIn/Register/HaveQts");
+
     public string UpdateEmail(string? returnUrl, string? cancelUrl) =>
         Page("/Authenticated/UpdateEmail/Index", authenticationJourneyRequired: false)
             .SetQueryParam("returnUrl", returnUrl)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasNiNumberPage.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasNiNumberPage.cshtml
@@ -5,7 +5,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.TrnDateOfBirth()" />
+    <govuk-back-link href="@LinkGenerator.RegisterDateOfBirth()" />
 }
 
 <div class="govuk-grid-row">

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasNiNumberPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasNiNumberPage.cshtml.cs
@@ -1,17 +1,18 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
-using TeacherIdentity.AuthServer.Pages.SignIn.Trn;
+using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
 
 [BindProperties]
 [RequiresTrnLookup]
-public class HasNiNumberPage : TrnLookupPageModel
+public class HasNiNumberPage : PageModel
 {
-    public HasNiNumberPage(IdentityLinkGenerator linkGenerator, TrnLookupHelper trnLookupHelper)
-        : base(linkGenerator, trnLookupHelper)
+    private IdentityLinkGenerator _linkGenerator;
+    public HasNiNumberPage(IdentityLinkGenerator linkGenerator)
     {
+        _linkGenerator = linkGenerator;
     }
 
     [Display(Name = "Do you have a National Insurance number?")]
@@ -32,8 +33,8 @@ public class HasNiNumberPage : TrnLookupPageModel
         HttpContext.GetAuthenticationState().OnHasNationalInsuranceNumberSet((bool)HasNiNumber!);
 
         return (bool)HasNiNumber!
-            ? Redirect(LinkGenerator.RegisterNiNumber())
-            : Redirect(LinkGenerator.RegisterHasTrn());
+            ? Redirect(_linkGenerator.RegisterNiNumber())
+            : Redirect(_linkGenerator.RegisterHasTrn());
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
@@ -42,7 +43,7 @@ public class HasNiNumberPage : TrnLookupPageModel
 
         if (!authenticationState.DateOfBirthSet)
         {
-            context.Result = new RedirectResult(LinkGenerator.RegisterDateOfBirth());
+            context.Result = new RedirectResult(_linkGenerator.RegisterDateOfBirth());
         }
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasTrnPage.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasTrnPage.cshtml
@@ -1,0 +1,37 @@
+@page "/sign-in/register/has-trn"
+@model TeacherIdentity.AuthServer.Pages.SignIn.Register.HasTrnPage
+@{
+    ViewBag.Title = "Do you have a teacher reference number (TRN)?";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@Model.BackLink" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.RegisterHasTrn()" method="post" asp-antiforgery="true">
+            <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
+
+            <p>You’ll have a TRN if you:</p>
+
+            <ul class="govuk-list govuk-list--bullet">
+                <li>hold qualified teacher status (QTS) in England or Wales</li>
+                <li>hold early years teacher status (EYTS) in England</li>
+                <li>already hold a national professional qualification (NPQ)</li>
+                <li>are working towards QTS or a EYTS</li>
+            </ul>
+
+            <govuk-radios asp-for="HasTrn">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend class="govuk-fieldset__legend--m"/>
+                    <govuk-radios-item value="True">Yes</govuk-radios-item>
+                    <govuk-radios-item value="False">No</govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>
+

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasTrnPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasTrnPage.cshtml.cs
@@ -1,0 +1,59 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
+
+[RequiresTrnLookup]
+public class HasTrnPage : PageModel
+{
+    private IdentityLinkGenerator _linkGenerator;
+    public HasTrnPage(IdentityLinkGenerator linkGenerator)
+    {
+        _linkGenerator = linkGenerator;
+    }
+
+    [BindProperty]
+    [Display(Name = "Do you have a TRN?")]
+    [Required(ErrorMessage = "Tell us if you know your TRN")]
+    public bool? HasTrn { get; set; }
+
+    public string BackLink => HttpContext.GetAuthenticationState().HasNationalInsuranceNumberSet
+        ? _linkGenerator.RegisterNiNumber()
+        : _linkGenerator.RegisterHasNiNumber();
+
+    public void OnGet()
+    {
+    }
+
+    public IActionResult OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        HttpContext.GetAuthenticationState().OnHasTrnSet(HasTrn!.Value);
+
+        return HasTrn.Value ?
+            Redirect(_linkGenerator.RegisterTrn()) :
+            Redirect(_linkGenerator.RegisterHaveQts());
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var authenticationState = context.HttpContext.GetAuthenticationState();
+
+        if (!authenticationState.HasNationalInsuranceNumberSet)
+        {
+            context.Result = new RedirectResult(_linkGenerator.RegisterHasNiNumber());
+            return;
+        }
+
+        if (!authenticationState.NationalInsuranceNumberSet)
+        {
+            context.Result = new RedirectResult(_linkGenerator.RegisterNiNumber());
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasTrnPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasTrnPage.cshtml.cs
@@ -19,7 +19,7 @@ public class HasTrnPage : PageModel
     [Required(ErrorMessage = "Tell us if you know your TRN")]
     public bool? HasTrn { get; set; }
 
-    public string BackLink => HttpContext.GetAuthenticationState().HasNationalInsuranceNumberSet
+    public string BackLink => HttpContext.GetAuthenticationState().HasNationalInsuranceNumber == true
         ? _linkGenerator.RegisterNiNumber()
         : _linkGenerator.RegisterHasNiNumber();
 
@@ -51,7 +51,7 @@ public class HasTrnPage : PageModel
             return;
         }
 
-        if (!authenticationState.NationalInsuranceNumberSet)
+        if (authenticationState is { HasNationalInsuranceNumber: true, NationalInsuranceNumberSet: false })
         {
             context.Result = new RedirectResult(_linkGenerator.RegisterNiNumber());
         }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/NiNumberPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/NiNumberPage.cshtml.cs
@@ -1,17 +1,18 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
-using TeacherIdentity.AuthServer.Pages.SignIn.Trn;
+using Microsoft.AspNetCore.Mvc.RazorPages;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
 
 [BindProperties]
 [RequiresTrnLookup]
-public class NiNumberPage : TrnLookupPageModel
+public class NiNumberPage : PageModel
 {
-    public NiNumberPage(IdentityLinkGenerator linkGenerator, TrnLookupHelper trnLookupHelper)
-        : base(linkGenerator, trnLookupHelper)
+    private IdentityLinkGenerator _linkGenerator;
+    public NiNumberPage(IdentityLinkGenerator linkGenerator)
     {
+        _linkGenerator = linkGenerator;
     }
 
     [Display(Name = "What is your National Insurance number?", Description = "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.")]
@@ -39,7 +40,7 @@ public class NiNumberPage : TrnLookupPageModel
             HttpContext.GetAuthenticationState().OnNationalInsuranceNumberSet(NiNumber!);
         }
 
-        return Redirect(LinkGenerator.RegisterHasTrn());
+        return Redirect(_linkGenerator.RegisterHasTrn());
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
@@ -48,7 +49,7 @@ public class NiNumberPage : TrnLookupPageModel
 
         if (!authenticationState.HasNationalInsuranceNumberSet)
         {
-            context.Result = new RedirectResult(LinkGenerator.RegisterHasNiNumber());
+            context.Result = new RedirectResult(_linkGenerator.RegisterHasNiNumber());
         }
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/HasTrnPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/HasTrnPage.cshtml.cs
@@ -35,7 +35,7 @@ public class HasTrnPage : TrnLookupPageModel
             return this.PageWithErrors();
         }
 
-        HttpContext.GetAuthenticationState().OnHasTrnSet(StatedTrn);
+        HttpContext.GetAuthenticationState().OnTrnSet(StatedTrn);
 
         return await TryFindTrn() ?? Redirect(LinkGenerator.TrnOfficialName());
     }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
@@ -186,6 +186,19 @@ public sealed class AuthenticationStateHelper
                 s.OnHasNationalInsuranceNumberSet(true);
             };
 
+        public Func<AuthenticationState, Task> RegisterHasNiNumber(
+            DateOnly? dateOfBirth = null,
+            string? firstName = null,
+            string? lastName = null,
+            string? mobileNumber = null,
+            string? email = null,
+            User? user = null) =>
+            async s =>
+            {
+                await RegisterHasNiNumberSet(dateOfBirth, firstName, lastName, mobileNumber, email, user)(s);
+                s.OnNationalInsuranceNumberSet(Faker.Identification.UkNationalInsuranceNumber());
+            };
+
         public Func<AuthenticationState, Task> RegisterExistingUserAccountMatch(
             User? existingUserAccount = null,
             DateOnly? dateOfBirth = null,
@@ -379,7 +392,7 @@ public sealed class AuthenticationStateHelper
             async s =>
             {
                 await _configure.EmailVerified(email)(s);
-                s.OnHasTrnSet(statedTrn);
+                s.OnTrnSet(statedTrn);
             };
 
         public Func<AuthenticationState, Task> OfficialNameSet(

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/HasNiNumberPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/HasNiNumberPageTests.cs
@@ -160,6 +160,28 @@ public class HasNiNumberPageTests : TestBase
     }
 
     [Fact]
+    public async Task Post_HasNiNumberFalse_RedirectsToHasTrnPage()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), CustomScopes.DqtRead);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/has-nino?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "HasNiNumber", false },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/register/has-trn", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
     public async Task Post_HasNiNumberTrue_RedirectsToNiNumberPage()
     {
         // Arrange

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/HasTrnPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/HasTrnPageTests.cs
@@ -1,0 +1,180 @@
+using TeacherIdentity.AuthServer.Oidc;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
+
+public class HasTrnPageTests : TestBase
+{
+    public HasTrnPageTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, $"/sign-in/register/has-trn");
+    }
+
+    [Fact]
+    public async Task Get_NoAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await MissingAuthenticationState_ReturnsBadRequest(HttpMethod.Get, $"/sign-in/register/has-trn");
+    }
+
+    [Fact]
+    public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/register/has-trn");
+    }
+
+    [Fact]
+    public async Task Get_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(_currentPageAuthenticationState(), CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/register/has-trn");
+    }
+
+    [Fact]
+    public async Task Get_RequiresTrnLookupFalse_ReturnsBadRequest()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/has-trn?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_HasNinoNotSet_RedirectsToRegisterHasNiNumber()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_hasNinoPageAuthenticationState(), CustomScopes.DqtRead);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/has-trn?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/register/has-nino", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_NinoNotSet_RedirectsToRegisterNiNumber()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_ninoPageAuthenticationState(), CustomScopes.DqtRead);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/has-trn?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/register/ni-number", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_RendersContent()
+    {
+        await ValidRequest_RendersContent(_currentPageAuthenticationState(), "/sign-in/register/has-trn", CustomScopes.DqtRead);
+    }
+
+    [Fact]
+    public async Task Post_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Post, $"/sign-in/register/has-trn");
+    }
+
+    [Fact]
+    public async Task Post_NoAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await MissingAuthenticationState_ReturnsBadRequest(HttpMethod.Post, $"/sign-in/register/has-trn");
+    }
+
+    [Fact]
+    public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/register/has-trn");
+    }
+
+    [Fact]
+    public async Task Post_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(_currentPageAuthenticationState(), CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/register/has-trn");
+    }
+
+    [Fact]
+    public async Task Post_NullHasTrn_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), CustomScopes.DqtRead);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/has-trn?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "HasTrn", "Tell us if you know your TRN");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Post_ValidHasTrn_UpdatesAuthenticationStateRedirectsToTrnOfficialName(bool hasTrn)
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), CustomScopes.DqtRead);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/has-trn?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "HasTrn", hasTrn },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        Assert.Equal(hasTrn, authStateHelper.AuthenticationState.HasTrn);
+    }
+
+    [Fact]
+    public async Task Post_FalseRequiresTrnLookup_ReturnsBadRequest()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), null);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/has-trn?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "HasTrn", true },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    private readonly AuthenticationStateConfigGenerator _currentPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.HasTrn);
+    private readonly AuthenticationStateConfigGenerator _ninoPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.NiNumber);
+    private readonly AuthenticationStateConfigGenerator _hasNinoPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.HasNiNumber);
+
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/NiNumberPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/NiNumberPageTests.cs
@@ -166,7 +166,7 @@ public class NiNumberPageTests : TestBase
     [InlineData("QQ 12 34 56 C")]
     [InlineData("QQ123456C")]
     [InlineData("qQ123456c")]
-    public async Task Post_ValidNiNumber_SetsNiNumberOnAuthenticationState(string niNumber)
+    public async Task Post_ValidNiNumber_SetsNiNumberOnAuthenticationStateAndRedirects(string niNumber)
     {
         // Arrange
         var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), CustomScopes.DqtRead);
@@ -184,6 +184,7 @@ public class NiNumberPageTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/register/has-trn", response.Headers.Location?.OriginalString);
 
         Assert.Equal(niNumber, authStateHelper.AuthenticationState.NationalInsuranceNumber);
     }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/RegisterJourneyAuthenticationStateHelper.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/RegisterJourneyAuthenticationStateHelper.cs
@@ -39,6 +39,9 @@ public static class RegisterJourneyAuthenticationStateHelper
                 case RegisterJourneyPage.NiNumber:
                     return c => c.RegisterHasNiNumberSet();
 
+                case RegisterJourneyPage.HasTrn:
+                    return c => c.RegisterHasNiNumber();
+
                 case RegisterJourneyPage.AccountExists:
                     return c => c.RegisterExistingUserAccountMatch(user);
 
@@ -82,4 +85,5 @@ public enum RegisterJourneyPage
     ResendExistingAccountPhone,
     HasNiNumber,
     NiNumber,
+    HasTrn,
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/TrnLookupHelperTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/TrnLookupHelperTests.cs
@@ -167,7 +167,7 @@ public class TrnLookupHelperTests
     {
         // Arrange
         var authenticationState = CreateAuthenticationState();
-        authenticationState.OnHasTrnSet("RP99/12345");
+        authenticationState.OnTrnSet("RP99/12345");
 
         var dqtApiClientMock = new Mock<IDqtApiClient>();
         dqtApiClientMock
@@ -312,7 +312,7 @@ public class TrnLookupHelperTests
 
         authState.OnEmailSet(Faker.Internet.Email());
         authState.OnEmailVerified();
-        authState.OnHasTrnSet(statedTrn);
+        authState.OnTrnSet(statedTrn);
         authState.OnOfficialNameSet(
             Faker.Name.First(),
             Faker.Name.Last(),


### PR DESCRIPTION
### Context

The core ID journey is being extended to include matching a TRN so that we can use the core journey everywhere.

### Changes proposed in this pull request

Add a new page at /sign-in/register/has-trn following the designs at https://get-an-identity-prototype.herokuapp.com/auth/have-trn

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
