### PR TITLE
Sign in journey abstraction

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CheckCanAccessStepAttribute.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CheckCanAccessStepAttribute.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+
+namespace TeacherIdentity.AuthServer.Journeys;
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+public class CheckCanAccessStepAttribute : Attribute, IPageFilter
+{
+    public CheckCanAccessStepAttribute(string stepName)
+    {
+        StepName = stepName;
+    }
+
+    public string StepName { get; }
+
+    public void OnPageHandlerExecuted(PageHandlerExecutedContext context)
+    {
+    }
+
+    public void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        var journey = context.HttpContext.RequestServices.GetRequiredService<SignInJourney>();
+
+        if (!journey.CanAccessStep(StepName))
+        {
+            context.Result = new RedirectResult(journey.GetLastAccessibleStep());
+        }
+    }
+
+    public void OnPageHandlerSelected(PageHandlerSelectedContext context)
+    {
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourney.cs
@@ -13,6 +13,31 @@ public class CoreSignInJourney : SignInJourney
     {
     }
 
+    public override bool CanAccessStep(string step)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override string? GetNextStep(string currentStep)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override string? GetPreviousStep(string currentStep)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override string GetStartStep()
+    {
+        throw new NotImplementedException();
+    }
+
+    public override string GetStepUrl(string step)
+    {
+        throw new NotImplementedException();
+    }
+
     public override bool IsFinished()
     {
         throw new NotImplementedException();

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourney.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Mvc;
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.Journeys;
+
+public class CoreSignInJourney : SignInJourney
+{
+    public CoreSignInJourney(
+        AuthenticationState authenticationState,
+        HttpContext httpContext,
+        IdentityLinkGenerator linkGenerator)
+        : base(authenticationState, httpContext, linkGenerator)
+    {
+    }
+
+    public override bool IsFinished()
+    {
+        throw new NotImplementedException();
+    }
+
+    protected override Task<IActionResult> OnEmailVerifiedCore(User? user)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourney.cs
@@ -5,11 +5,8 @@ namespace TeacherIdentity.AuthServer.Journeys;
 
 public class CoreSignInJourney : SignInJourney
 {
-    public CoreSignInJourney(
-        AuthenticationState authenticationState,
-        HttpContext httpContext,
-        IdentityLinkGenerator linkGenerator)
-        : base(authenticationState, httpContext, linkGenerator)
+    public CoreSignInJourney(HttpContext httpContext, IdentityLinkGenerator linkGenerator)
+        : base(httpContext, linkGenerator)
     {
     }
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
@@ -13,6 +13,31 @@ public class CoreSignInJourneyWithTrnLookup : TrnLookupJourneyBase
     {
     }
 
+    public override bool CanAccessStep(string step)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override string? GetNextStep(string currentStep)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override string? GetPreviousStep(string currentStep)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override string GetStartStep()
+    {
+        throw new NotImplementedException();
+    }
+
+    public override string GetStepUrl(string step)
+    {
+        throw new NotImplementedException();
+    }
+
     public override bool IsFinished()
     {
         throw new NotImplementedException();

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Mvc;
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.Journeys;
+
+public class CoreSignInJourneyWithTrnLookup : TrnLookupJourneyBase
+{
+    public CoreSignInJourneyWithTrnLookup(
+        AuthenticationState authenticationState,
+        HttpContext httpContext,
+        IdentityLinkGenerator linkGenerator)
+        : base(authenticationState, httpContext, linkGenerator)
+    {
+    }
+
+    public override bool IsFinished()
+    {
+        throw new NotImplementedException();
+    }
+
+    protected override Task<IActionResult> OnEmailVerifiedCore(User? user)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
@@ -5,11 +5,8 @@ namespace TeacherIdentity.AuthServer.Journeys;
 
 public class CoreSignInJourneyWithTrnLookup : TrnLookupJourneyBase
 {
-    public CoreSignInJourneyWithTrnLookup(
-        AuthenticationState authenticationState,
-        HttpContext httpContext,
-        IdentityLinkGenerator linkGenerator)
-        : base(authenticationState, httpContext, linkGenerator)
+    public CoreSignInJourneyWithTrnLookup(HttpContext httpContext, IdentityLinkGenerator linkGenerator)
+        : base(httpContext, linkGenerator)
     {
     }
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/LegacyTrnJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/LegacyTrnJourney.cs
@@ -13,6 +13,31 @@ public class LegacyTrnJourney : TrnLookupJourneyBase
     {
     }
 
+    public override bool CanAccessStep(string step)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override string? GetNextStep(string currentStep)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override string? GetPreviousStep(string currentStep)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override string GetStartStep()
+    {
+        throw new NotImplementedException();
+    }
+
+    public override string GetStepUrl(string step)
+    {
+        throw new NotImplementedException();
+    }
+
     public override bool IsFinished()
     {
         throw new NotImplementedException();

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/LegacyTrnJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/LegacyTrnJourney.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Mvc;
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.Journeys;
+
+public class LegacyTrnJourney : TrnLookupJourneyBase
+{
+    public LegacyTrnJourney(
+        AuthenticationState authenticationState,
+        HttpContext httpContext,
+        IdentityLinkGenerator linkGenerator)
+        : base(authenticationState, httpContext, linkGenerator)
+    {
+    }
+
+    public override bool IsFinished()
+    {
+        throw new NotImplementedException();
+    }
+
+    protected override Task<IActionResult> OnEmailVerifiedCore(User? user)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/LegacyTrnJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/LegacyTrnJourney.cs
@@ -5,11 +5,8 @@ namespace TeacherIdentity.AuthServer.Journeys;
 
 public class LegacyTrnJourney : TrnLookupJourneyBase
 {
-    public LegacyTrnJourney(
-        AuthenticationState authenticationState,
-        HttpContext httpContext,
-        IdentityLinkGenerator linkGenerator)
-        : base(authenticationState, httpContext, linkGenerator)
+    public LegacyTrnJourney(HttpContext httpContext, IdentityLinkGenerator linkGenerator)
+        : base(httpContext, linkGenerator)
     {
     }
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/SignInJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/SignInJourney.cs
@@ -23,33 +23,15 @@ public abstract class SignInJourney
 
     public abstract bool IsFinished();
 
-    public virtual string GetStartStep() => Steps.Email;
+    public abstract string GetStartStep();
 
-    public virtual string GetStepUrl(string step) => step switch
-    {
-        Steps.Email => LinkGenerator.Email(),
-        Steps.EmailConfirmation => LinkGenerator.EmailConfirmation(),
-        _ => throw new ArgumentException($"Unknown step: '{step}'.")
-    };
+    public abstract string GetStepUrl(string step);
 
-    public virtual string? GetNextStep(string currentStep) => currentStep switch
-    {
-        Steps.Email => Steps.EmailConfirmation,
-        _ => null
-    };
+    public abstract string? GetNextStep(string currentStep);
 
-    public virtual string? GetPreviousStep(string currentStep) => currentStep switch
-    {
-        Steps.EmailConfirmation => Steps.Email,
-        _ => null
-    };
+    public abstract string? GetPreviousStep(string currentStep);
 
-    public virtual bool CanAccessStep(string step) => step switch
-    {
-        Steps.Email => !AuthenticationState.EmailAddressVerified,
-        Steps.EmailConfirmation => !AuthenticationState.EmailAddressVerified && AuthenticationState.EmailAddressSet,
-        _ => false
-    };
+    public abstract bool CanAccessStep(string step);
 
     public virtual string GetLastAccessibleStep()
     {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/SignInJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/SignInJourney.cs
@@ -5,12 +5,9 @@ namespace TeacherIdentity.AuthServer.Journeys;
 
 public abstract class SignInJourney
 {
-    protected SignInJourney(
-        AuthenticationState authenticationState,
-        HttpContext httpContext,
-        IdentityLinkGenerator linkGenerator)
+    protected SignInJourney(HttpContext httpContext, IdentityLinkGenerator linkGenerator)
     {
-        AuthenticationState = authenticationState;
+        AuthenticationState = httpContext.GetAuthenticationState();
         HttpContext = httpContext;
         LinkGenerator = linkGenerator;
     }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/SignInJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/SignInJourney.cs
@@ -1,0 +1,141 @@
+using Microsoft.AspNetCore.Mvc;
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.Journeys;
+
+public abstract class SignInJourney
+{
+    protected SignInJourney(
+        AuthenticationState authenticationState,
+        HttpContext httpContext,
+        IdentityLinkGenerator linkGenerator)
+    {
+        AuthenticationState = authenticationState;
+        HttpContext = httpContext;
+        LinkGenerator = linkGenerator;
+    }
+
+    public AuthenticationState AuthenticationState { get; }
+
+    public HttpContext HttpContext { get; }
+
+    public IdentityLinkGenerator LinkGenerator { get; }
+
+    public abstract bool IsFinished();
+
+    public virtual string GetStartStep() => Steps.Email;
+
+    public virtual string GetStepUrl(string step) => step switch
+    {
+        Steps.Email => LinkGenerator.Email(),
+        Steps.EmailConfirmation => LinkGenerator.EmailConfirmation(),
+        _ => throw new ArgumentException($"Unknown step: '{step}'.")
+    };
+
+    public virtual string? GetNextStep(string currentStep) => currentStep switch
+    {
+        Steps.Email => Steps.EmailConfirmation,
+        _ => null
+    };
+
+    public virtual string? GetPreviousStep(string currentStep) => currentStep switch
+    {
+        Steps.EmailConfirmation => Steps.Email,
+        _ => null
+    };
+
+    public virtual bool CanAccessStep(string step) => step switch
+    {
+        Steps.Email => !AuthenticationState.EmailAddressVerified,
+        Steps.EmailConfirmation => !AuthenticationState.EmailAddressVerified && AuthenticationState.EmailAddressSet,
+        _ => false
+    };
+
+    public virtual string GetLastAccessibleStep()
+    {
+        // This is used when the user tries to access a page in the journey that's not accessible.
+        // We want to redirect them somewhere valid for the journey but we don't have a current step
+        // to invoke GetNextStep() with.
+        //
+        // Find the final step in the journey that's accessible and return that.
+
+        var step = GetStartStep();
+
+        while (true)
+        {
+            var nextStep = GetNextStep(step);
+
+            if (nextStep is null)
+            {
+                break;
+            }
+
+            step = nextStep;
+        }
+
+        // step is now the final step in journey. Walk backwards until we find a step that's accessible.
+
+        while (!CanAccessStep(step))
+        {
+            step = GetPreviousStep(step);
+
+            if (step is null)
+            {
+                throw new InvalidOperationException("Journey has no available steps.");
+            }
+        }
+
+        return GetStepUrl(step);
+    }
+
+    public string GetStartStepUrl() => GetStepUrl(GetStartStep());
+
+    public string GetNextStepUrl(string currentStep)
+    {
+        if (IsFinished())
+        {
+            return AuthenticationState.PostSignInUrl;
+        }
+
+        var nextStep = GetNextStep(currentStep) ??
+            throw new InvalidOperationException($"Journey has no next step (current step: '{currentStep}').");
+
+        if (!CanAccessStep(nextStep))
+        {
+            throw new InvalidOperationException($"Next step is not accessible (step: '{nextStep}').");
+        }
+
+        return GetStepUrl(nextStep);
+    }
+
+    public string GetPreviousStepUrl(string currentStep)
+    {
+        var previousStep = GetPreviousStep(currentStep) ??
+            throw new InvalidOperationException($"Journey has no previous step (current step: '{currentStep}').");
+
+        if (!CanAccessStep(previousStep))
+        {
+            throw new InvalidOperationException($"Previous step is not accessible (step: '{previousStep}').");
+        }
+
+        return GetStepUrl(previousStep);
+    }
+
+    public Task<IActionResult> OnEmailVerified(User? user)
+    {
+        if (!CanAccessStep(Steps.EmailConfirmation))
+        {
+            throw new InvalidOperationException("Email cannot be verified at this time.");
+        }
+
+        return OnEmailVerifiedCore(user);
+    }
+
+    protected abstract Task<IActionResult> OnEmailVerifiedCore(User? user);
+
+    public static class Steps
+    {
+        public const string Email = $"{nameof(SignInJourney)}.{nameof(Email)}";
+        public const string EmailConfirmation = $"{nameof(SignInJourney)}.{nameof(EmailConfirmation)}";
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/SignInJourneyProvider.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/SignInJourneyProvider.cs
@@ -1,0 +1,47 @@
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Oidc;
+
+namespace TeacherIdentity.AuthServer.Journeys;
+
+public class SignInJourneyProvider
+{
+    public SignInJourney GetSignInJourneyState(AuthenticationState authenticationState, HttpContext httpContext)
+    {
+        if (authenticationState.TryGetOAuthState(out var oAuthState) && oAuthState.RequiresTrnLookup)
+        {
+            var useLegacyTrnJourney = oAuthState.TrnRequirementType == TrnRequirementType.Legacy || oAuthState.HasScope(CustomScopes.Trn);
+
+            return useLegacyTrnJourney ?
+                ActivatorUtilities.CreateInstance<LegacyTrnJourney>(httpContext.RequestServices, authenticationState, httpContext) :
+                ActivatorUtilities.CreateInstance<CoreSignInJourneyWithTrnLookup>(httpContext.RequestServices, authenticationState, httpContext);
+        }
+
+        if (authenticationState.UserRequirements.HasFlag(UserRequirements.StaffUserType))
+        {
+            return ActivatorUtilities.CreateInstance<StaffSignInJourney>(httpContext.RequestServices, authenticationState, httpContext);
+        }
+
+        return ActivatorUtilities.CreateInstance<CoreSignInJourney>(httpContext.RequestServices, authenticationState, httpContext);
+    }
+}
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddSignInJourneyStateProvider(this IServiceCollection services)
+    {
+        services.AddSingleton<SignInJourneyProvider>();
+
+        services.AddTransient<SignInJourney>(sp =>
+        {
+            var provider = sp.GetRequiredService<SignInJourneyProvider>();
+            var httpContextAccessor = sp.GetRequiredService<IHttpContextAccessor>();
+
+            var httpContext = httpContextAccessor.HttpContext ?? throw new InvalidOperationException("No current HttpContext");
+            var authenticationState = httpContext.GetAuthenticationState();
+
+            return provider.GetSignInJourneyState(authenticationState, httpContext);
+        });
+
+        return services;
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/StaffSignInJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/StaffSignInJourney.cs
@@ -5,11 +5,8 @@ namespace TeacherIdentity.AuthServer.Journeys;
 
 public class StaffSignInJourney : SignInJourney
 {
-    public StaffSignInJourney(
-        AuthenticationState authenticationState,
-        HttpContext httpContext,
-        IdentityLinkGenerator linkGenerator)
-        : base(authenticationState, httpContext, linkGenerator)
+    public StaffSignInJourney(HttpContext httpContext, IdentityLinkGenerator linkGenerator)
+        : base(httpContext, linkGenerator)
     {
     }
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/StaffSignInJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/StaffSignInJourney.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Mvc;
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.Journeys;
+
+public class StaffSignInJourney : SignInJourney
+{
+    public StaffSignInJourney(
+        AuthenticationState authenticationState,
+        HttpContext httpContext,
+        IdentityLinkGenerator linkGenerator)
+        : base(authenticationState, httpContext, linkGenerator)
+    {
+    }
+
+    public override bool IsFinished()
+    {
+        throw new NotImplementedException();
+    }
+
+    protected override Task<IActionResult> OnEmailVerifiedCore(User? user)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/StaffSignInJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/StaffSignInJourney.cs
@@ -13,6 +13,31 @@ public class StaffSignInJourney : SignInJourney
     {
     }
 
+    public override bool CanAccessStep(string step)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override string? GetNextStep(string currentStep)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override string? GetPreviousStep(string currentStep)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override string GetStartStep()
+    {
+        throw new NotImplementedException();
+    }
+
+    public override string GetStepUrl(string step)
+    {
+        throw new NotImplementedException();
+    }
+
     public override bool IsFinished()
     {
         throw new NotImplementedException();

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnLookupJourneyBase.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnLookupJourneyBase.cs
@@ -1,0 +1,12 @@
+namespace TeacherIdentity.AuthServer.Journeys;
+
+public abstract class TrnLookupJourneyBase : SignInJourney
+{
+    protected TrnLookupJourneyBase(
+        AuthenticationState authenticationState,
+        HttpContext httpContext,
+        IdentityLinkGenerator linkGenerator)
+        : base(authenticationState, httpContext, linkGenerator)
+    {
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnLookupJourneyBase.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnLookupJourneyBase.cs
@@ -2,11 +2,8 @@ namespace TeacherIdentity.AuthServer.Journeys;
 
 public abstract class TrnLookupJourneyBase : SignInJourney
 {
-    protected TrnLookupJourneyBase(
-        AuthenticationState authenticationState,
-        HttpContext httpContext,
-        IdentityLinkGenerator linkGenerator)
-        : base(authenticationState, httpContext, linkGenerator)
+    protected TrnLookupJourneyBase(HttpContext httpContext, IdentityLinkGenerator linkGenerator)
+        : base(httpContext, linkGenerator)
     {
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
@@ -34,6 +34,7 @@ using TeacherIdentity.AuthServer.Infrastructure.Filters;
 using TeacherIdentity.AuthServer.Infrastructure.ModelBinding;
 using TeacherIdentity.AuthServer.Infrastructure.Security;
 using TeacherIdentity.AuthServer.Infrastructure.Swagger;
+using TeacherIdentity.AuthServer.Journeys;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Notifications;
 using TeacherIdentity.AuthServer.Oidc;
@@ -494,7 +495,8 @@ public class Program
             .AddTransient<UserClaimHelper>()
             .AddSingleton(
                 new QueryStringSignatureHelper(
-                    builder.Configuration["QueryStringSignatureKey"] ?? throw new Exception("QueryStringSignatureKey missing from configuration.")));
+                    builder.Configuration["QueryStringSignatureKey"] ?? throw new Exception("QueryStringSignatureKey missing from configuration.")))
+            .AddSignInJourneyStateProvider();
 
         builder.Services.AddNotifications(builder.Environment, builder.Configuration);
 


### PR DESCRIPTION
Today there are many places where we handle sign in journey orchestration; `AuthenticationState` holds all state for the journey and has _some_ routing knowledge. Individual pages, for the most part, know where to go next and where to go back to. On top of this we have a variety of filters - `RequireAuthenticationMilestoneAttribute`, `CheckUserRequirementsForTrnJourneyFilterFactory` and many overrides of `OnPageHandlerExecuting()` in individual pages that check that the user is allowed to access the current page. These filters aren't super consistent either; sometimes we redirect users to an available page and sometimes we return a `400` error.

It would be nice to move this orchestration logic to somewhere central so that we can get more consistency and remove repetition.

This PR proposes an abstraction for managing sign in journeys - `SignInJourney`. There's also a `SignInJourneyProvider` which gets a `SignInJourney` given an `AuthenticationState`. I've added stub classes for the current journeys we support too.

Each journey implements its own class inheriting from `SignInJourney`. This class exposes the following capabilities:
- the start step for the journey;
- whether the journey is finished;
- the next step in the journey, given the current page;
- the previous step in the journey, given the current page;
- whether a given step is accessible given the state of the journey;
- the last accessible step given the state of the journey.

With this we can simplify a lot:
- All the filters mentioned above and `OnPageHandlerExecuting()` implementations that check if the current page is accessible can be replaced with a single attribute - `CheckCanAccessStepAttribute` - that delegates to the journey's `CanAccessStep` method. This will work even if the page is used in multiple journeys and the logic for its availability differs between journeys.
- Logic that is common over multiple journeys can be put into the appropriate base class (e.g. creating a user, looking up a TRN).

The following types/methods could ultimately get removed if we rolled this out everywhere:
- `AuthenticationJourneyType`
- `AuthenticationMilestone`
- `AuthenticationState.GetNextHopUrl()`
- `AuthenticationState.IsComplete()`

Ultimately it would be good to split up `AuthenticationState` into journey-specific state types as well and this provides some groundwork for doing that.