### PR TITLE
Use STJ for webhook message serialization

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/Json/Modifiers.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/Json/Modifiers.cs
@@ -1,0 +1,48 @@
+using System.Linq.Expressions;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
+using Optional;
+
+namespace TeacherIdentity.AuthServer.Infrastructure.Json;
+
+public static class Modifiers
+{
+    /// <summary>
+    /// Only serialize Option<T> properties if they have a value.
+    /// </summary>
+    public static void OptionProperties(JsonTypeInfo typeInfo)
+    {
+        if (typeInfo.Kind != JsonTypeInfoKind.Object)
+        {
+            return;
+        }
+
+        foreach (var property in typeInfo.Properties)
+        {
+            var isOptionType = property.PropertyType?.IsGenericType == true &&
+                property.PropertyType.GetGenericTypeDefinition() == typeof(Option<>);
+
+            if (isOptionType)
+            {
+                var underlyingType = property.PropertyType!.GenericTypeArguments[0];
+
+                property.ShouldSerialize = CreateShouldSerializePredicate(property.PropertyType);
+                property.CustomConverter = (JsonConverter)Activator.CreateInstance(typeof(OptionJsonConverter<>).MakeGenericType(underlyingType))!;
+            }
+        }
+
+        static Func<object, object?, bool> CreateShouldSerializePredicate(Type propertyType)
+        {
+            var parentParameter = Expression.Parameter(typeof(object));
+            var propertyParameter = Expression.Parameter(typeof(object));
+
+            return (Func<object, object?, bool>)Expression.Lambda(
+                typeof(Func<object, object?, bool>),
+                body: Expression.Property(
+                    Expression.Convert(propertyParameter, propertyType),
+                    "HasValue"),
+                parentParameter,
+                propertyParameter).Compile();
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/Json/OptionJsonConverter.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/Json/OptionJsonConverter.cs
@@ -1,0 +1,22 @@
+using System.Diagnostics;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Optional;
+using Optional.Unsafe;
+
+namespace TeacherIdentity.AuthServer.Infrastructure.Json;
+
+public class OptionJsonConverter<T> : JsonConverter<Option<T>>
+{
+    public override Option<T> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        var asT = JsonSerializer.Deserialize<T>(ref reader, options)!;
+        return Option.Some(asT);
+    }
+
+    public override void Write(Utf8JsonWriter writer, Option<T> value, JsonSerializerOptions options)
+    {
+        Debug.Assert(value.HasValue);  // Modifier should ensure we only get here if there's a value
+        JsonSerializer.Serialize<T>(writer, value.ValueOrFailure(), options);
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Notifications/WebHooks/WebHookNotificationPublisher.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Notifications/WebHooks/WebHookNotificationPublisher.cs
@@ -1,13 +1,10 @@
-using System.Linq.Expressions;
-using System.Reflection;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json.Serialization.Metadata;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
-using Newtonsoft.Json.Serialization;
-using Optional;
-using Optional.Unsafe;
+using TeacherIdentity.AuthServer.Infrastructure.Json;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Notifications.Messages;
 
@@ -31,14 +28,20 @@ public class WebHookNotificationPublisher : INotificationPublisher
         _webHooksCacheLifetime = TimeSpan.FromSeconds(optionsAccessor.Value.WebHooksCacheDurationSeconds);
     }
 
-    protected static JsonSerializerSettings SerializerSettings { get; } = new JsonSerializerSettings()
+    protected static JsonSerializerOptions SerializerOptions { get; } = new JsonSerializerOptions(JsonSerializerDefaults.Web)
     {
         Converters =
         {
-            new StringEnumConverter(),
-            new DateOnlyJsonConverter()
+            new JsonStringEnumConverter(),
+            new NotificationMessageConverter()
         },
-        ContractResolver = new ContractResolver()
+        TypeInfoResolver = new DefaultJsonTypeInfoResolver()
+        {
+            Modifiers =
+            {
+                Modifiers.OptionProperties
+            }
+        }
     };
 
     protected IWebHookNotificationSender Sender { get; }
@@ -67,97 +70,18 @@ public class WebHookNotificationPublisher : INotificationPublisher
     }
 
     protected string SerializeNotification(NotificationEnvelope notification) =>
-        JsonConvert.SerializeObject(notification, SerializerSettings);
+        JsonSerializer.Serialize(notification, SerializerOptions);
 
-    private class ContractResolver : CamelCasePropertyNamesContractResolver
+    private class NotificationMessageConverter : JsonConverter<INotificationMessage>
     {
-        protected override JsonProperty CreateProperty(MemberInfo member, MemberSerialization memberSerialization)
+        public override INotificationMessage? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            var property = base.CreateProperty(member, memberSerialization);
-
-            // If the property is an Option<T> then only serialize it if it has a value
-            if (property.PropertyType?.IsGenericType == true && property.PropertyType.GetGenericTypeDefinition() == typeof(Option<>))
-            {
-                var innerType = property.PropertyType.GetGenericArguments()[0];
-                property.ShouldSerialize = CreateShouldSerializePredicate(member.DeclaringType!, innerType, property.PropertyName!);
-                property.Converter = (JsonConverter)Activator.CreateInstance(typeof(OptionJsonConverter<>).MakeGenericType(innerType))!;
-            }
-
-            return property;
+            throw new NotSupportedException();
         }
 
-        private static Predicate<object> CreateShouldSerializePredicate(Type objectType, Type innerPropertyType, string propertyName)
+        public override void Write(Utf8JsonWriter writer, INotificationMessage value, JsonSerializerOptions options)
         {
-            var objParameter = Expression.Parameter(typeof(object));
-
-            // Create a delegate that corresponds to:
-            // return ((Option<TProperty>)((T)object).Property).HasValue;
-
-            return (Predicate<object>)Expression.Lambda(
-                typeof(Predicate<object>),
-                Expression.Block(
-                    Expression.Property(
-                        Expression.Convert(
-                            Expression.Property(
-                                Expression.Convert(objParameter, objectType),
-                                propertyName
-                            ),
-                            typeof(Option<>).MakeGenericType(innerPropertyType)),
-                        "HasValue")),
-                objParameter).Compile();
-        }
-    }
-
-    private class OptionJsonConverter<T> : JsonConverter
-    {
-        public override bool CanConvert(Type objectType)
-        {
-            return objectType == typeof(Option<T>);
-        }
-
-        public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
-        {
-            var value = serializer.Deserialize<T>(reader);
-            return Option.Some(value);
-        }
-
-        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
-        {
-            // Note this will throw if HasValue is false, but we should never get here in that case
-            var option = (Option<T>)value!;
-            serializer.Serialize(writer, option.ValueOrFailure());
-        }
-    }
-
-    private class DateOnlyJsonConverter : JsonConverter
-    {
-        private const string Format = "yyyy-MM-dd";
-
-        public override bool CanConvert(Type objectType) => objectType == typeof(DateOnly) || objectType == typeof(DateOnly?);
-
-        public override object? ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
-        {
-            var asString = reader.ReadAsString();
-
-            if (asString is null)
-            {
-                return default;
-            }
-
-            return DateOnly.ParseExact(asString, Format);
-        }
-
-        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
-        {
-            if (value is null)
-            {
-                writer.WriteNull();
-            }
-            else
-            {
-                var asString = ((DateOnly)value).ToString(Format);
-                writer.WriteValue(asString);
-            }
+            JsonSerializer.Serialize(writer, value, value.GetType(), options);
         }
     }
 }


### PR DESCRIPTION
Ports the `Option<T>` serialization support to `System.Text.Json` and uses it for serializing webhook payloads.