### PR TITLE
Add register trn page

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -107,6 +107,10 @@ public abstract class IdentityLinkGenerator
 
     public string RegisterHaveQts() => Page("/SignIn/Register/HaveQts");
 
+    public string RegisterIttProvider() => Page("/SignIn/Register/IttProvider");
+
+    public string RegisterCheckAnswers() => Page("/SignIn/Register/CheckAnswers");
+
     public string UpdateEmail(string? returnUrl, string? cancelUrl) =>
         Page("/Authenticated/UpdateEmail/Index", authenticationJourneyRequired: false)
             .SetQueryParam("returnUrl", returnUrl)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasTrnPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasTrnPage.cshtml.cs
@@ -19,11 +19,7 @@ public class HasTrnPage : PageModel
     [Required(ErrorMessage = "Tell us if you know your TRN")]
     public bool? HasTrn { get; set; }
 
-<<<<<<< HEAD
     public string BackLink => HttpContext.GetAuthenticationState().HasNationalInsuranceNumber == true
-=======
-    public string BackLink => HttpContext.GetAuthenticationState().HasNationalInsuranceNumberSet
->>>>>>> dad3c80 (Add has TRN page for register journey)
         ? _linkGenerator.RegisterNiNumber()
         : _linkGenerator.RegisterHasNiNumber();
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasTrnPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasTrnPage.cshtml.cs
@@ -19,7 +19,11 @@ public class HasTrnPage : PageModel
     [Required(ErrorMessage = "Tell us if you know your TRN")]
     public bool? HasTrn { get; set; }
 
+<<<<<<< HEAD
     public string BackLink => HttpContext.GetAuthenticationState().HasNationalInsuranceNumber == true
