### PR TITLE
Add register has qts page

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -105,7 +105,7 @@ public abstract class IdentityLinkGenerator
 
     public string RegisterTrn() => Page("/SignIn/Register/TrnPage");
 
-    public string RegisterHaveQts() => Page("/SignIn/Register/HaveQts");
+    public string RegisterHasQts() => Page("/SignIn/Register/HasQtsPage");
 
     public string RegisterIttProvider() => Page("/SignIn/Register/IttProvider");
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasQtsPage.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasQtsPage.cshtml
@@ -1,0 +1,27 @@
+@page "/sign-in/register/has-qts"
+@model TeacherIdentity.AuthServer.Pages.SignIn.Register.HasQtsPage
+@{
+    ViewBag.Title = Html.DisplayNameFor(m => m.AwardedQts);
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@Model.BackLink" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.RegisterHasQts()" method="post" asp-antiforgery="true">
+            <govuk-radios asp-for="AwardedQts">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--xl"/>
+
+                    <govuk-radios-item value="True">Yes</govuk-radios-item>
+                    <govuk-radios-item value="False">No</govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>
+

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasQtsPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasQtsPage.cshtml.cs
@@ -1,0 +1,62 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
+
+[BindProperties]
+[RequiresTrnLookup]
+public class HasQtsPage : PageModel
+{
+    private IdentityLinkGenerator _linkGenerator;
+
+    public HasQtsPage(IdentityLinkGenerator linkGenerator)
+    {
+        _linkGenerator = linkGenerator;
+    }
+
+    [BindNever]
+    public string BackLink => HttpContext.GetAuthenticationState().HasTrn == true
+        ? _linkGenerator.RegisterTrn()
+        : _linkGenerator.RegisterHasTrn();
+
+    [Display(Name = "Have you been awarded qualified teacher status (QTS)?")]
+    [Required(ErrorMessage = "Tell us if you have been awarded qualified teacher status (QTS)")]
+    public bool? AwardedQts { get; set; }
+
+    public void OnGet()
+    {
+    }
+
+    public IActionResult OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        HttpContext.GetAuthenticationState().OnAwardedQtsSet((bool)AwardedQts!);
+
+        return (bool)AwardedQts!
+            ? Redirect(_linkGenerator.RegisterIttProvider())
+            : Redirect(_linkGenerator.RegisterCheckAnswers());
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var authenticationState = context.HttpContext.GetAuthenticationState();
+
+        if (!authenticationState.HasTrnSet)
+        {
+            context.Result = new RedirectResult(_linkGenerator.RegisterHasTrn());
+            return;
+        }
+
+        if (authenticationState.StatedTrn is null)
+        {
+            context.Result = new RedirectResult(_linkGenerator.RegisterTrn());
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasTrnPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasTrnPage.cshtml.cs
@@ -38,7 +38,7 @@ public class HasTrnPage : PageModel
 
         return HasTrn.Value ?
             Redirect(_linkGenerator.RegisterTrn()) :
-            Redirect(_linkGenerator.RegisterHaveQts());
+            Redirect(_linkGenerator.RegisterHasQts());
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/TrnPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/TrnPage.cshtml.cs
@@ -41,7 +41,7 @@ public class TrnPage : PageModel
             HttpContext.GetAuthenticationState().OnTrnSet(StatedTrn);
         }
 
-        return Redirect(_linkGenerator.RegisterHaveQts());
+        return Redirect(_linkGenerator.RegisterHasQts());
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
@@ -212,6 +212,19 @@ public sealed class AuthenticationStateHelper
                 s.OnHasTrnSet(true);
             };
 
+        public Func<AuthenticationState, Task> RegisterTrnSet(
+            DateOnly? dateOfBirth = null,
+            string? firstName = null,
+            string? lastName = null,
+            string? mobileNumber = null,
+            string? email = null,
+            User? user = null) =>
+            async s =>
+            {
+                await RegisterHasTrnSet(dateOfBirth, firstName, lastName, mobileNumber, email, user)(s);
+                s.OnTrnSet(TestData.GenerateTrn());
+            };
+
         public Func<AuthenticationState, Task> RegisterExistingUserAccountMatch(
             User? existingUserAccount = null,
             DateOnly? dateOfBirth = null,

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/HasNiNumberPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/HasNiNumberPageTests.cs
@@ -46,16 +46,10 @@ public class HasNiNumberPageTests : TestBase
     [Fact]
     public async Task Get_RequiresTrnLookupFalse_ReturnsBadRequest()
     {
-        // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/has-nino?{authStateHelper.ToQueryParam()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+        await JourneyRequiresTrnLookup_TrnLookupRequiredIsFalse_ReturnsBadRequest(
+            _currentPageAuthenticationState(),
+            HttpMethod.Get,
+            "/sign-in/register/has-nino");
     }
 
     [Fact]
@@ -101,21 +95,16 @@ public class HasNiNumberPageTests : TestBase
     [Fact]
     public async Task Post_RequiresTrnLookupFalse_ReturnsBadRequest()
     {
-        // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/has-nino?{authStateHelper.ToQueryParam()}")
+        var content = new FormUrlEncodedContentBuilder()
         {
-            Content = new FormUrlEncodedContentBuilder()
-            {
-                { "HasNiNumber", true },
-            }
+            { "HasNiNumber", true },
         };
 
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+        await JourneyRequiresTrnLookup_TrnLookupRequiredIsFalse_ReturnsBadRequest(
+            _currentPageAuthenticationState(),
+            HttpMethod.Post,
+            "/sign-in/register/has-nino",
+            content);
     }
 
     [Fact]

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/HasQtsPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/HasQtsPageTests.cs
@@ -1,0 +1,198 @@
+using TeacherIdentity.AuthServer.Oidc;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
+
+public class HasQtsPageTests : TestBase
+{
+    public HasQtsPageTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, $"/sign-in/register/has-qts");
+    }
+
+    [Fact]
+    public async Task Get_NoAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await MissingAuthenticationState_ReturnsBadRequest(HttpMethod.Get, $"/sign-in/register/has-qts");
+    }
+
+    [Fact]
+    public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/register/has-qts");
+    }
+
+    [Fact]
+    public async Task Get_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(_currentPageAuthenticationState(), CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/register/has-qts");
+    }
+
+    [Fact]
+    public async Task Get_RequiresTrnLookupFalse_ReturnsBadRequest()
+    {
+        await JourneyRequiresTrnLookup_TrnLookupRequiredIsFalse_ReturnsBadRequest(
+            _currentPageAuthenticationState(),
+            HttpMethod.Get,
+            "/sign-in/register/has-qts");
+    }
+
+    [Fact]
+    public async Task Get_HasTrnNotSet_RedirectsToHasTrnPage()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_hasTrnPageAuthenticationState(), CustomScopes.DqtRead);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/has-qts?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/register/has-trn", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_HasTrnButTrnNotSet_RedirectsToTrnPage()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_trnPageAuthenticationState(), CustomScopes.DqtRead);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/has-qts?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/register/trn", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_RendersContent()
+    {
+        await ValidRequest_RendersContent(_currentPageAuthenticationState(), "/sign-in/register/has-qts", CustomScopes.DqtRead);
+    }
+
+    [Fact]
+    public async Task Post_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Post, $"/sign-in/register/has-qts");
+    }
+
+    [Fact]
+    public async Task Post_NoAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await MissingAuthenticationState_ReturnsBadRequest(HttpMethod.Post, $"/sign-in/register/has-qts");
+    }
+
+    [Fact]
+    public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/register/has-qts");
+    }
+
+    [Fact]
+    public async Task Post_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(_currentPageAuthenticationState(), CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/register/has-qts");
+    }
+
+    [Fact]
+    public async Task Post_HasTrnNotSet_RedirectsToHasTrnPage()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_hasTrnPageAuthenticationState(), CustomScopes.DqtRead);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/has-qts?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/register/has-trn", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_RequiresTrnLookupFalse_ReturnsBadRequest()
+    {
+        var content = new FormUrlEncodedContentBuilder()
+        {
+            { "AwardedQts", true },
+        };
+
+        await JourneyRequiresTrnLookup_TrnLookupRequiredIsFalse_ReturnsBadRequest(
+            _currentPageAuthenticationState(),
+            HttpMethod.Post,
+            "/sign-in/register/has-qts",
+            content);
+    }
+
+    [Fact]
+    public async Task Post_HasTrnButTrnNotSet_RedirectsToTrnPage()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_trnPageAuthenticationState(), CustomScopes.DqtRead);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/has-qts?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/register/trn", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_NullAwardedQts_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), CustomScopes.DqtRead);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/has-qts?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "AwardedQts", "Tell us if you have been awarded qualified teacher status (QTS)");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Post_ValidForm_SetsAwardedQtsOnAuthenticationState(bool awardedQts)
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), CustomScopes.DqtRead);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/has-qts?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "AwardedQts", awardedQts },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal(awardedQts, authStateHelper.AuthenticationState.AwardedQts);
+    }
+
+    private readonly AuthenticationStateConfigGenerator _currentPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.HasQts);
+    private readonly AuthenticationStateConfigGenerator _trnPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.Trn);
+    private readonly AuthenticationStateConfigGenerator _hasTrnPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.HasTrn);
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/HasTrnPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/HasTrnPageTests.cs
@@ -36,16 +36,10 @@ public class HasTrnPageTests : TestBase
     [Fact]
     public async Task Get_RequiresTrnLookupFalse_ReturnsBadRequest()
     {
-        // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/has-trn?{authStateHelper.ToQueryParam()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+        await JourneyRequiresTrnLookup_TrnLookupRequiredIsFalse_ReturnsBadRequest(
+            _currentPageAuthenticationState(),
+            HttpMethod.Get,
+            "/sign-in/register/has-trn");
     }
 
     [Fact]
