### PR TITLE
Added support for web hook message types

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/Endpoints/SetJourneyTrnLookupStateRequestBody.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/Endpoints/SetJourneyTrnLookupStateRequestBody.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel.DataAnnotations;
-using Newtonsoft.Json;
 
 namespace TeacherIdentity.AuthServer.Api.Endpoints;
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Events/WebHookAddedEvent.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Events/WebHookAddedEvent.cs
@@ -1,3 +1,5 @@
+using TeacherIdentity.AuthServer.Models;
+
 namespace TeacherIdentity.AuthServer.Events;
 
 public record WebHookAddedEvent : EventBase
@@ -6,4 +8,5 @@ public record WebHookAddedEvent : EventBase
     public required Guid AddedByUserId { get; init; }
     public required string Endpoint { get; init; }
     public required bool Enabled { get; init; }
+    public required WebHookMessageTypes WebHookMessageTypes { get; init; }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Events/WebHookUpdatedEvent.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Events/WebHookUpdatedEvent.cs
@@ -1,3 +1,5 @@
+using TeacherIdentity.AuthServer.Models;
+
 namespace TeacherIdentity.AuthServer.Events;
 
 public record WebHookUpdatedEvent : EventBase
@@ -7,6 +9,7 @@ public record WebHookUpdatedEvent : EventBase
     public required WebHookUpdatedEventChanges Changes { get; init; }
     public required string Endpoint { get; init; }
     public required bool Enabled { get; init; }
+    public required WebHookMessageTypes WebHookMessageTypes { get; init; }
 }
 
 [Flags]
@@ -16,4 +19,5 @@ public enum WebHookUpdatedEventChanges
     Endpoint = 1 << 0,
     Enabled = 1 << 1,
     Secret = 1 << 2,
+    WebHookMessageTypes = 1 << 3
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/ModelBinding/WebHookMessageTypesModelBinder.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/ModelBinding/WebHookMessageTypesModelBinder.cs
@@ -15,16 +15,13 @@ public class WebHookMessageTypesModelBinder : IModelBinder
 
         var valueProviderResult = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);
         var rawValues = valueProviderResult.Values.ToArray();
-        if (rawValues != null)
+        if (Enum.TryParse(string.Join(",", rawValues), out WebHookMessageTypes result))
         {
-            if (Enum.TryParse(string.Join(",", rawValues), out WebHookMessageTypes result))
-            {
-                bindingContext.Result = ModelBindingResult.Success(result);
-            }
-            else
-            {
-                bindingContext.Result = ModelBindingResult.Failed();
-            }
+            bindingContext.Result = ModelBindingResult.Success(result);
+        }
+        else
+        {
+            bindingContext.Result = ModelBindingResult.Failed();
         }
 
         return Task.CompletedTask;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/ModelBinding/WebHookMessageTypesModelBinder.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/ModelBinding/WebHookMessageTypesModelBinder.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.Infrastructure.ModelBinding;
