### PR TITLE
Add register check answers page

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/CheckAnswers.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/CheckAnswers.cshtml
@@ -1,0 +1,82 @@
+@page "/sign-in/register/check-answers"
+@model TeacherIdentity.AuthServer.Pages.SignIn.Register.CheckAnswers
+@{
+    ViewBag.Title = "Check your answers";
+}
+
+@section BeforeContent
+{
+    <govuk-back-link href="@Model.BackLink" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.RegisterCheckAnswers()" method="post" asp-antiforgery="true">
+            <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
+
+            <govuk-summary-list>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Email</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value class="empty-hyphens">@Html.ShyEmail(Model.EmailAddress!)</govuk-summary-list-row-value>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Mobile phone</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.MobilePhoneNumber</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.RegisterPhone()" visually-hidden-text="mobile phone">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.FullName</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.RegisterName()" visually-hidden-text="name">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.DateOfBirth?.ToString("dd MMMM yyyy")</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.RegisterDateOfBirth()" visually-hidden-text="date of birth">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                @if (Model.RequiresTrnLookup == true)
+                {
+                    @if (Model.HasNationalInsuranceNumberSet == true)
+                    {
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>National Insurance number</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value>@(Model.NationalInsuranceNumber ?? "Not given")</govuk-summary-list-row-value>
+                            <govuk-summary-list-row-actions>
+                                <govuk-summary-list-row-action href="@LinkGenerator.RegisterHasNiNumber()" visually-hidden-text="national insurance number">Change</govuk-summary-list-row-action>
+                            </govuk-summary-list-row-actions>
+                        </govuk-summary-list-row>
+                    }
+                    @if (Model.AwardedQtsSet == true)
+                    {
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>Have you been awarded QTS?</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value>@(Model.AwardedQts == true ? "Yes" : "No")</govuk-summary-list-row-value>
+                            <govuk-summary-list-row-actions>
+                                <govuk-summary-list-row-action href="@LinkGenerator.RegisterHasQts()" visually-hidden-text="awarded QTS">Change</govuk-summary-list-row-action>
+                            </govuk-summary-list-row-actions>
+                        </govuk-summary-list-row>
+                    }
+                    @if (Model.AwardedQts == true)
+                    {
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>Where did you get your QTS?</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value>@(Model.IttProviderName ?? "Not given")</govuk-summary-list-row-value>
+                            <govuk-summary-list-row-actions>
+                                <govuk-summary-list-row-action href="@LinkGenerator.RegisterIttProvider()" visually-hidden-text="teacher training provider">Change</govuk-summary-list-row-action>
+                            </govuk-summary-list-row-actions>
+                        </govuk-summary-list-row>
+                    }
+                }
+            </govuk-summary-list>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>
+

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/CheckAnswers.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/CheckAnswers.cshtml.cs
@@ -1,0 +1,88 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Pages.SignIn.Trn;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
+
+public class CheckAnswers : PageModel
+{
+    private readonly IClock _clock;
+    private readonly TrnLookupHelper _trnLookupHelper;
+    private readonly TeacherIdentityServerDbContext _dbContext;
+    private readonly IdentityLinkGenerator _linkGenerator;
+
+    public CheckAnswers(
+        IdentityLinkGenerator linkGenerator,
+        TeacherIdentityServerDbContext dbContext,
+        IClock clock,
+        TrnLookupHelper trnLookupHelper)
+    {
+        _linkGenerator = linkGenerator;
+        _dbContext = dbContext;
+        _clock = clock;
+        _trnLookupHelper = trnLookupHelper;
+    }
+
+    public string BackLink => HttpContext.GetAuthenticationState().OAuthState?.RequiresTrnLookup == true
+        ? _linkGenerator.RegisterIttProvider()
+        : _linkGenerator.RegisterDateOfBirth();
+
+    public bool? RequiresTrnLookup => HttpContext.GetAuthenticationState().OAuthState?.RequiresTrnLookup;
+    public string? EmailAddress => HttpContext.GetAuthenticationState().EmailAddress;
+    public string? MobilePhoneNumber => HttpContext.GetAuthenticationState().MobileNumber;
+    public string? FullName => HttpContext.GetAuthenticationState().GetPreferredName();
+    public DateOnly? DateOfBirth => HttpContext.GetAuthenticationState().DateOfBirth;
+    public bool? HasNationalInsuranceNumberSet => HttpContext.GetAuthenticationState().HasNationalInsuranceNumberSet;
+    public string? NationalInsuranceNumber => HttpContext.GetAuthenticationState().NationalInsuranceNumber;
+    public bool? AwardedQtsSet => HttpContext.GetAuthenticationState().AwardedQtsSet;
+    public bool? AwardedQts => HttpContext.GetAuthenticationState().AwardedQts;
+    public string? IttProviderName => HttpContext.GetAuthenticationState().IttProviderName;
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        return await TryCreateUser();
+    }
+
+    protected async Task<IActionResult> TryCreateUser()
+    {
+        var authenticationState = HttpContext.GetAuthenticationState();
+
+        var userId = Guid.NewGuid();
+        var user = new User()
+        {
+            Created = _clock.UtcNow,
+            DateOfBirth = authenticationState.DateOfBirth,
+            EmailAddress = authenticationState.EmailAddress!,
+            MobileNumber = authenticationState.MobileNumber,
+            NormalizedMobileNumber = MobileNumber.Parse(authenticationState.MobileNumber!),
+            FirstName = authenticationState.FirstName!,
+            LastName = authenticationState.LastName!,
+            Updated = _clock.UtcNow,
+            UserId = userId,
+            UserType = UserType.Default,
+            LastSignedIn = _clock.UtcNow,
+            RegisteredWithClientId = authenticationState.OAuthState?.ClientId,
+        };
+
+        _dbContext.Users.Add(user);
+
+        _dbContext.AddEvent(new Events.UserRegisteredEvent()
+        {
+            ClientId = authenticationState.OAuthState?.ClientId,
+            CreatedUtc = _clock.UtcNow,
+            User = user
+        });
+
+        await _dbContext.SaveChangesAsync();
+
+        authenticationState.OnUserRegistered(user);
+        await authenticationState.SignIn(HttpContext);
+
+        return Redirect(authenticationState.GetNextHopUrl(_linkGenerator));
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
@@ -296,6 +296,12 @@ public static class PageExtensions
         await page.ClickContinueButton();
     }
 
+    public static async Task SubmitCheckAnswersPage(this IPage page, DateOnly dateOfBirth)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/register/check-answers");
+        await page.ClickContinueButton();
+    }
+
     public static async Task SubmitCompletePageForNewUser(this IPage page)
     {
         await page.WaitForUrlPathAsync("/sign-in/complete");

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Register.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Register.cs
@@ -40,6 +40,8 @@ public class Register : IClassFixture<HostFixture>
 
         await page.SubmitDateOfBirthPage(dateOfBirth);
 
+        await page.SubmitCheckAnswersPage(dateOfBirth);
+
         await page.SubmitCompletePageForNewUser();
 
         await page.AssertSignedInOnTestClient(email, trn: null, firstName, lastName);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
@@ -231,11 +231,27 @@ public sealed class AuthenticationStateHelper
             string? lastName = null,
             string? mobileNumber = null,
             string? email = null,
-            User? user = null) =>
+            User? user = null,
+            bool? awardedQts = null) =>
             async s =>
             {
                 await RegisterTrnSet(dateOfBirth, firstName, lastName, mobileNumber, email, user)(s);
-                s.OnAwardedQtsSet(true);
+                s.OnAwardedQtsSet(awardedQts == true);
+            };
+
+        public Func<AuthenticationState, Task> RegisterIttProviderSet(
+            DateOnly? dateOfBirth = null,
+            string? firstName = null,
+            string? lastName = null,
+            string? mobileNumber = null,
+            string? email = null,
+            User? user = null,
+            bool? awardedQts = false,
+            string? ittProviderName = "provider") =>
+            async s =>
+            {
+                await RegisterHasQtsSet(dateOfBirth, firstName, lastName, mobileNumber, email, user, awardedQts)(s);
+                s.OnHasIttProviderSet(hasIttProvider: ittProviderName is not null, ittProviderName);
             };
 
         public Func<AuthenticationState, Task> RegisterExistingUserAccountMatch(

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/CheckAnswersTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/CheckAnswersTests.cs
@@ -1,0 +1,158 @@
+using AngleSharp.Html.Dom;
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Oidc;
+using User = TeacherIdentity.AuthServer.Models.User;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
+
+public class CheckAnswersTests : TestBase
+{
+    public CheckAnswersTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register/check-answers");
+    }
+
+    [Fact]
+    public async Task Get_MissingAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register/check-answers");
+    }
+
+    [Fact]
+    public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/register/check-answers");
+    }
+
+    [Fact]
+    public async Task Get_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(_currentPageAuthenticationState(), CustomScopes.DqtRead, HttpMethod.Get, "/sign-in/register/check-answers");
+    }
+
+    [Theory]
+    [MemberData(nameof(CheckAnswersState))]
+    public async Task Get_ValidRequest_RendersExpectedContent(
+        bool requiresTrnLookup,
+        RegisterJourneyPage registerJourneyStage,
+        bool awardedQts)
+    {
+        // Arrange
+        var additionalScopes = requiresTrnLookup ? CustomScopes.DqtRead : null;
+
+        var currentAuthenticationStateConfig = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(registerJourneyStage);
+
+        var authStateHelper = await CreateAuthenticationStateHelper(currentAuthenticationStateConfig(awardedQts: awardedQts), additionalScopes);
+        var authState = authStateHelper.AuthenticationState;
+
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/check-answers?{authStateHelper.ToQueryParam()}");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+
+        var doc = await response.GetDocument();
+        Assert.Equal(authState.EmailAddress, doc.GetSummaryListValueForKey("Email"));
+        Assert.Equal(authState.MobileNumber, doc.GetSummaryListValueForKey("Mobile phone"));
+        Assert.Equal($"{authState.FirstName} {authState.LastName}", doc.GetSummaryListValueForKey("Name"));
+        Assert.Equal(authState.DateOfBirth?.ToString("dd MMMM yyyy"), doc.GetSummaryListValueForKey("Date of birth"));
+
+        var hasNiNumberSet = registerJourneyStage > RegisterJourneyPage.HasNiNumber;
+        var awardedQtsSet = registerJourneyStage > RegisterJourneyPage.HasQts;
+
+        AssertRowValid("National Insurance number", requiresTrnLookup && hasNiNumberSet, authState.NationalInsuranceNumber, doc);
+        AssertRowValid("Have you been awarded QTS?", requiresTrnLookup && awardedQtsSet, authState.AwardedQts == true ? "Yes" : "No", doc);
+        AssertRowValid("Where did you get your QTS?", requiresTrnLookup && awardedQts, authState.IttProviderName, doc);
+    }
+
+    [Fact]
+    public async Task Post_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Post, "/sign-in/register/check-answers");
+    }
+
+    [Fact]
+    public async Task Post_MissingAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Post, "/sign-in/register/check-answers");
+    }
+
+    [Fact]
+    public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/register/check-answers");
+    }
+
+    [Fact]
+    public async Task Post_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(_currentPageAuthenticationState(), CustomScopes.DqtRead, HttpMethod.Post, "/sign-in/register/check-answers");
+    }
+
+    [Fact]
+    public async Task Post_ValidForm_CreatesUserAndRedirectsToPostSignInUrl()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/check-answers?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        User? user = null;
+
+        await TestData.WithDbContext(async dbContext =>
+        {
+            user = await dbContext.Users.Where(u => u.EmailAddress == authStateHelper.AuthenticationState.EmailAddress).SingleOrDefaultAsync();
+            Assert.NotNull(user);
+        });
+
+        EventObserver.AssertEventsSaved(
+            e =>
+            {
+                var userRegisteredEvent = Assert.IsType<UserRegisteredEvent>(e);
+                Assert.Equal(Clock.UtcNow, userRegisteredEvent.CreatedUtc);
+                Assert.Equal(user?.UserId, userRegisteredEvent.User.UserId);
+            });
+
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith(authStateHelper.AuthenticationState.PostSignInUrl, response.Headers.Location?.OriginalString);
+    }
+
+    private void AssertRowValid(string rowName, bool shouldExist, string? value, IHtmlDocument doc)
+    {
+        if (shouldExist)
+        {
+            Assert.Equal(value, doc.GetSummaryListValueForKey(rowName));
+        }
+        else
+        {
+            Assert.Null(doc.GetSummaryListRowForKey(rowName));
+        }
+    }
+
+    public static TheoryData<bool, RegisterJourneyPage, bool> CheckAnswersState { get; } = new()
+    {
+        // requiresTrnLookup, HasNiNumberSet, AwardedQtsSet, AwardedQts
+        { false, RegisterJourneyPage.CheckAnswers, false },
+        { true, RegisterJourneyPage.CheckAnswers, false },
+        { true, RegisterJourneyPage.CheckAnswers, true },
+        { true, RegisterJourneyPage.HasQts, false },
+        { true, RegisterJourneyPage.HasNiNumber, false },
+    };
+
+    private readonly AuthenticationStateConfigGenerator _currentPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.CheckAnswers);
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/RegisterJourneyAuthenticationStateHelper.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/RegisterJourneyAuthenticationStateHelper.cs
@@ -2,13 +2,16 @@ using TeacherIdentity.AuthServer.Models;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
 
