### PR TITLE
Back-port JSON test helper fixes from QT API

### DIFF
--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AssertEx.Http.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AssertEx.Http.cs
@@ -7,10 +7,7 @@ public static partial class AssertEx
 {
     public static async Task<JsonDocument> JsonResponse(HttpResponseMessage response, int expectedStatusCode = StatusCodes.Status200OK)
     {
-        if (response is null)
-        {
-            throw new ArgumentNullException(nameof(response));
-        }
+        ArgumentNullException.ThrowIfNull(response);
 
         Assert.Equal(expectedStatusCode, (int)response.StatusCode);
         Assert.Equal("application/json", response.Content.Headers.ContentType?.MediaType);
@@ -18,6 +15,16 @@ public static partial class AssertEx
         var result = await response.Content.ReadFromJsonAsync<JsonDocument>(SerializerOptions);
         Assert.NotNull(result);
         return result!;
+    }
+
+    public static async Task JsonResponseEquals(HttpResponseMessage response, object expected, int expectedStatusCode = StatusCodes.Status200OK)
+    {
+        ArgumentNullException.ThrowIfNull(response);
+        ArgumentNullException.ThrowIfNull(expected);
+
+        var jsonDocument = await JsonResponse(response, expectedStatusCode);
+
+        JsonObjectEquals(expected, jsonDocument);
     }
 
     public static async Task JsonResponseIsError(HttpResponseMessage response, int expectedErrorCode, int expectedStatusCode)
@@ -43,12 +50,24 @@ public static partial class AssertEx
         Assert.Equal(expectedError, problemDetails.Errors?[propertyName].Single());
     }
 