+
+public class WebHookMessageTypesModelBinder : IModelBinder
+{
+    public Task BindModelAsync(ModelBindingContext bindingContext)
+    {
+        var modelType = bindingContext.ModelType;
+        if (!typeof(WebHookMessageTypes).IsAssignableTo(modelType))
+        {
+            throw new InvalidOperationException($"Cannot bind to {modelType}.");
+        }
+
+        var valueProviderResult = bindingContext.ValueProvider.GetValue(bindingContext.ModelName);
+        var rawValues = valueProviderResult.Values.ToArray();
+        if (rawValues != null)
+        {
+            if (Enum.TryParse(string.Join(",", rawValues), out WebHookMessageTypes result))
+            {
+                bindingContext.Result = ModelBindingResult.Success(result);
+            }
+            else
+            {
+                bindingContext.Result = ModelBindingResult.Failed();
+            }
+        }
+
+        return Task.CompletedTask;
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230418142022_WebHookMessageTypes.Designer.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230418142022_WebHookMessageTypes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeacherIdentity.AuthServer.Models;
@@ -12,9 +13,11 @@ using TeacherIdentity.AuthServer.Models;
 namespace TeacherIdentity.AuthServer.Migrations
 {
     [DbContext(typeof(TeacherIdentityServerDbContext))]
-    partial class TeacherIdentityServerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230418142022_WebHookMessageTypes")]
+    partial class WebHookMessageTypes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230418142022_WebHookMessageTypes.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230418142022_WebHookMessageTypes.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeacherIdentity.AuthServer.Migrations
+{
+    /// <inheritdoc />
+    public partial class WebHookMessageTypes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "web_hook_message_types",
+                table: "webhooks",
+                type: "integer",
+                nullable: false,
+                defaultValue: 3);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "web_hook_message_types",
+                table: "webhooks");
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/Mappings/WebHookMapping.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/Mappings/WebHookMapping.cs
@@ -12,6 +12,7 @@ public class WebHookMapping : IEntityTypeConfiguration<WebHook>
         builder.Property(w => w.Endpoint).IsRequired().HasMaxLength(200);
         builder.Property(w => w.Endpoint).IsRequired();
         builder.Property(w => w.Secret).HasMaxLength(64);
+        builder.Property(w => w.WebHookMessageTypes).IsRequired().HasDefaultValue(WebHookMessageTypes.All);
         builder.HasKey(w => w.WebHookId);
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/WebHook.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/WebHook.cs
@@ -10,4 +10,5 @@ public class WebHook
     public required string Endpoint { get; set; }
     public required bool Enabled { get; set; }
     public required string Secret { get; set; }
+    public required WebHookMessageTypes WebHookMessageTypes { get; set; }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/WebHookMessageTypes.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/WebHookMessageTypes.cs
@@ -5,7 +5,7 @@ public enum WebHookMessageTypes
 {
     None = 0,
 
-    UserUpdated = 1,
+    UserUpdated = 1 << 0,
     UserMerged = 1 << 1,
 
     All = UserUpdated | UserMerged

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/WebHookMessageTypes.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/WebHookMessageTypes.cs
@@ -1,0 +1,12 @@
+namespace TeacherIdentity.AuthServer.Models;
+
+[Flags]
+public enum WebHookMessageTypes
+{
+    None = 0,
+
+    UserUpdated = 1,
+    UserMerged = 1 << 1,
+
+    All = UserUpdated | UserMerged
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AddWebHook.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AddWebHook.cshtml
@@ -1,4 +1,5 @@
 @page "/admin/webhooks/new"
+@using TeacherIdentity.AuthServer.Notifications.Messages;
 @model TeacherIdentity.AuthServer.Pages.Admin.AddWebHookModel
 @{
     ViewBag.Title = "Add web hook";
@@ -17,8 +18,8 @@
         <govuk-checkboxes-fieldset>
             <govuk-checkboxes-fieldset-legend class="govuk-fieldset__legend--m" />
 
-            <govuk-checkboxes-item value="@WebHookMessageTypes.UserUpdated" checked="@Model.WebHookMessageTypes.HasFlag(WebHookMessageTypes.UserUpdated)">User Updated</govuk-checkboxes-item>
-            <govuk-checkboxes-item value="@WebHookMessageTypes.UserMerged" checked="@Model.WebHookMessageTypes.HasFlag(WebHookMessageTypes.UserMerged)">User Merged</govuk-checkboxes-item>
+            <govuk-checkboxes-item value="@WebHookMessageTypes.UserUpdated" checked="@Model.WebHookMessageTypes.HasFlag(WebHookMessageTypes.UserUpdated)">@UserUpdatedMessage.MessageTypeName</govuk-checkboxes-item>
+            <govuk-checkboxes-item value="@WebHookMessageTypes.UserMerged" checked="@Model.WebHookMessageTypes.HasFlag(WebHookMessageTypes.UserMerged)">@UserMergedMessage.MessageTypeName</govuk-checkboxes-item>
         </govuk-checkboxes-fieldset>
     </govuk-checkboxes>
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AddWebHook.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AddWebHook.cshtml
@@ -13,5 +13,14 @@
         <govuk-checkboxes-item value="@true">Enabled</govuk-checkboxes-item>
     </govuk-checkboxes>
 
+    <govuk-checkboxes asp-for="WebHookMessageTypes">
+        <govuk-checkboxes-fieldset>
+            <govuk-checkboxes-fieldset-legend class="govuk-fieldset__legend--m" />
+
+            <govuk-checkboxes-item value="@WebHookMessageTypes.UserUpdated" checked="@Model.WebHookMessageTypes.HasFlag(WebHookMessageTypes.UserUpdated)">User Updated</govuk-checkboxes-item>
+            <govuk-checkboxes-item value="@WebHookMessageTypes.UserMerged" checked="@Model.WebHookMessageTypes.HasFlag(WebHookMessageTypes.UserMerged)">User Merged</govuk-checkboxes-item>
+        </govuk-checkboxes-fieldset>
+    </govuk-checkboxes>
+
     <govuk-button type="submit">Save</govuk-button>
 </form>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AddWebHook.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AddWebHook.cshtml.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Infrastructure.ModelBinding;
 using TeacherIdentity.AuthServer.Infrastructure.Security;
 using TeacherIdentity.AuthServer.Models;
 
@@ -25,6 +26,10 @@ public class AddWebHookModel : PageModel
     [Required(ErrorMessage = "Enter an endpoint")]
     public string? Endpoint { get; set; }
 
+    [Display(Name = "Which events would you like to trigger this webhook?", Description = "Select all that apply")]
+    [ModelBinder(BinderType = typeof(WebHookMessageTypesModelBinder))]
+    public WebHookMessageTypes WebHookMessageTypes { get; set; }
+
     [BindProperty]
     public bool Enabled { get; set; }
 
@@ -40,6 +45,11 @@ public class AddWebHookModel : PageModel
             ModelState.AddModelError(nameof(Endpoint), "Enter an absolute HTTP(s) URI");
         }
 
+        if (WebHookMessageTypes == WebHookMessageTypes.None)
+        {
+            ModelState.AddModelError(nameof(WebHookMessageTypes), "Select at least one event which will trigger the webhook");
+        }
+
         if (!ModelState.IsValid)
         {
             return this.PageWithErrors();
@@ -52,7 +62,8 @@ public class AddWebHookModel : PageModel
             WebHookId = webHookId,
             Enabled = Enabled,
             Endpoint = Endpoint!,
-            Secret = WebHook.GenerateSecret()
+            Secret = WebHook.GenerateSecret(),
+            WebHookMessageTypes = WebHookMessageTypes
         });
 
         _dbContext.AddEvent(new WebHookAddedEvent()
@@ -61,7 +72,8 @@ public class AddWebHookModel : PageModel
             CreatedUtc = _clock.UtcNow,
             Enabled = Enabled,
             Endpoint = Endpoint!,
-            WebHookId = webHookId
+            WebHookId = webHookId,
+            WebHookMessageTypes = WebHookMessageTypes
         });
 
         await _dbContext.SaveChangesAsync();

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditWebHook.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditWebHook.cshtml
@@ -17,6 +17,15 @@
         <govuk-checkboxes-item value="@true">Enabled</govuk-checkboxes-item>
     </govuk-checkboxes>
 
+    <govuk-checkboxes asp-for="WebHookMessageTypes">
+        <govuk-checkboxes-fieldset>
+            <govuk-checkboxes-fieldset-legend class="govuk-fieldset__legend--m" />
+
+            <govuk-checkboxes-item value="@WebHookMessageTypes.UserUpdated" checked="@Model.WebHookMessageTypes.HasFlag(WebHookMessageTypes.UserUpdated)">User Updated</govuk-checkboxes-item>
+            <govuk-checkboxes-item value="@WebHookMessageTypes.UserMerged" checked="@Model.WebHookMessageTypes.HasFlag(WebHookMessageTypes.UserMerged)">User Merged</govuk-checkboxes-item>
+        </govuk-checkboxes-fieldset>
+    </govuk-checkboxes>
+
     <govuk-input asp-for="Secret" disabled class="govuk-!-margin-bottom-2" />
 
     <govuk-checkboxes asp-for="RegenerateSecret" class="govuk-checkboxes--small">

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditWebHook.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditWebHook.cshtml
@@ -1,4 +1,5 @@
 @page "/admin/webhooks/{webHookId}"
+@using TeacherIdentity.AuthServer.Notifications.Messages;
 @model TeacherIdentity.AuthServer.Pages.Admin.EditWebHookModel
 @{
     ViewBag.Title = "Edit web hook";
@@ -21,8 +22,8 @@
         <govuk-checkboxes-fieldset>
             <govuk-checkboxes-fieldset-legend class="govuk-fieldset__legend--m" />
 
-            <govuk-checkboxes-item value="@WebHookMessageTypes.UserUpdated" checked="@Model.WebHookMessageTypes.HasFlag(WebHookMessageTypes.UserUpdated)">User Updated</govuk-checkboxes-item>
-            <govuk-checkboxes-item value="@WebHookMessageTypes.UserMerged" checked="@Model.WebHookMessageTypes.HasFlag(WebHookMessageTypes.UserMerged)">User Merged</govuk-checkboxes-item>
+            <govuk-checkboxes-item value="@WebHookMessageTypes.UserUpdated" checked="@Model.WebHookMessageTypes.HasFlag(WebHookMessageTypes.UserUpdated)">@UserUpdatedMessage.MessageTypeName</govuk-checkboxes-item>
+            <govuk-checkboxes-item value="@WebHookMessageTypes.UserMerged" checked="@Model.WebHookMessageTypes.HasFlag(WebHookMessageTypes.UserMerged)">@UserMergedMessage.MessageTypeName</govuk-checkboxes-item>
         </govuk-checkboxes-fieldset>
     </govuk-checkboxes>
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditWebHook.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditWebHook.cshtml.cs
@@ -33,6 +33,7 @@ public class EditWebHookModel : PageModel
     [BindProperty]
     public bool Enabled { get; set; }
 
+    [Display(Name = "Which events would you like to trigger this webhook?", Description = "Select all that apply")]
     [ModelBinder(BinderType = typeof(WebHookMessageTypesModelBinder))]
     public WebHookMessageTypes WebHookMessageTypes { get; set; }
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/TempData.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/TempData.cs
@@ -1,6 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
-using Newtonsoft.Json;
 using JsonSerializer = System.Text.Json.JsonSerializer;
 
 namespace TeacherIdentity.AuthServer;
@@ -22,16 +21,9 @@ public static class TempDataExtensions
         data = null;
         if (tempData.TryGetValue(TempDataKeys.FlashSuccess, out object? flashSuccessObject) && flashSuccessObject is string flashSuccessString)
         {
-            try
-            {
-                var flashSuccessData = FlashSuccessData.Deserialize(flashSuccessString);
-                data = (flashSuccessData.Heading, flashSuccessData.Message);
-                return true;
-            }
-            catch (JsonSerializationException)
-            {
-                // Deserialization failed
-            }
+            var flashSuccessData = FlashSuccessData.Deserialize(flashSuccessString);
+            data = (flashSuccessData.Heading, flashSuccessData.Message);
+            return true;
         }
         return false;
     }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AddWebHookTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AddWebHookTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Models;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Admin;
 
@@ -53,13 +54,15 @@ public class AddWebHookTests : TestBase
         // Arrange
         var endpoint = Faker.Internet.Url();
         var enabled = true;
+        var webHookMessageTypes = WebHookMessageTypes.UserMerged;
 
         var request = new HttpRequestMessage(HttpMethod.Post, "/admin/webhooks/new")
         {
             Content = new FormUrlEncodedContentBuilder()
             {
                 { "Endpoint", endpoint },
-                { "Enabled", enabled }
+                { "Enabled", enabled },
+                { "WebHookMessageTypes", webHookMessageTypes }
             }
         };
 
@@ -90,6 +93,7 @@ public class AddWebHookTests : TestBase
                 Assert.Equal(webHookId, webHookAdded.WebHookId);
                 Assert.Equal(enabled, webHookAdded.Enabled);
                 Assert.Equal(endpoint, webHookAdded.Endpoint);
+                Assert.Equal(webHookMessageTypes, webHookAdded.WebHookMessageTypes);
             });
 
         var redirectedResponse = await response.FollowRedirect(HttpClient);


### PR DESCRIPTION
### Context

Need to allow webhook consumers to choose which events they are interested in

### Changes proposed in this pull request

Added web hook message type support including DB + UI changes

### Guidance to review

N/A

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