@@ -153,6 +147,10 @@ public class HasTrnPageTests : TestBase
         {
             Assert.StartsWith("/sign-in/register/trn", response.Headers.Location?.OriginalString);
         }
+        else
+        {
+            Assert.StartsWith("/sign-in/register/has-qts", response.Headers.Location?.OriginalString);
+        }
 
         Assert.Equal(hasTrn, authStateHelper.AuthenticationState.HasTrn);
     }
@@ -160,26 +158,19 @@ public class HasTrnPageTests : TestBase
     [Fact]
     public async Task Post_FalseRequiresTrnLookup_ReturnsBadRequest()
     {
-        // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), null);
-
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/has-trn?{authStateHelper.ToQueryParam()}")
+        var content = new FormUrlEncodedContentBuilder()
         {
-            Content = new FormUrlEncodedContentBuilder()
-            {
-                { "HasTrn", true },
-            }
+            { "HasTrn", true },
         };
 
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+        await JourneyRequiresTrnLookup_TrnLookupRequiredIsFalse_ReturnsBadRequest(
+            _currentPageAuthenticationState(),
+            HttpMethod.Post,
+            "/sign-in/register/has-trn",
+            content);
     }
 
     private readonly AuthenticationStateConfigGenerator _currentPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.HasTrn);
     private readonly AuthenticationStateConfigGenerator _ninoPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.NiNumber);
     private readonly AuthenticationStateConfigGenerator _hasNinoPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.HasNiNumber);
