### PR TITLE
Use a fixed verification PIN for dev environments

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/UserVerification/FixedPinUserVerificationOptions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/UserVerification/FixedPinUserVerificationOptions.cs
@@ -1,0 +1,10 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TeacherIdentity.AuthServer.Services.UserVerification;
+
+public class FixedPinUserVerificationOptions
+{
+    [Required]
+    [StringLength(maximumLength: 5, MinimumLength = 5)]
+    public required string Pin { get; set; }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/UserVerification/FixedPinUserVerificationService.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/UserVerification/FixedPinUserVerificationService.cs
@@ -1,0 +1,32 @@
+using Microsoft.Extensions.Options;
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.Services.UserVerification;
+
+public class FixedPinUserVerificationService : IUserVerificationService
+{
+    private readonly FixedPinUserVerificationOptions _options;
+
+    public FixedPinUserVerificationService(IOptions<FixedPinUserVerificationOptions> optionsAccessor)
+    {
+        _options = optionsAccessor.Value;
+    }
+
+    public Task<PinGenerationResult> GenerateEmailPin(string email) =>
+        Task.FromResult(PinGenerationResult.Success(_options.Pin));
+
+    public Task<PinGenerationResult> GenerateSmsPin(MobileNumber mobileNumber) =>
+        Task.FromResult(PinGenerationResult.Success(_options.Pin));
+
+    public Task<PinVerificationFailedReasons> VerifyEmailPin(string email, string pin)
+    {
+        var result = pin == _options.Pin ? PinVerificationFailedReasons.None : PinVerificationFailedReasons.Unknown;
+        return Task.FromResult(result);
+    }
+
+    public Task<PinVerificationFailedReasons> VerifySmsPin(MobileNumber mobileNumber, string pin)
+    {
+        var result = pin == _options.Pin ? PinVerificationFailedReasons.None : PinVerificationFailedReasons.Unknown;
+        return Task.FromResult(result);
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Development.json
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Development.json
@@ -68,5 +68,9 @@
   "DqtEvidence": {
     "StorageContainerName": "dqt-evidence"
   },
-  "QueryStringSignatureKey": "qskey"
+  "QueryStringSignatureKey": "qskey",
+  "UserVerification": {
+    "UseFixedPin": true,
+    "Pin": "00000"
+  }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Account.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Account.cs
@@ -26,7 +26,7 @@ public class Account : IClassFixture<HostFixture>
 
         await page.SubmitEmailPage(user.EmailAddress);
 
-        await page.SubmitEmailConfirmationPage(_hostFixture.CapturedEmailConfirmationPins.Last().Pin);
+        await page.SubmitEmailConfirmationPage(HostFixture.UserVerificationPin);
 
         await page.AssertOnAccountPage();
     }
@@ -45,7 +45,7 @@ public class Account : IClassFixture<HostFixture>
 
         await page.SubmitEmailPage(user.EmailAddress);
 
-        await page.SubmitEmailConfirmationPage(_hostFixture.CapturedEmailConfirmationPins.Last().Pin);
+        await page.SubmitEmailConfirmationPage(HostFixture.UserVerificationPin);
 
         await page.SubmitCompletePageForExistingUser();
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Api.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Api.cs
@@ -30,7 +30,7 @@ public class Api : IClassFixture<HostFixture>
         await page.FillAsync("text=Your email address", adminUser.EmailAddress);
         await page.ClickAsync("button:text-is('Continue')");
 
-        var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
+        var pin = HostFixture.UserVerificationPin;
         await page.FillAsync("text=Enter your code", pin);
         await page.ClickAsync("button:text-is('Continue')");
 
@@ -92,7 +92,7 @@ public class Api : IClassFixture<HostFixture>
         await page.FillAsync("text=Your email address", adminUser.EmailAddress);
         await page.ClickAsync("button:text-is('Continue')");
 
-        var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
+        var pin = HostFixture.UserVerificationPin;
         await page.FillAsync("text=Enter your code", pin);
         await page.ClickAsync("button:text-is('Continue')");
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignIn.StaffUser.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignIn.StaffUser.cs
@@ -32,7 +32,7 @@ public partial class SignIn
         await page.FillAsync("text=Your email address", staffUser.EmailAddress);
         await page.ClickAsync("button:text-is('Continue')");
 
-        var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
+        var pin = HostFixture.UserVerificationPin;
         await page.FillAsync("text=Enter your code", pin);
         await page.ClickAsync("button:text-is('Continue')");
 
@@ -63,7 +63,7 @@ public partial class SignIn
         await page.FillAsync("text=Your email address", staffUser.EmailAddress);
         await page.ClickAsync("button:text-is('Continue')");
 
-        var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
+        var pin = HostFixture.UserVerificationPin;
         await page.FillAsync("text=Enter your code", pin);
         await page.ClickAsync("button:text-is('Continue')");
 
@@ -85,7 +85,7 @@ public partial class SignIn
         await page.FillAsync("text=Your email address", user.EmailAddress);
         await page.ClickAsync("button:text-is('Continue')");
 
-        var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
+        var pin = HostFixture.UserVerificationPin;
         await page.FillAsync("text=Enter your code", pin);
         await page.ClickAsync("button:text-is('Continue')");
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignIn.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignIn.cs
@@ -37,7 +37,7 @@ public partial class SignIn : IClassFixture<HostFixture>
         await page.FillAsync("text=Enter your email address", user.EmailAddress);
         await page.ClickAsync("button:text-is('Continue')");
 
-        var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
+        var pin = HostFixture.UserVerificationPin;
         await page.FillAsync("text=Enter your code", pin);
         await page.ClickAsync("button:text-is('Continue')");
 
@@ -89,7 +89,7 @@ public partial class SignIn : IClassFixture<HostFixture>
         await page.FillAsync("text=Enter your email address", email);
         await page.ClickAsync("button:text-is('Continue')");
 
-        var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
+        var pin = HostFixture.UserVerificationPin;
         await page.FillAsync("text=Enter your code", pin);
         await page.ClickAsync("button:text-is('Continue')");
 
@@ -217,7 +217,7 @@ public partial class SignIn : IClassFixture<HostFixture>
         await page.FillAsync("text=Enter your email address", email);
         await page.ClickAsync("button:text-is('Continue')");
 
-        var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
+        var pin = HostFixture.UserVerificationPin;
         await page.FillAsync("text=Enter your code", pin);
         await page.ClickAsync("button:text-is('Continue')");
 
@@ -390,7 +390,7 @@ public partial class SignIn : IClassFixture<HostFixture>
         await page.FillAsync("text=Enter your email address", email);
         await page.ClickAsync("button:text-is('Continue')");
 
-        var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
+        var pin = HostFixture.UserVerificationPin;
         await page.FillAsync("text=Enter your code", pin);
         await page.ClickAsync("button:text-is('Continue')");
 
@@ -455,7 +455,7 @@ public partial class SignIn : IClassFixture<HostFixture>
 
         // Should now be on 'TRN in use' page
 
-        pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
+        pin = HostFixture.UserVerificationPin;
         await page.FillAsync("text=Enter your code", pin);
 
         await page.ClickAsync("button:text-is('Continue')");
@@ -522,7 +522,7 @@ public partial class SignIn : IClassFixture<HostFixture>
         await page.FillAsync("text=Enter your email address", user.EmailAddress);
         await page.ClickAsync("button:text-is('Continue')");
 
-        var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
+        var pin = HostFixture.UserVerificationPin;
         await page.FillAsync("text=Enter your code", pin);
         await page.ClickAsync("button:text-is('Continue')");
 
@@ -584,7 +584,7 @@ public partial class SignIn : IClassFixture<HostFixture>
         await page.FillAsync("text=Enter your email address", email);
         await page.ClickAsync("button:text-is('Continue')");
 
-        var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
+        var pin = HostFixture.UserVerificationPin;
         await page.FillAsync("text=Enter your code", pin);
         await page.ClickAsync("button:text-is('Continue')");
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignOut.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/SignOut.cs
@@ -26,7 +26,7 @@ public class SignOut : IClassFixture<HostFixture>
 
         await page.SubmitEmailPage(user.EmailAddress);
 
-        await page.SubmitEmailConfirmationPage(_hostFixture.CapturedEmailConfirmationPins.Last().Pin);
+        await page.SubmitEmailConfirmationPage(HostFixture.UserVerificationPin);
 
         await page.SubmitCompletePageForExistingUser();
 
@@ -61,7 +61,7 @@ public class SignOut : IClassFixture<HostFixture>
 
         await page.SubmitEmailPage(user.EmailAddress);
 
-        await page.SubmitEmailConfirmationPage(_hostFixture.CapturedEmailConfirmationPins.Last().Pin);
+        await page.SubmitEmailConfirmationPage(HostFixture.UserVerificationPin);
 
         await page.SignOutFromAccountPageWithoutClientContext();
 
@@ -90,7 +90,7 @@ public class SignOut : IClassFixture<HostFixture>
 
         await page.SubmitEmailPage(user.EmailAddress);
 
-        await page.SubmitEmailConfirmationPage(_hostFixture.CapturedEmailConfirmationPins.Last().Pin);
+        await page.SubmitEmailConfirmationPage(HostFixture.UserVerificationPin);
 
         await page.SubmitCompletePageForExistingUser();
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/UpdateDetails.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/UpdateDetails.cs
@@ -32,7 +32,7 @@ public class UpdateDetails : IClassFixture<HostFixture>
         await page.FillAsync("text=Enter your email address", user.EmailAddress);
         await page.ClickAsync("button:text-is('Continue')");
 
-        var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
+        var pin = HostFixture.UserVerificationPin;
         await page.FillAsync("text=Enter your code", pin);
         await page.ClickAsync("button:text-is('Continue')");
 
@@ -83,7 +83,7 @@ public class UpdateDetails : IClassFixture<HostFixture>
         await page.FillAsync("text=Enter your email address", user.EmailAddress);
         await page.ClickAsync("button:text-is('Continue')");
 
-        var pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
+        var pin = HostFixture.UserVerificationPin;
         await page.FillAsync("text=Enter your code", pin);
         await page.ClickAsync("button:text-is('Continue')");
 
@@ -101,7 +101,7 @@ public class UpdateDetails : IClassFixture<HostFixture>
         // Confirm your email address page
 
         await page.WaitForSelectorAsync("h1:text-is('Confirm your email address')");
-        pin = _hostFixture.CapturedEmailConfirmationPins.Last().Pin;
+        pin = HostFixture.UserVerificationPin;
         await page.FillAsync("text=Enter your code", pin);
         await page.ClickAsync("button:text-is('Continue')");
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/appsettings.json
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/appsettings.json
@@ -12,7 +12,10 @@
       "SharedKey": "OKqdp0+u8QSzwk5unfZrTRZzqwYJSOuo0pOsOIVhkog=",
       "EnableStubEndpoints": true
     },
-    "QueryStringSignatureKey": "qskey"
+    "QueryStringSignatureKey": "qskey",
+    "UserVerification": {
+      "UseFixedPin": true
+    }
   },
   "Client": {
     "ClientId": "testclient",

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -55,7 +55,9 @@ locals {
       Zendesk__Token                               = lookup(local.infrastructure_secrets, "ZENDESK_TOKEN", ""),
       Zendesk__Username                            = lookup(local.infrastructure_secrets, "ZENDESK_USERNAME", ""),
       Zendesk__UseFakeClient                       = lookup(local.infrastructure_secrets, "ZENDESK_TOKEN", "") == "" ? "true" : "false",
-      QueryStringSignatureKey                      = local.infrastructure_secrets.QUERYSTRING_SIGNATURE_KEY
+      QueryStringSignatureKey                      = local.infrastructure_secrets.QUERYSTRING_SIGNATURE_KEY,
+      UserVerification__UseFixedPin                = lookup(local.infrastructure_secrets, "USER_VERIFICATION_USE_FIXED_PIN", "false"),
+      UserVerification__Pin                        = lookup(local.infrastructure_secrets, "USER_VERIFICATION_PIN", "")
     }
   )
 


### PR DESCRIPTION
For local development and some non-production environments it would be useful to have a known, fixed PIN for email & SMS verification to remove the need for picking through logs to find a 'real' code.

This change adds a `FixedPinUserVerificationService` implementation of `IUserVerificationService` and enables it when a `UserVerification:UseFixedPin` config entry is set. It's enabled for local dev by default and also our end-to-end tests.

Developers can still use the real implementation if desired by overriding the config value in user secrets.