### PR TITLE
Port the validation of email addresses from Notify

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/DataAnnotationsExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/DataAnnotationsExtensions.cs
@@ -109,6 +109,15 @@ public class MobilePhoneAttribute : ValidationAttribute
 }
 
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
+public class EmailAddressAttribute : ValidationAttribute
+{
+    public override bool IsValid(object? value)
+    {
+        return value is string str && EmailAddress.TryParse(str, out _);
+    }
+}
+
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
 public class NationalInsuranceNumber : ValidationAttribute
 {
     public override bool IsValid(object? value)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/EmailAddress.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/EmailAddress.cs
@@ -1,0 +1,157 @@
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace TeacherIdentity.AuthServer.Models;
+
+/// <summary>
+/// Represents a valid mobile phone number that can be sent messages via Notify.
+/// </summary>
+[DebuggerDisplay("{_normalizedValue}")]
+public sealed class EmailAddress : IEquatable<EmailAddress>, IParsable<EmailAddress>
+{
+    private const string ValidLocalChars = @"a-zA-Z0-9.!#$%&'*+/=?^_`{|}~\-";
+    private const string EmailRegexPattern = @"^[" + ValidLocalChars + @"]+@([^.@][^@\s]+)$";
+
+    private const string ObscureZeroWidthWhitespace = "\u180E\u200B\u200C\u200D\u2060\uFEFF";
+    private const string ObscureFullWidthWhitespace = "\u00A0\u202F";
+
+    private static readonly Regex _hostnamePartRegex = new Regex(@"^(xn|[a-z0-9]+)(-?-[a-z0-9]+)*$", RegexOptions.IgnoreCase);
+    private static readonly Regex _tldPartRegex = new Regex(@"^([a-z]{2,63}|xn--([a-z0-9]+-)*[a-z0-9]+)$", RegexOptions.IgnoreCase);
+
+    private readonly string _normalizedValue;
+
+    private EmailAddress(string normalizedValue)
+    {
+        _normalizedValue = normalizedValue;
+    }
+
+    public static EmailAddress Parse(string emailAddress)
+    {
+        if (!TryParseCore(emailAddress, out var result, out var error))
+        {
+            throw error;
+        }
+
+        return result;
+    }
+
+    public static bool TryParse(string emailAddress, [MaybeNullWhen(false)] out EmailAddress result) =>
+        TryParseCore(emailAddress, out result, out _);
+
+    static EmailAddress IParsable<EmailAddress>.Parse(string s, IFormatProvider? provider) => Parse(s);
+
+    static bool IParsable<EmailAddress>.TryParse(
+        string? s,
+        IFormatProvider? provider,
+        [MaybeNullWhen(false)] out EmailAddress result)
+    {
+        if (s is null)
+        {
+            result = null;
+            return false;
+        }
+
+        return TryParse(s, out result);
+    }
+
+    private static bool TryParseCore(
+        string emailAddress,
+        [MaybeNullWhen(false)] out EmailAddress result,
+        [MaybeNullWhen(true)] out FormatException error)
+    {
+        var normalizedEmailAddress = StripAndRemoveObscureWhitespace(emailAddress);
+        Match match = Regex.Match(normalizedEmailAddress, EmailRegexPattern);
+
+        if (normalizedEmailAddress.Length > 320)
+        {
+            error = new FormatException("Email address too long.");
+            result = default;
+            return false;
+        }
+
+        // not an email
+        if (!match.Success || normalizedEmailAddress.Contains(".."))
+        {
+            error = new FormatException("Not a valid email address.");
+            result = default;
+            return false;
+        }
+
+        string hostname = match.Groups[1].Value;
+
+        // idna = "Internationalized domain name" - this mapping converts unicode into its accurate ascii
+        // representation as the web uses. '例え.テスト'.encode('idna') == b'xn--r8jz45g.xn--zckzah'
+        try
+        {
+            hostname = new IdnMapping().GetAscii(hostname);
+        }
+        catch (ArgumentException)
+        {
+            error = new FormatException("Failed to convert to ASCII representation.");
+            result = default;
+            return false;
+        }
+
+        string[] parts = hostname.Split('.');
+
+        if (hostname.Length > 253 || parts.Length < 2)
+        {
+            error = new FormatException("Hostname invalid length.");
+            result = default;
+            return false;
+        }
+
+        foreach (string part in parts)
+        {
+            if (string.IsNullOrEmpty(part) || part.Length > 63 || !_hostnamePartRegex.IsMatch(part))
+            {
+                error = new FormatException("Invalid hostname.");
+                result = default;
+                return false;
+            }
+        }
+
+        // if the part after the last . is not a valid TLD then bail out
+        if (!_tldPartRegex.IsMatch(parts[^1]))
+        {
+            error = new FormatException("Invalid top level domain");
+            result = default;
+            return false;
+        }
+
+        result = new EmailAddress(normalizedEmailAddress);
+        error = default;
+        return true;
+
+        static string StripAndRemoveObscureWhitespace(string value)
+        {
+            if (value == "")
+            {
+                return "";
+            }
+
+            foreach (char character in ObscureZeroWidthWhitespace + ObscureFullWidthWhitespace)
+            {
+                value = value.Replace(character.ToString(), "");
+            }
+
+            return value.Trim();
+        }
+    }
+
+    public bool Equals(EmailAddress? other) => other is not null && _normalizedValue.Equals(other._normalizedValue);
+
+    public override bool Equals([NotNullWhen(true)] object? obj) => obj is EmailAddress other && Equals(other);
+
+    public override int GetHashCode() => _normalizedValue.GetHashCode();
+
+    public override string ToString() => _normalizedValue;
+
+    public static bool operator ==(EmailAddress left, EmailAddress right) =>
+        (left is null && right is null) ||
+        (left is not null && right is not null && left.Equals(right));
+
+    public static bool operator !=(EmailAddress left, EmailAddress right) => !(left == right);
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/MobileNumber.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/MobileNumber.cs
@@ -328,7 +328,7 @@ public sealed class MobileNumber : IEquatable<MobileNumber>, IParsable<MobileNum
             return false;
         }
 
-        result = new(normalizedNumber);
+        result = new MobileNumber(normalizedNumber);
         error = default;
         return true;
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/ModelTests/EmailAddressTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/ModelTests/EmailAddressTests.cs
@@ -1,0 +1,119 @@
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.Tests.ModelTests;
+
+public class EmailAddressTests
+{
+    [Theory]
+    [MemberData(nameof(ValidEmailAddresses))]
+    public void TryParse_ValidEmailAddress_ReturnsTrue(string emailAddress)
+    {
+        // Arrange
+
+        // Act
+        var valid = EmailAddress.TryParse(emailAddress, out var parsedEmailAddress);
+
+        // Assert
+        Assert.True(valid);
+        Assert.NotNull(parsedEmailAddress);
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidEmailAddresses))]
+    public void TryParse_InvalidEmailAddress_ReturnsFalse(string emailAddress)
+    {
+        // Arrange
+
+        // Act
+        var valid = EmailAddress.TryParse(emailAddress, out var parsedEmailAddress);
+
+        // Assert
+        Assert.False(valid);
+        Assert.Null(parsedEmailAddress);
+    }
+
+    [Theory]
+    [MemberData(nameof(ValidEmailAddresses))]
+    public void Parse_ValidEmailAddress_ReturnsInstance(string emailAddress)
+    {
+        // Arrange
+
+        // Act
+        var parsedEmailAddress = EmailAddress.Parse(emailAddress);
+
+        // Assert
+        Assert.NotNull(parsedEmailAddress);
+    }
+
+    [Theory]
+    [MemberData(nameof(InvalidEmailAddresses))]
+    public void Parse_InvalidEmailAddress_ThrowsFormatException(string emailAddress)
+    {
+        // Arrange
+
+        // Act
+        var ex = Record.Exception(() => EmailAddress.Parse(emailAddress));
+
+        // Assert
+        Assert.IsType<FormatException>(ex);
+    }
+
+    public static IEnumerable<object[]> ValidEmailAddresses => _validEmailAddresses.Select(n => new object[] { n });
+
+    public static IEnumerable<object[]> InvalidEmailAddresses => _invalidEmailAddresses.Select(n => new object[] { n });
+
+    private static readonly string[] _validEmailAddresses = new[]
+    {
+        "email@domain.com",
+        "email@domain.COM",
+        "firstname.lastname@domain.com",
+        "firstname.o'lastname@domain.com",
+        "email@subdomain.domain.com",
+        "firstname+lastname@domain.com",
+        "1234567890@domain.com",
+        "email@domain-one.com",
+        "_______@domain.com",
+        "email@domain.name",
+        "email@domain.superlongtld",
+        "email@domain.co.jp",
+        "firstname-lastname@domain.com",
+        "info@german-financial-services.vermögensberatung",
+        "info@german-financial-services.reallylongarbitrarytldthatiswaytoohugejustincase",
+        "japanese-info@例え.テスト",
+        "email@double--hyphen.com",
+    };
+
+    private static readonly string[] _invalidEmailAddresses = new[]
+    {
+        "email@123.123.123.123",
+        "email@[123.123.123.123]",
+        "plainaddress",
+        "@no-local-part.com",
+        "Outlook Contact <outlook-contact@domain.com>",
+        "no-at.domain.com",
+        "no-tld@domain",
+        ";beginning-semicolon@domain.co.uk",
+        "middle-semicolon@domain.co;uk",
+        "trailing-semicolon@domain.com;",
+        "\"email+leading-quotes@domain.com",
+        "email+middle\"-quotes@domain.com",
+        "\"quoted-local-part\"@domain.com",
+        "\"quoted@domain.com\"",
+        "lots-of-dots@domain..gov..uk",
+        "two-dots..in-local@domain.com",
+        "multiple@domains@domain.com",
+        "spaces in local@domain.com",
+        "spaces-in-domain@dom ain.com",
+        "underscores-in-domain@dom_ain.com",
+        "pipe-in-domain@example.com|gov.uk",
+        "comma,in-local@gov.uk",
+        "comma-in-domain@domain,gov.uk",
+        "pound-sign-in-local£@domain.com",
+        "local-with-’-apostrophe@domain.com",
+        "local-with-”-quotes@domain.com",
+        "domain-starts-with-a-dot@.domain.com",
+        "brackets(in)local@domain.com",
+        $"email-too-long-{new string('a', 320)}@example.com",
+        "incorrect-punycode@xn---something.com",
+    };
+}


### PR DESCRIPTION
### Context

Our current email validation is fairly loose (the built-in [ASP.NET](http://asp.net/) Core email validation) and we treat some emails as valid even though Notify does not. If we can’t actually email a particular email address then it’s no use to us.

### Changes proposed in this pull request

Port the email validation from Notify and use it to create an EmailAddress type (similar to MobileNumber).

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
