### PR TITLE
Add Itt Providers page to register journey

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasNiNumberPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasNiNumberPage.cshtml.cs
@@ -9,7 +9,8 @@ namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
 [RequiresTrnLookup]
 public class HasNiNumberPage : PageModel
 {
-    private IdentityLinkGenerator _linkGenerator;
+    private readonly IdentityLinkGenerator _linkGenerator;
+
     public HasNiNumberPage(IdentityLinkGenerator linkGenerator)
     {
         _linkGenerator = linkGenerator;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasQtsPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasQtsPage.cshtml.cs
@@ -10,7 +10,7 @@ namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
 [RequiresTrnLookup]
 public class HasQtsPage : PageModel
 {
-    private IdentityLinkGenerator _linkGenerator;
+    private readonly IdentityLinkGenerator _linkGenerator;
 
     public HasQtsPage(IdentityLinkGenerator linkGenerator)
     {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasTrnPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasTrnPage.cshtml.cs
@@ -8,7 +8,8 @@ namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
 [RequiresTrnLookup]
 public class HasTrnPage : PageModel
 {
-    private IdentityLinkGenerator _linkGenerator;
+    private readonly IdentityLinkGenerator _linkGenerator;
+
     public HasTrnPage(IdentityLinkGenerator linkGenerator)
     {
         _linkGenerator = linkGenerator;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/IttProvider.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/IttProvider.cshtml
@@ -1,0 +1,67 @@
+@page "/sign-in/register/itt-provider"
+@model TeacherIdentity.AuthServer.Pages.SignIn.Register.IttProvider
+@addTagHelper *, Joonasw.AspNetCore.SecurityHeaders
+@{
+    ViewBag.Title = Html.DisplayNameFor(m => m.HasIttProvider);
+}
+
+@section Styles
+{
+    <link rel="stylesheet" href="~/Styles/Components/accessible-autocomplete.min.css" asp-append-version="true" />
+}
+
+@section Scripts
+{
+    <script src="~/Scripts/Components/accessible-autocomplete.min.js"></script>
+    <script asp-add-nonce="true">
+        window.onload = function () {
+            const inputName = '@nameof(Model.IttProviderName)';
+            const select = document.querySelector(`select[name=${inputName}`);
+            const value = select.value;
+            const container = select.parentElement;
+
+            accessibleAutocomplete({
+                element: container,
+                id: inputName,
+                source: @Html.Raw(Json.Serialize(Model.IttProviderNames)),
+                defaultValue: value
+            })
+
+            container.removeChild(select);
+            const input = container.querySelector('input');
+            input.name = inputName;
+        }
+    </script>
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.RegisterHasQts()" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.RegisterIttProvider()" method="post" asp-antiforgery="true">
+            <govuk-radios asp-for="HasIttProvider">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--xl"/>
+
+                    <govuk-radios-item value="True">Yes
+                        <govuk-radios-item-conditional>
+                            <govuk-select asp-for="IttProviderName">
+                                <govuk-select-label class="govuk-label--s"/>
+                                <govuk-select-item value=""></govuk-select-item>
+                                @foreach (var ittProviderName in Model.IttProviderNames ?? Enumerable.Empty<string>())
+                                {
+                                    <govuk-select-item value="@ittProviderName">@ittProviderName</govuk-select-item>
+                                }
+                            </govuk-select>
+                        </govuk-radios-item-conditional>
+                    </govuk-radios-item>
+                    <govuk-radios-item value="False">No</govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/IttProvider.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/IttProvider.cshtml.cs
@@ -1,0 +1,75 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Caching.Memory;
+using TeacherIdentity.AuthServer.Services.DqtApi;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
+
+[BindProperties]
+[RequiresTrnLookup]
+public class IttProvider : PageModel
+{
+    private readonly IMemoryCache _cache;
+    private readonly IDqtApiClient _dqtApiClient;
+    private readonly IdentityLinkGenerator _linkGenerator;
+
+    public string[]? IttProviderNames;
+
+    public IttProvider(
+        IMemoryCache cache,
+        IdentityLinkGenerator linkGenerator,
+        IDqtApiClient dqtApiClient)
+    {
+        _cache = cache;
+        _linkGenerator = linkGenerator;
+        _dqtApiClient = dqtApiClient;
+    }
+
+    // Properties are set in the order that they are declared. Because the value of HasIttProvider
+    // is used in the conditional RequiredIfTrue attribute, it should be set first.
+    [Display(Name = "Did a university, SCITT or school award your QTS?")]
+    [Required(ErrorMessage = "Tell us how you were awarded qualified teacher status (QTS)")]
+    public bool? HasIttProvider { get; set; }
+
+    [Display(Name = "Where did you get your QTS?", Description = "Your university, SCITT, school or other training provider")]
+    [RequiredIfTrue(nameof(HasIttProvider), ErrorMessage = "Enter your university, SCITT, school or other training provider")]
+    public string? IttProviderName { get; set; }
+
+    public void OnGet()
+    {
+    }
+
+    public IActionResult OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        HttpContext.GetAuthenticationState().OnHasIttProviderSet((bool)HasIttProvider!, IttProviderName);
+
+        return Redirect(_linkGenerator.RegisterCheckAnswers());
+    }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        var authenticationState = context.HttpContext.GetAuthenticationState();
+
+        if (!authenticationState.AwardedQtsSet)
+        {
+            context.Result = new RedirectResult(_linkGenerator.RegisterHasQts());
+            return;
+        }
+
+        if (!_cache.TryGetValue("IttProviderNames", out IttProviderNames))
+        {
+            IttProviderNames = (await _dqtApiClient.GetIttProviders()).IttProviders.Select(result => result.ProviderName).ToArray();
+            var cacheEntryOptions = new MemoryCacheEntryOptions().SetAbsoluteExpiration(TimeSpan.FromMinutes(10));
+            _cache.Set("IttProviderNames", IttProviderNames, cacheEntryOptions);
+        }
+
+        await next();
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/NiNumberPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/NiNumberPage.cshtml.cs
@@ -9,7 +9,8 @@ namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
 [RequiresTrnLookup]
 public class NiNumberPage : PageModel
 {
-    private IdentityLinkGenerator _linkGenerator;
+    private readonly IdentityLinkGenerator _linkGenerator;
+
     public NiNumberPage(IdentityLinkGenerator linkGenerator)
     {
         _linkGenerator = linkGenerator;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/TrnPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/TrnPage.cshtml.cs
@@ -9,7 +9,7 @@ namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
 [RequiresTrnLookup]
 public class TrnPage : PageModel
 {
-    private IdentityLinkGenerator _linkGenerator;
+    private readonly IdentityLinkGenerator _linkGenerator;
 
     public TrnPage(IdentityLinkGenerator linkGenerator)
     {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
@@ -225,6 +225,19 @@ public sealed class AuthenticationStateHelper
                 s.OnTrnSet(TestData.GenerateTrn());
             };
 
+        public Func<AuthenticationState, Task> RegisterHasQtsSet(
+            DateOnly? dateOfBirth = null,
+            string? firstName = null,
+            string? lastName = null,
+            string? mobileNumber = null,
+            string? email = null,
+            User? user = null) =>
+            async s =>
+            {
+                await RegisterTrnSet(dateOfBirth, firstName, lastName, mobileNumber, email, user)(s);
+                s.OnAwardedQtsSet(true);
+            };
+
         public Func<AuthenticationState, Task> RegisterExistingUserAccountMatch(
             User? existingUserAccount = null,
             DateOnly? dateOfBirth = null,

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/IttProviderTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/IttProviderTests.cs
@@ -1,0 +1,213 @@
+using Microsoft.Extensions.Caching.Memory;
+using TeacherIdentity.AuthServer.Oidc;
+using TeacherIdentity.AuthServer.Services.DqtApi;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
+
+public class IttProviderTests : TestBase
+{
+    public IttProviderTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+        HostFixture.DqtApiClient.Setup(mock => mock.GetIttProviders(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetIttProvidersResponse()
+            {
+                IttProviders = new IttProvider[]
+                {
+                    new() { ProviderName = "provider 1" },
+                    new() { ProviderName = "provider 2" },
+                }
+            });
+    }
+
+    [Fact]
+    public async Task Get_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, $"/sign-in/register/itt-provider");
+    }
+
+    [Fact]
+    public async Task Get_NoAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await MissingAuthenticationState_ReturnsBadRequest(HttpMethod.Get, $"/sign-in/register/itt-provider");
+    }
+
+    [Fact]
+    public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/register/itt-provider");
+    }
+
+    [Fact]
+    public async Task Get_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(_currentPageAuthenticationState(), CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/register/itt-provider");
+    }
+
+    [Fact]
+    public async Task Get_FalseRequiresTrnLookup_ReturnsBadRequest()
+    {
+        await JourneyRequiresTrnLookup_TrnLookupRequiredIsFalse_ReturnsBadRequest(
+            _currentPageAuthenticationState(),
+            HttpMethod.Get,
+            "/sign-in/register/itt-provider");
+    }
+
+    [Fact]
+    public async Task Get_AwardedQtsNotSet_RedirectsToHasQtsPage()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_previousPageAuthenticationState(), CustomScopes.DqtRead);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/itt-provider?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/register/has-qts", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_StoresIttProviderNamesInCache()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), CustomScopes.DqtRead);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/itt-provider?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var ittProviderNames = HostFixture.Services.GetService<IMemoryCache>()?.Get<string[]>("IttProviderNames");
+        Assert.Equal(new[] { "provider 1", "provider 2" }, ittProviderNames);
+    }
+
+    [Fact]
+    public async Task Post_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Post, $"/sign-in/register/itt-provider");
+    }
+
+    [Fact]
+    public async Task Post_NoAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await MissingAuthenticationState_ReturnsBadRequest(HttpMethod.Post, $"/sign-in/register/itt-provider");
+    }
+
+    [Fact]
+    public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/register/itt-provider");
+    }
+
+    [Fact]
+    public async Task Post_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(_currentPageAuthenticationState(), CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/register/itt-provider");
+    }
+
+    [Fact]
+    public async Task Post_FalseRequiresTrnLookup_ReturnsBadRequest()
+    {
+        var content = new FormUrlEncodedContentBuilder()
+        {
+            { "HasIttProvider", true },
+            { "IttProviderName", "provider" },
+        };
+
+        await JourneyRequiresTrnLookup_TrnLookupRequiredIsFalse_ReturnsBadRequest(
+            _currentPageAuthenticationState(),
+            HttpMethod.Post,
+            "/sign-in/register/itt-provider",
+            content);
+    }
+
+    [Fact]
+    public async Task Post_AwardedQtsNotSet_RedirectsToAwardedQtsPage()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_previousPageAuthenticationState(), CustomScopes.DqtRead);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/itt-provider?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/register/has-qts", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_NullHasIttProvider_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), CustomScopes.DqtRead);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/itt-provider?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "HasIttProvider", "Tell us how you were awarded qualified teacher status (QTS)");
+    }
+
+    [Fact]
+    public async Task Post_EmptyIttProviderName_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), CustomScopes.DqtRead);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/itt-provider?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "HasIttProvider", true },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "IttProviderName", "Enter your university, SCITT, school or other training provider");
+    }
+
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Post_ValidForm_UpdatesAuthenticationState(bool hasIttProvider)
+    {
+        // Arrange
+        var ittProviderName = "provider";
+
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), CustomScopes.DqtRead);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/itt-provider?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "HasIttProvider", hasIttProvider },
+                { "IttProviderName", ittProviderName },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+
+        Assert.Equal(hasIttProvider, authStateHelper.AuthenticationState.HasIttProvider);
+        Assert.Equal(hasIttProvider ? ittProviderName : null, authStateHelper.AuthenticationState.IttProviderName);
+    }
+
+    private readonly AuthenticationStateConfigGenerator _currentPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.IttProvider);
+    private readonly AuthenticationStateConfigGenerator _previousPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.HasQts);
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/RegisterJourneyAuthenticationStateHelper.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/RegisterJourneyAuthenticationStateHelper.cs
@@ -48,6 +48,9 @@ public static class RegisterJourneyAuthenticationStateHelper
                 case RegisterJourneyPage.HasQts:
                     return c => c.RegisterTrnSet();
 
+                case RegisterJourneyPage.IttProvider:
+                    return c => c.RegisterHasQtsSet();
+
                 case RegisterJourneyPage.AccountExists:
                     return c => c.RegisterExistingUserAccountMatch(user);
 
@@ -94,4 +97,5 @@ public enum RegisterJourneyPage
     HasTrn,
     Trn,
     HasQts,
+    IttProvider
 }


### PR DESCRIPTION
### Context

The core ID journey is being extended to include matching a TRN so that we can use the core journey everywhere.

### Changes proposed in this pull request

Add a new page at /sign-in/register/itt-providers following the designs at https://get-an-identity-prototype.herokuapp.com/auth/how-qts

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