+=======
+    public string BackLink => HttpContext.GetAuthenticationState().HasNationalInsuranceNumberSet
+>>>>>>> dad3c80 (Add has TRN page for register journey)
         ? _linkGenerator.RegisterNiNumber()
         : _linkGenerator.RegisterHasNiNumber();
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/TrnPage.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/TrnPage.cshtml
@@ -1,0 +1,40 @@
+@page "/sign-in/register/trn"
+@model TeacherIdentity.AuthServer.Pages.SignIn.Register.TrnPage
+@{
+    ViewBag.Title = "What is your teacher reference number (TRN)?";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.RegisterHasTrn()" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.RegisterTrn()" method="post" asp-antiforgery="true">
+            <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
+
+            <p>A TRN is 7 digits long, for example 4567814</p>
+            <p>It might include the letters RP and a slash, for example RP99/12345</p>
+            <p>It’s previously been known as a QTS, GTC, DfE, DfES and DCSF number</p>
+
+            <govuk-input asp-for="StatedTrn" spellcheck="false">
+                <govuk-input-label class="govuk-label--s"/>
+            </govuk-input>
+
+            <govuk-button type="submit" class="govuk-visually-hidden" name="submit" value="hidden_submit"/>
+
+            <govuk-details>
+                <govuk-details-summary>I don’t know my TRN</govuk-details-summary>
+                <govuk-details-text>
+                    <p>You can continue without it</p>
+                    <govuk-button type="submit" class="govuk-button--secondary" name="submit" value="trn_not_known">
+                        Continue without it
+                    </govuk-button>
+                </govuk-details-text>
+            </govuk-details>
+
+            <govuk-button type="submit" name="submit" value="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>
+

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/TrnPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/TrnPage.cshtml.cs
@@ -1,0 +1,56 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
+
+[BindProperties]
+[RequiresTrnLookup]
+public class TrnPage : PageModel
+{
+    private IdentityLinkGenerator _linkGenerator;
+
+    public TrnPage(IdentityLinkGenerator linkGenerator)
+    {
+        _linkGenerator = linkGenerator;
+    }
+
+    [Display(Name = "Enter your TRN")]
+    [Required(ErrorMessage = "Enter your TRN")]
+    [RegularExpression(@"\A\D*(\d{1}\D*){7}\D*\Z", ErrorMessage = "Your TRN number should contain 7 digits")]
+    public string? StatedTrn { get; set; }
+
+    public void OnGet()
+    {
+    }
+
+    public IActionResult OnPost(string submit)
+    {
+        if (submit == "trn_not_known")
+        {
+            HttpContext.GetAuthenticationState().OnHasTrnSet(false);
+        }
+        else
+        {
+            if (!ModelState.IsValid)
+            {
+                return this.PageWithErrors();
+            }
+
+            HttpContext.GetAuthenticationState().OnTrnSet(StatedTrn);
+        }
+
+        return Redirect(_linkGenerator.RegisterHaveQts());
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var authenticationState = context.HttpContext.GetAuthenticationState();
+
+        if (!authenticationState.HasTrnSet)
+        {
+            context.Result = new RedirectResult(_linkGenerator.RegisterHasTrn());
+        }
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
@@ -186,7 +186,7 @@ public sealed class AuthenticationStateHelper
                 s.OnHasNationalInsuranceNumberSet(true);
             };
 
-        public Func<AuthenticationState, Task> RegisterHasNiNumber(
+        public Func<AuthenticationState, Task> RegisterNiNumberSet(
             DateOnly? dateOfBirth = null,
             string? firstName = null,
             string? lastName = null,
@@ -197,6 +197,19 @@ public sealed class AuthenticationStateHelper
             {
                 await RegisterHasNiNumberSet(dateOfBirth, firstName, lastName, mobileNumber, email, user)(s);
                 s.OnNationalInsuranceNumberSet(Faker.Identification.UkNationalInsuranceNumber());
+            };
+
+        public Func<AuthenticationState, Task> RegisterHasTrnSet(
+            DateOnly? dateOfBirth = null,
+            string? firstName = null,
+            string? lastName = null,
+            string? mobileNumber = null,
+            string? email = null,
+            User? user = null) =>
+            async s =>
+            {
+                await RegisterNiNumberSet(dateOfBirth, firstName, lastName, mobileNumber, email, user)(s);
+                s.OnHasTrnSet(true);
             };
 
         public Func<AuthenticationState, Task> RegisterExistingUserAccountMatch(

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/HasTrnPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/HasTrnPageTests.cs
@@ -130,7 +130,7 @@ public class HasTrnPageTests : TestBase
     [Theory]
     [InlineData(true)]
     [InlineData(false)]
-    public async Task Post_ValidHasTrn_UpdatesAuthenticationStateRedirectsToTrnOfficialName(bool hasTrn)
+    public async Task Post_ValidHasTrn_UpdatesAuthenticationStateRedirectsToTrn(bool hasTrn)
     {
         // Arrange
         var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), CustomScopes.DqtRead);
@@ -148,6 +148,7 @@ public class HasTrnPageTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/register/trn", response.Headers.Location?.OriginalString);
 
         Assert.Equal(hasTrn, authStateHelper.AuthenticationState.HasTrn);
     }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/HasTrnPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/HasTrnPageTests.cs
@@ -148,7 +148,11 @@ public class HasTrnPageTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith("/sign-in/register/trn", response.Headers.Location?.OriginalString);
+
+        if (hasTrn)
+        {
+            Assert.StartsWith("/sign-in/register/trn", response.Headers.Location?.OriginalString);
+        }
 
         Assert.Equal(hasTrn, authStateHelper.AuthenticationState.HasTrn);
     }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/RegisterJourneyAuthenticationStateHelper.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/RegisterJourneyAuthenticationStateHelper.cs
@@ -40,7 +40,10 @@ public static class RegisterJourneyAuthenticationStateHelper
                     return c => c.RegisterHasNiNumberSet();
 
                 case RegisterJourneyPage.HasTrn:
-                    return c => c.RegisterHasNiNumber();
+                    return c => c.RegisterNiNumberSet();
+
+                case RegisterJourneyPage.Trn:
+                    return c => c.RegisterHasTrnSet();
 
                 case RegisterJourneyPage.AccountExists:
                     return c => c.RegisterExistingUserAccountMatch(user);
@@ -86,4 +89,5 @@ public enum RegisterJourneyPage
     HasNiNumber,
     NiNumber,
     HasTrn,
+    Trn
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/TrnPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/TrnPageTests.cs
@@ -1,0 +1,215 @@
+using TeacherIdentity.AuthServer.Oidc;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
+
+public class TrnPageTests : TestBase
+{
+    public TrnPageTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, $"/sign-in/register/trn");
+    }
+
+    [Fact]
+    public async Task Get_NoAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await MissingAuthenticationState_ReturnsBadRequest(HttpMethod.Get, $"/sign-in/register/trn");
+    }
+
+    [Fact]
+    public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/register/trn");
+    }
+
+    [Fact]
+    public async Task Get_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(_currentPageAuthenticationState(), CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/register/trn");
+    }
+
+    [Fact]
+    public async Task Get_HasTrnNotSet_RedirectsToHasTrn()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_previousPageAuthenticationState(), CustomScopes.DqtRead);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/trn?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/register/has-trn", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_RequiresTrnLookupFalse_ReturnsBadRequest()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/trn?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_RendersContent()
+    {
+        await ValidRequest_RendersContent(_currentPageAuthenticationState(), "/sign-in/register/trn", CustomScopes.DqtRead);
+    }
+
+    [Fact]
+    public async Task Post_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Post, $"/sign-in/register/trn");
+    }
+
+    [Fact]
+    public async Task Post_NoAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await MissingAuthenticationState_ReturnsBadRequest(HttpMethod.Post, $"/sign-in/register/trn");
+    }
+
+    [Fact]
+    public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/register/trn");
+    }
+
+    [Fact]
+    public async Task Post_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(_currentPageAuthenticationState(), CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/register/trn");
+    }
+
+    [Fact]
+    public async Task Post_EmptyStatedTrn_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), CustomScopes.DqtRead);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/trn?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "submit", "submit" },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "StatedTrn", "Enter your TRN");
+    }
+
+    [Theory]
+    [InlineData("abc")]
+    [InlineData("123456")]
+    [InlineData("1234567 8")]
+    public async Task Post_InvalidStatedTrn_ReturnsError(string statedTrn)
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), CustomScopes.DqtRead);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/trn?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "StatedTrn", statedTrn },
+                { "submit", "submit" },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "StatedTrn", "Your TRN number should contain 7 digits");
+    }
+
+    [Fact]
+    public async Task Post_FalseRequiresTrnLookup_ReturnsBadRequest()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), null);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/trn?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "StatedTrn", TestData.GenerateTrn() },
+                { "submit", "submit" },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_HasTrnNotSet_RedirectsToHasTrn()
+    {
+        // Arrange
+        var statedTrn = TestData.GenerateTrn();
+        var authStateHelper = await CreateAuthenticationStateHelper(_previousPageAuthenticationState(), CustomScopes.DqtRead);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/trn?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "StatedTrn", statedTrn },
+                { "submit", "submit" },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/register/has-trn", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_ValidStatedTrn_UpdatesAuthenticationState()
+    {
+        // Arrange
+        var statedTrn = TestData.GenerateTrn();
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), CustomScopes.DqtRead);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/trn?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "StatedTrn", statedTrn },
+                { "submit", "submit" },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        Assert.Equal(statedTrn, authStateHelper.AuthenticationState.StatedTrn);
+    }
+
+    private readonly AuthenticationStateConfigGenerator _currentPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.Trn);
+    private readonly AuthenticationStateConfigGenerator _previousPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.HasTrn);
+}


### PR DESCRIPTION
### Context

The core ID journey is being extended to include matching a TRN so that we can use the core journey everywhere.

### Changes proposed in this pull request

Add a new page at /sign-in/register/trn following the designs at https://get-an-identity-prototype.herokuapp.com/auth/trn

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