+    public static async Task JsonResponseHasValidationErrorsForProperties(
+        HttpResponseMessage response,
+        IReadOnlyDictionary<string, string> expectedErrors,
+        int expectedStatusCode = 400)
+    {
+        var problemDetails = await ResponseIsProblemDetails(response, expectedStatusCode);
+
+        Assert.NotNull(problemDetails.Extensions);
+
+        foreach (var e in expectedErrors)
+        {
+            Assert.Equal(e.Value, problemDetails.Errors?[e.Key].Single());
+        }
+    }
+
     private static async Task<ProblemDetails> ResponseIsProblemDetails(HttpResponseMessage response, int expectedStatusCode)
     {
-        if (response is null)
-        {
-            throw new ArgumentNullException(nameof(response));
-        }
+        ArgumentNullException.ThrowIfNull(response);
 
         Assert.Equal(expectedStatusCode, (int)response.StatusCode);
         Assert.Equal("application/problem+json", response.Content.Headers.ContentType?.MediaType);
@@ -64,8 +83,23 @@ public static partial class AssertEx
     {
         public string? Title { get; set; }
         public int Status { get; set; }
+        [JsonConverter(typeof(ProblemDetailsErrorJsonConverter))]
         public IDictionary<string, string[]>? Errors { get; set; }
         [JsonExtensionData]
         public IDictionary<string, JsonElement>? Extensions { get; set; }
+    }
+
+    private class ProblemDetailsErrorJsonConverter : JsonConverter<IDictionary<string, string[]>>
+    {
+        public override IDictionary<string, string[]>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var dic = (Dictionary<string, string[]>)JsonSerializer.Deserialize(ref reader, typeToConvert, options)!;
+            return new Dictionary<string, string[]>(dic, StringComparer.OrdinalIgnoreCase);
+        }
+
+        public override void Write(Utf8JsonWriter writer, IDictionary<string, string[]> value, JsonSerializerOptions options)
+        {
+            throw new NotSupportedException();
+        }
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AssertEx.Json.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AssertEx.Json.cs
@@ -8,126 +8,133 @@ namespace TeacherIdentity.AuthServer.Tests;
 
 public static partial class AssertEx
 {
-    public static JsonSerializerOptions SerializerOptions { get; } = new JsonSerializerOptions()
+    public static JsonSerializerOptions SerializerOptions { get; } = new JsonSerializerOptions(JsonSerializerDefaults.Web)
     {
         Converters =
         {
             new JsonStringEnumConverter()
-        },
-        PropertyNameCaseInsensitive = true
+        }
     };
 
     public static void JsonEquals(string expected, string actual) =>
         JsonEquals(JsonNode.Parse(expected), JsonNode.Parse(actual));
 
     public static void JsonObjectEquals(JsonDocument expected, object actual) =>
-        JsonEquals(JsonSerializer.SerializeToNode(expected.RootElement), JsonSerializer.SerializeToNode(actual, SerializerOptions));
+        JsonEquals(JsonSerializer.SerializeToNode(expected.RootElement, SerializerOptions), JsonSerializer.SerializeToNode(actual, SerializerOptions));
 
     public static void JsonObjectEquals(object expected, object actual) =>
         JsonEquals(JsonSerializer.SerializeToNode(expected, SerializerOptions), JsonSerializer.SerializeToNode(actual, SerializerOptions));
 
     public static void JsonEquals(JsonNode? expected, JsonNode? actual)
     {
-        if (expected is null && actual is null)
-        {
-            return;
-        }
-        else if (expected is null && actual is not null)
-        {
-            var path = GetPrintablePath(expected?.GetPath());
-            throw new JsonNotEqualException($"JSON not equal:\nExpected: null\nActual: <not null>\nPath: {path}");
-        }
-        else if (expected is not null && actual is null)
-        {
-            var path = GetPrintablePath(expected?.GetPath());
-            throw new JsonNotEqualException($"JSON not equal:\nExpected: <not null>\nActual: null\nPath: {path}");
-        }
+        Core(expected, actual, pathHint: null);
 
-        Debug.Assert(expected is not null);
-        Debug.Assert(actual is not null);
-
-        if (expected is JsonValue expectedJValue)
+        static void Core(JsonNode? expected, JsonNode? actual, string? pathHint)
         {
-            if (actual is not JsonValue actualJValue)
+            if (expected is null && actual is null)
             {
-                ThrowMismatchedTypeException("JsonValue", actual.GetType().Name, GetPrintablePath(expected.GetPath()));
+                return;
+            }
+            else if (expected is null && actual is not null)
+            {
+                var path = GetPrintablePath(expected?.GetPath());
+                throw new JsonNotEqualException($"JSON not equal:\nExpected: null\nActual: <not null>\nPath: {path}");
+            }
+            else if (expected is not null && actual is null)
+            {
+                var path = GetPrintablePath(expected?.GetPath());
+                throw new JsonNotEqualException($"JSON not equal:\nExpected: <not null>\nActual: null\nPath: {path}");
             }
 
-            // We don't care if the types are different, only if the generated JSON is different
-            var expectedValue = expectedJValue.ToString();
-            var actualValue = actualJValue.ToString();
+            Debug.Assert(expected is not null);
+            Debug.Assert(actual is not null);
 
-            if (StringComparer.Ordinal.Compare(expectedValue, actualValue) != 0)
+            if (expected is JsonValue expectedJValue)
             {
-                ThrowNotEqualException(expectedValue, actualValue, GetPrintablePath(expected.GetPath()));
-            }
-        }
-        else if (expected is JsonArray expectedJArray)
-        {
-            if (actual is not JsonArray actualJArray)
-            {
-                ThrowMismatchedTypeException("JsonArray", actual.GetType().Name, GetPrintablePath(expected.GetPath()));
-            }
-
-            if (expectedJArray.Count != actualJArray.Count)
-            {
-                throw new JsonNotEqualException(
-                    $"JSON not equal\nExpected {expectedJArray.Count} elements\nGot: {actualJArray.Count}\nPath: {GetPrintablePath(expected.GetPath())}");
-            }
-
-            for (var i = 0; i < expectedJArray.Count; i++)
-            {
-                var expectedElement = expectedJArray[i]!;
-                var actualElement = actualJArray[i]!;
-
-                JsonEquals(expectedElement, actualElement);
-            }
-        }
-        else if (expected is JsonObject expectedJObject)
-        {
-            if (actual is not JsonObject actualJObject)
-            {
-                ThrowMismatchedTypeException("JsonObject", actual.GetType().Name, GetPrintablePath(expected.GetPath()));
-            }
-
-            // Compare each property on `expected` with `actual`
-            foreach (var (name, expectedProp) in (IDictionary<string, JsonNode?>)expectedJObject)
-            {
-                var actualProp = actualJObject[name];
-                if (actualProp == null)
+                if (actual is not JsonValue actualJValue)
                 {
-                    throw new JsonNotEqualException(
-                        $"JSON not equal\nMissing property: '{name}'\nPath: {GetPrintablePath(expected.GetPath())}");
+                    ThrowMismatchedTypeException("JsonValue", actual.GetType().Name, GetPrintablePath(expected.GetPath()));
                 }
 
-                JsonEquals(expectedProp, actualProp);
-            }
+                // We don't care if the types are different, only if the generated JSON is different
+                var expectedValue = expectedJValue.ToString();
+                var actualValue = actualJValue.ToString();
 
-            // Check `actual` doesn't have extra properties over `expected`
-            foreach (var (name, actualProp) in (IDictionary<string, JsonNode?>)actualJObject)
-            {
-                var expectedProp = expectedJObject[name];
-                if (expectedProp == null)
+                if (StringComparer.Ordinal.Compare(expectedValue, actualValue) != 0)
                 {
-                    throw new JsonNotEqualException(
-                        $"JSON not equal\nExtra property {name}\nPath: {GetPrintablePath(expected.GetPath())}");
+                    ThrowNotEqualException(expectedValue, actualValue, GetPrintablePath(expected.GetPath()));
                 }
             }
+            else if (expected is JsonArray expectedJArray)
+            {
+                if (actual is not JsonArray actualJArray)
+                {
+                    ThrowMismatchedTypeException("JsonArray", actual.GetType().Name, GetPrintablePath(expected.GetPath()));
+                }
+
+                if (expectedJArray.Count != actualJArray.Count)
+                {
+                    throw new JsonNotEqualException(
+                        $"JSON not equal\nExpected {expectedJArray.Count} elements\nGot: {actualJArray.Count}\nPath: {GetPrintablePath(expected.GetPath())}");
+                }
+
+                for (var i = 0; i < expectedJArray.Count; i++)
+                {
+                    var expectedElement = expectedJArray[i]!;
+                    var actualElement = actualJArray[i]!;
+
+                    Core(expectedElement, actualElement, expectedElement.GetPath());
+                }
+            }
+            else if (expected is JsonObject expectedJObject)
+            {
+                if (actual is not JsonObject actualJObject)
+                {
+                    ThrowMismatchedTypeException("JsonObject", actual.GetType().Name, GetPrintablePath(expected.GetPath()));
+                }
+
+                // Compare each property on `expected` with `actual`
+                foreach (var (name, expectedProp) in (IDictionary<string, JsonNode?>)expectedJObject)
+                {
+                    if (!actualJObject.ContainsKey(name))
+                    {
+                        throw new JsonNotEqualException(
+                            $"JSON not equal\nActual is missing property: '{name}'\nPath: {GetPrintablePath(expected.GetPath())}");
+                    }
+
+                    var actualProp = actualJObject[name];
+                    Core(expectedProp, actualProp, $"{expected.GetPath()}.{name}");
+                }
+
+                // Check `actual` doesn't have extra properties over `expected`
+                foreach (var (name, actualProp) in (IDictionary<string, JsonNode?>)actualJObject)
+                {
+                    if (!expectedJObject.ContainsKey(name))
+                    {
+                        throw new JsonNotEqualException(
+                            $"JSON not equal\nActual has extra property '{name}'\nPath: {GetPrintablePath(expected.GetPath())}");
+                    }
+                }
+            }
+            else
+            {
+                throw new NotSupportedException($"Don't know how to compare JTokens of type '{expected.GetType().Name}'.");
+            }
+
+            string GetPrintablePath(string? path) => !string.IsNullOrEmpty(path) ?
+                path :
+                !string.IsNullOrEmpty(pathHint) ?
+                pathHint :
+                "(root)";
+
+            [DoesNotReturn]
+            void ThrowNotEqualException(string expectedValue, string actualValue, string path) =>
+                throw new JsonNotEqualException($"JSON not equal:\nExpected: {expectedValue}\nActual: {actualValue}\nPath: {path}");
+
+            [DoesNotReturn]
+            void ThrowMismatchedTypeException(string expectedType, string actualType, string path) =>
+                throw new JsonNotEqualException($"Token types not equal\nExpected: {expectedType}\nActual: {actualType}\nPath: {path}");
         }
-        else
-        {
-            throw new NotSupportedException($"Don't know how to compare JTokens of type '{expected.GetType().Name}'.");
-        }
-
-        string GetPrintablePath(string? path) => string.IsNullOrEmpty(path) ? "(root)" : path;
-
-        [DoesNotReturn]
-        void ThrowNotEqualException(string expectedValue, string actualValue, string path) =>
-            throw new JsonNotEqualException($"JSON not equal:\nExpected: {expectedValue}\nActual: {actualValue}\nPath: {path}");
-
-        [DoesNotReturn]
-        void ThrowMismatchedTypeException(string expectedType, string actualType, string path) =>
-            throw new JsonNotEqualException($"Token types not equal\nExpected: {expectedType}\nActual: {actualType}\nPath: {path}");
     }
 
     public class JsonNotEqualException : Exception

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/TrnTokens/PostTrnTokenTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/TrnTokens/PostTrnTokenTests.cs
@@ -2,7 +2,6 @@ using System.Text;
 using Microsoft.EntityFrameworkCore;
 using Newtonsoft.Json;
 using TeacherIdentity.AuthServer.Api.V1.Requests;
-using TeacherIdentity.AuthServer.Api.V1.Responses;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Api.V1.TrnTokens;
 
@@ -116,11 +115,9 @@ public class PostTrnTokenTests : TestBase
         var response = await ApiKeyHttpClient.PostAsync("/api/v1/trn-tokens", content);
 
         // Assert
-        var trnTokenResponse = JsonConvert.DeserializeObject<PostTrnTokenResponse>(await response.Content.ReadAsStringAsync());
-
-        Assert.NotNull(trnTokenResponse);
-        Assert.Equal(trnTokenResponse.Trn, trnTokenRequest.Trn);
-        Assert.Equal(trnTokenResponse.Email, trnTokenRequest.Email);
-        Assert.NotNull(trnTokenResponse.TrnToken);
+        var jsonResponse = await AssertEx.JsonResponse(response);
+        Assert.Equal(trnTokenRequest.Trn, jsonResponse.RootElement.GetProperty("trn").GetString());
+        Assert.Equal(trnTokenRequest.Email, jsonResponse.RootElement.GetProperty("email").GetString());
+        Assert.NotNull(jsonResponse.RootElement.GetProperty("trnToken").GetString());
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/Users/GetUserDetailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/Users/GetUserDetailTests.cs
@@ -53,10 +53,8 @@ public class GetUserDetailTests : TestBase
         var response = await httpClient.GetAsync($"/api/v1/users/{mergedUser.UserId}");
 
         // Assert
-        var responseObj = await AssertEx.JsonResponse(response);
-
-        AssertEx.JsonObjectEquals(
-            responseObj,
+        await AssertEx.JsonResponseEquals(
+            response,
             new
             {
                 userId = user.UserId,
@@ -88,10 +86,8 @@ public class GetUserDetailTests : TestBase
         var response = await httpClient.GetAsync($"/api/v1/users/{user.UserId}");
 
         // Assert
-        var responseObj = await AssertEx.JsonResponse(response);
-
-        AssertEx.JsonObjectEquals(
-            responseObj,
+        await AssertEx.JsonResponseEquals(
+            response,
             new
             {
                 userId = user.UserId,


### PR DESCRIPTION
QT API recently moved to `System.Text.Json` for its tests and I ported the helper methods from here to do that. In the process one small bug was fixed and a few improvements were made. This back-ports those changes.