-
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/NiNumberPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/NiNumberPageTests.cs
@@ -46,16 +46,10 @@ public class NiNumberPageTests : TestBase
     [Fact]
     public async Task Get_RequiresTrnLookupFalse_ReturnsBadRequest()
     {
-        // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
-
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/ni-number?{authStateHelper.ToQueryParam()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+        await JourneyRequiresTrnLookup_TrnLookupRequiredIsFalse_ReturnsBadRequest(
+            _currentPageAuthenticationState(),
+            HttpMethod.Get,
+            "/sign-in/register/ni-number");
     }
 
     [Fact]
@@ -143,22 +137,17 @@ public class NiNumberPageTests : TestBase
     [Fact]
     public async Task Post_RequiresTrnLookupFalse_ReturnsBadRequest()
     {
-        // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/ni-number?{authStateHelper.ToQueryParam()}")
+        var content = new FormUrlEncodedContentBuilder()
         {
-            Content = new FormUrlEncodedContentBuilder()
-            {
-                { "NiNumber", "QQ123456C" },
-                { "submit", "submit" },
-            }
+            { "NiNumber", "QQ123456C" },
+            { "submit", "submit" },
         };
 
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+        await JourneyRequiresTrnLookup_TrnLookupRequiredIsFalse_ReturnsBadRequest(
+            _currentPageAuthenticationState(),
+            HttpMethod.Post,
+            "/sign-in/register/ni-number",
+            content);
     }
 
     [Theory]

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/RegisterJourneyAuthenticationStateHelper.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/RegisterJourneyAuthenticationStateHelper.cs
@@ -45,6 +45,9 @@ public static class RegisterJourneyAuthenticationStateHelper
                 case RegisterJourneyPage.Trn:
                     return c => c.RegisterHasTrnSet();
 
+                case RegisterJourneyPage.HasQts:
+                    return c => c.RegisterTrnSet();
+
                 case RegisterJourneyPage.AccountExists:
                     return c => c.RegisterExistingUserAccountMatch(user);
 
@@ -89,5 +92,6 @@ public enum RegisterJourneyPage
     HasNiNumber,
     NiNumber,
     HasTrn,
-    Trn
+    Trn,
+    HasQts,
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TestBase.CommonTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TestBase.CommonTests.cs
@@ -166,6 +166,30 @@ public partial class TestBase
         }
     }
 
+    public async Task JourneyRequiresTrnLookup_TrnLookupRequiredIsFalse_ReturnsBadRequest(
+        AuthenticationStateConfiguration configureAuthenticationHelper,
+        HttpMethod method,
+        string url,
+        HttpContent? content = null)
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(configureAuthenticationHelper, additionalScopes: null);
+
+        var fullUrl = $"{url}?{authStateHelper.ToQueryParam()}";
+        var request = new HttpRequestMessage(method, fullUrl);
+
+        if (content is not null)
+        {
+            request.Content = content;
+        }
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
     public async Task ValidRequest_RendersContent(
         AuthenticationStateConfiguration configureAuthenticationHelper,
         string url,


### PR DESCRIPTION
### Context

The core ID journey is being extended to include matching a TRN so that we can use the core journey everywhere.

### Changes proposed in this pull request

Add a new page at /sign-in/register/has-qts following the designs at https://get-an-identity-prototype.herokuapp.com/auth/have-qts

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