-public delegate AuthenticationStateConfiguration AuthenticationStateConfigGenerator(User? user = null, string? mobileNumber = null);
+public delegate AuthenticationStateConfiguration AuthenticationStateConfigGenerator(
+    User? user = null,
+    string? mobileNumber = null,
+    bool? awardedQts = null);
 
 public static class RegisterJourneyAuthenticationStateHelper
 {
     public static AuthenticationStateConfigGenerator ConfigureAuthenticationStateForPage(RegisterJourneyPage page)
     {
-        return (user, mobileNumber) =>
+        return (user, mobileNumber, awardedQts) =>
         {
             switch (page)
             {
@@ -49,7 +52,10 @@ public static class RegisterJourneyAuthenticationStateHelper
                     return c => c.RegisterTrnSet();
 
                 case RegisterJourneyPage.IttProvider:
-                    return c => c.RegisterHasQtsSet();
+                    return c => c.RegisterHasQtsSet(awardedQts: awardedQts);
+
+                case RegisterJourneyPage.CheckAnswers:
+                    return c => c.RegisterIttProviderSet(awardedQts: awardedQts);
 
                 case RegisterJourneyPage.AccountExists:
                     return c => c.RegisterExistingUserAccountMatch(user);
@@ -97,5 +103,6 @@ public enum RegisterJourneyPage
     HasTrn,
     Trn,
     HasQts,
-    IttProvider
+    IttProvider,
+    CheckAnswers,
 }


### PR DESCRIPTION
### Context

The core ID journey is being extended to include matching a TRN so that we can use the core journey everywhere.

### Changes proposed in this pull request

Add a new page at /sign-in/register/check-answers following the designs at https://get-an-identity-prototype.herokuapp.com/auth/check-answers  .

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
