### PR TITLE
Use Notify for generating email and SMS templates

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/Notification/INotificationSender.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/Notification/INotificationSender.cs
@@ -2,7 +2,7 @@ namespace TeacherIdentity.AuthServer.Services.Notification;
 
 public interface INotificationSender
 {
-    Task SendEmail(string to, string subject, string body);
+    Task SendEmail(string templateId, string to, IReadOnlyDictionary<string, string> personalization);
 
-    Task SendSms(string to, string message);
+    Task SendSms(string templateId, string to, IReadOnlyDictionary<string, string> personalization);
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/Notification/NoopNotificationSender.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/Notification/NoopNotificationSender.cs
@@ -2,6 +2,6 @@ namespace TeacherIdentity.AuthServer.Services.Notification;
 
 public class NoopNotificationSender : INotificationSender
 {
-    public Task SendEmail(string to, string subject, string body) => Task.CompletedTask;
-    public Task SendSms(string to, string message) => Task.CompletedTask;
+    public Task SendEmail(string templateId, string to, IReadOnlyDictionary<string, string> personalization) => Task.CompletedTask;
+    public Task SendSms(string templateId, string to, IReadOnlyDictionary<string, string> personalization) => Task.CompletedTask;
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/Notification/NotificationSender.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/Notification/NotificationSender.cs
@@ -5,9 +5,6 @@ namespace TeacherIdentity.AuthServer.Services.Notification;
 
 public class NotificationSender : INotificationSender
 {
-    private const string EmailTemplateId = "fa26cec0-bf41-42ee-b3ac-b600f6faf8af";
-    private const string SmsTemplateId = "fb66d1f5-00e5-4889-8edb-eb849423e141";
-
     private readonly NotifyOptions _options;
     private readonly NotificationClient _notificationClient;
     private readonly NotificationClient? _noSendNotificationClient;
@@ -25,7 +22,7 @@ public class NotificationSender : INotificationSender
         }
     }
 
-    public async Task SendEmail(string to, string subject, string body)
+    public async Task SendEmail(string templateId, string to, IReadOnlyDictionary<string, string> personalization)
     {
         NotificationClient client = _notificationClient;
 
@@ -54,24 +51,20 @@ public class NotificationSender : INotificationSender
         {
             await client.SendEmailAsync(
                 to,
-                EmailTemplateId,
-                personalisation: new Dictionary<string, dynamic>()
-                {
-                    { "subject", subject },
-                    { "body", body }
-                });
+                templateId,
+                personalisation: personalization.ToDictionary(kvp => kvp.Key, kvp => (dynamic)kvp.Value));
 
-            _logger.LogInformation("Successfully sent {Subject} email to {Email}.", subject, to);
+            _logger.LogInformation("Successfully sent email to {Email}.", to);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed sending {Subject} email to {Email}.", to);
+            _logger.LogError(ex, "Failed sending email to {Email}.", to);
 
             throw;
         }
     }
 
-    public async Task SendSms(string to, string message)
+    public async Task SendSms(string templateId, string to, IReadOnlyDictionary<string, string> personalization)
     {
         NotificationClient client = _notificationClient;
 
@@ -79,11 +72,8 @@ public class NotificationSender : INotificationSender
         {
             await client.SendSmsAsync(
                 to,
-                SmsTemplateId,
-                personalisation: new Dictionary<string, dynamic>()
-                {
-                    { "message", message }
-                });
+                templateId,
+                personalisation: personalization.ToDictionary(kvp => kvp.Key, kvp => (dynamic)kvp.Value));
 
             _logger.LogInformation("Successfully sent verification SMS to {MobileNumber}.", to);
         }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailTests.cs
@@ -259,7 +259,7 @@ public class EmailTests : TestBase
     {
         // Arrange
         HostFixture.NotificationSender
-            .Setup(mock => mock.SendEmail(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(mock => mock.SendEmail(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, string>>()))
             .Throws(new Exception("ValidationError"));
 
         var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/EmailTests.cs
@@ -278,7 +278,7 @@ public class EmailTests : TestBase
     {
         // Arrange
         HostFixture.NotificationSender
-            .Setup(mock => mock.SendEmail(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(mock => mock.SendEmail(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, string>>()))
             .Throws(new Exception("ValidationError"));
 
         var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/PhoneTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/PhoneTests.cs
@@ -169,7 +169,7 @@ public class PhoneTests : TestBase
     {
         // Arrange
         HostFixture.NotificationSender
-            .Setup(mock => mock.SendSms(It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(mock => mock.SendSms(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, string>>()))
             .Throws(new Exception("ValidationError"));
 
         var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ResendEmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ResendEmailConfirmationTests.cs
@@ -270,7 +270,7 @@ public class ResendEmailConfirmationTests : TestBase
     {
         // Arrange
         HostFixture.NotificationSender
-            .Setup(mock => mock.SendEmail(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(mock => mock.SendEmail(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, string>>()))
             .Throws(new Exception("ValidationError"));
 
         var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ResendPhoneConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/ResendPhoneConfirmationTests.cs
@@ -188,7 +188,7 @@ public class ResendPhoneConfirmationTests : TestBase
     {
         // Arrange
         HostFixture.NotificationSender
-            .Setup(mock => mock.SendSms(It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(mock => mock.SendSms(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, string>>()))
             .Throws(new Exception("ValidationError"));
 
         var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/ResendEmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/ResendEmailConfirmationTests.cs
@@ -365,7 +365,7 @@ public class ResendEmailConfirmationTests : TestBase
     {
         // Arrange
         HostFixture.NotificationSender
-            .Setup(mock => mock.SendEmail(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
+            .Setup(mock => mock.SendEmail(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyDictionary<string, string>>()))
             .Throws(new Exception("ValidationError"));
 
         var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(), additionalScopes: null);

--- a/terraform/app.tf
+++ b/terraform/app.tf
@@ -33,9 +33,9 @@ locals {
       EncryptionKeys__1                            = local.infrastructure_secrets.ENCRYPTION_KEY1,
       SigningKeys__0                               = local.infrastructure_secrets.SIGNING_KEY0,
       SigningKeys__1                               = local.infrastructure_secrets.SIGNING_KEY1,
-      Notify__ApiKey                               = local.infrastructure_secrets.NOTIFY_API_KEY,
+      Notify__ApiKey                               = lookup(local.infrastructure_secrets, "NOTIFY_ID_API_KEY", "")
       Notify__ApplyDomainFiltering                 = lookup(local.infrastructure_secrets, "NOTIFY_APPLY_DOMAIN_FILTERING", "false")
-      Notify__NoSendApiKey                         = lookup(local.infrastructure_secrets, "NOTIFY_NO_SEND_API_KEY", "")
+      Notify__NoSendApiKey                         = lookup(local.infrastructure_secrets, "NOTIFY_ID_NO_SEND_API_KEY", "")
       AdminCredentials__Username                   = local.infrastructure_secrets.ADMIN_CREDENTIALS_USERNAME,
       AdminCredentials__Password                   = local.infrastructure_secrets.ADMIN_CREDENTIALS_PASSWORD,
       Sentry__Dsn                                  = local.infrastructure_secrets.SENTRY_DSN,


### PR DESCRIPTION
We want to move the templates into Notify itself so that content designers can change them without developer involvement. In addition we will be able to use Notify’s ‘hide personalisation’ feature.