### PR TITLE
Use session state for storing TempData

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
@@ -428,12 +428,14 @@ public class Program
             options.KnownProxies.Clear();
         });
 
-        builder.Services.AddMvc(options =>
-        {
-            options.Conventions.Add(new Infrastructure.ApplicationModel.ApiControllerConvention());
+        builder.Services
+            .AddMvc(options =>
+            {
+                options.Conventions.Add(new Infrastructure.ApplicationModel.ApiControllerConvention());
 
-            options.ModelBinderProviders.Insert(0, new DateOnlyModelBinderProvider());
-        });
+                options.ModelBinderProviders.Insert(0, new DateOnlyModelBinderProvider());
+            })
+            .AddSessionStateTempDataProvider();
 
         builder.Services.AddCsp(nonceByteAmount: 32);
 


### PR DESCRIPTION
The default configuration uses a cookie which has a not-so-great name and is missing from our current cookie policy.