### PR TITLE
Use a more permissive NINO matching pattern

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/DataAnnotationsExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/DataAnnotationsExtensions.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
+using TeacherIdentity.AuthServer.Helpers;
 using TeacherIdentity.AuthServer.Models;
 
 namespace TeacherIdentity.AuthServer;
@@ -104,5 +105,14 @@ public class MobilePhoneAttribute : ValidationAttribute
     public override bool IsValid(object? value)
     {
         return value is string str && MobileNumber.TryParse(str, out _);
+    }
+}
+
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
+public class NationalInsuranceNumber : ValidationAttribute
+{
+    public override bool IsValid(object? value)
+    {
+        return value is string str && NationalInsuranceNumberHelper.IsValid(str);
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Helpers/NationalInsuranceNumberHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Helpers/NationalInsuranceNumberHelper.cs
@@ -1,0 +1,21 @@
+using System.Text.RegularExpressions;
+
+namespace TeacherIdentity.AuthServer.Helpers;
+
+public static partial class NationalInsuranceNumberHelper
+{
+    public static bool IsValid(string? nino)
+    {
+        if (nino is null)
+        {
+            return false;
+        }
+
+        var normalized = new string(nino.Where(c => !Char.IsWhiteSpace(c) && c != '-').ToArray());
+
+        return ValidNinoPattern().IsMatch(normalized);
+    }
+
+    [GeneratedRegex("^[A-CEGHJ-PR-TW-Za-ceghj-pr-tw-z]{1}[A-CEGHJ-NPR-TW-Za-ceghj-npr-tw-z]{1}[0-9]{6}[A-DFMa-dfm]{0,1}$")]
+    private static partial Regex ValidNinoPattern();
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/NiNumberPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/NiNumberPage.cshtml.cs
@@ -17,7 +17,7 @@ public class NiNumberPage : PageModel
 
     [Display(Name = "What is your National Insurance number?", Description = "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.")]
     [Required(ErrorMessage = "Enter a National Insurance number")]
-    [RegularExpression(@"(?i)\A[a-z]{2}(?: [0-9]{2}){3} [a-d]{1}|[a-z]{2}[0-9]{6}[a-d]{1}\Z", ErrorMessage = "Enter a National Insurance number in the correct format")]
+    [NationalInsuranceNumber(ErrorMessage = "Enter a National Insurance number in the correct format")]
     public string? NiNumber { get; set; }
 
     public void OnGet()

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/NiNumberPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/NiNumberPage.cshtml.cs
@@ -15,7 +15,7 @@ public class NiNumberPage : TrnLookupPageModel
 
     [Display(Name = "What is your National Insurance number?", Description = "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.")]
     [Required(ErrorMessage = "Enter a National Insurance number")]
-    [RegularExpression(@"(?i)\A[a-z]{2}(?: [0-9]{2}){3} [a-d]{1}|[a-z]{2}[0-9]{6}[a-d]{1}\Z", ErrorMessage = "Enter a National Insurance number in the correct format")]
+    [NationalInsuranceNumber(ErrorMessage = "Enter a National Insurance number in the correct format")]
     public string? NiNumber { get; set; }
 
     public void OnGet()

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/NiNumberPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/NiNumberPageTests.cs
@@ -117,9 +117,8 @@ public class NiNumberPageTests : TestBase
     }
 
     [Theory]
-    [InlineData("QQ 123456C")]
-    [InlineData("123456")]
-    [InlineData("QQ12345C")]
+    [InlineData("x")]
+    [InlineData("zyx")]
     public async Task Post_InvalidNiNumber_ReturnsError(string niNumber)
     {
         // Arrange
@@ -163,9 +162,9 @@ public class NiNumberPageTests : TestBase
     }
 
     [Theory]
-    [InlineData("QQ 12 34 56 C")]
-    [InlineData("QQ123456C")]
-    [InlineData("qQ123456c")]
+    [InlineData("AB 12 34 56 C")]
+    [InlineData("AB123456C")]
+    [InlineData("aB123456c")]
     public async Task Post_ValidNiNumber_SetsNiNumberOnAuthenticationStateAndRedirects(string niNumber)
     {
         // Arrange

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/NiNumberPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/NiNumberPageTests.cs
@@ -130,9 +130,8 @@ public class NiNumberPageTests : TestBase
     }
 
     [Theory]
-    [InlineData("QQ 123456C")]
-    [InlineData("123456")]
-    [InlineData("QQ12345C")]
+    [InlineData("x")]
+    [InlineData("zyx")]
     public async Task Post_InvalidNiNumber_ReturnsError(string niNumber)
     {
         // Arrange
@@ -155,9 +154,9 @@ public class NiNumberPageTests : TestBase
     }
 
     [Theory]
-    [InlineData("QQ 12 34 56 C")]
-    [InlineData("QQ123456C")]
-    [InlineData("qQ123456c")]
+    [InlineData("AB 12 34 56 C")]
+    [InlineData("AB123456C")]
+    [InlineData("aB123456c")]
     public async Task Post_ValidNiNumber_SetsNiNumberOnAuthenticationStateRedirectsToAwardedQtsPage(string niNumber)
     {
         // Arrange
@@ -215,7 +214,7 @@ public class NiNumberPageTests : TestBase
         {
             Content = new FormUrlEncodedContentBuilder()
             {
-                { "NiNumber", "QQ123456C" },
+                { "NiNumber", "AB123456C" },
                 { "submit", "submit" },
             }
         };

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/HelperTests/NationalInsuranceNumberHelperTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/HelperTests/NationalInsuranceNumberHelperTests.cs
@@ -1,0 +1,86 @@
+using TeacherIdentity.AuthServer.Helpers;
+
+namespace TeacherIdentity.AuthServer.Tests.HelperTests;
+
+public class NationalInsuranceNumberHelperTests
+{
+    [Fact]
+    public void IsValid_NinoWithSuffix_ReturnsTrue()
+    {
+        // Arrange
+        var nino = "AB123456C";
+
+        // Act
+        var isValid = NationalInsuranceNumberHelper.IsValid(nino);
+
+        // Assert
+        Assert.True(isValid);
+    }
+
+    [Fact]
+    public void IsValid_NinoWithoutSuffix_ReturnsTrue()
+    {
+        // Arrange
+        var nino = "AB123456";
+
+        // Act
+        var isValid = NationalInsuranceNumberHelper.IsValid(nino);
+
+        // Assert
+        Assert.True(isValid);
+    }
+
+    [Fact]
+    public void IsValid_EmptyNino_ReturnsFalse()
+    {
+        // Arrange
+        var nino = "";
+
+        // Act
+        var isValid = NationalInsuranceNumberHelper.IsValid(nino);
+
+        // Assert
+        Assert.False(isValid);
+    }
+
+    [Fact]
+    public void IsValid_ValidNinoWithSpaces_ReturnsTrue()
+    {
+        // Arrange
+        var nino = " AB 12 3 456 C ";
+
+        // Act
+        var isValid = NationalInsuranceNumberHelper.IsValid(nino);
+
+        // Assert
+        Assert.True(isValid);
+    }
+
+    [Fact]
+    public void IsValid_ValidNinoWithMixedCaseLetters_ReturnsTrue()
+    {
+        // Arrange
+        var nino = "Ab123456c";
+
+        // Act
+        var isValid = NationalInsuranceNumberHelper.IsValid(nino);
+
+        // Assert
+        Assert.True(isValid);
+    }
+
+    [Theory]
+    [InlineData("AB123456X")]
+    [InlineData("AB123456Cx")]
+    [InlineData("AB12345")]
+    public void IsValid_InvalidNino_ReturnsFalse(string nino)
+    {
+        // Arrange
+
+        // Act
+        var isValid = NationalInsuranceNumberHelper.IsValid(nino);
+
+        // Assert
+        Assert.False(isValid);
+    }
+}


### PR DESCRIPTION
Our current regex is fairly picky about spaces. This borrows an existing pattern from another service - https://github.com/alphagov/ier-frontend/blob/master/app/uk/gov/gds/ier/validation/NinoValidator.scala#L5 

I've ported the case & space normalization too as well as the tests.

I opted against a full-blown `NationalInsuranceNumber` type here as we've done for phone number since we're not persisting this anywhere or subsequently matching user records against it.