### PR TITLE
Tweak the IdentityLinkGenerator abstraction

### DIFF
--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text;
-using TeacherIdentity.AuthServer.Helpers;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Oidc;
 using TeacherIdentity.AuthServer.State;
@@ -70,9 +69,7 @@ public sealed class AuthenticationStateHelper
 
         authenticationStateProvider.SetAuthenticationState(httpContext: null, authenticationState);
 
-        var queryStringSignatureHelper = hostFixture.Services.GetRequiredService<QueryStringSignatureHelper>();
-        var linkGenerator = hostFixture.Services.GetRequiredService<LinkGenerator>();
-        var identityLinkGenerator = new TestIdentityLinkGenerator(queryStringSignatureHelper, authenticationState, linkGenerator);
+        var identityLinkGenerator = ActivatorUtilities.CreateInstance<TestIdentityLinkGenerator>(hostFixture.Services, authenticationState);
 
         return new AuthenticationStateHelper(journeyId, authenticationStateProvider, identityLinkGenerator);
     }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Infrastructure/TestIdentityLinkGenerator.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Infrastructure/TestIdentityLinkGenerator.cs
@@ -1,27 +1,24 @@
-using Flurl;
+using System.Diagnostics.CodeAnalysis;
 using TeacherIdentity.AuthServer.Helpers;
-using TeacherIdentity.AuthServer.State;
 
 namespace TeacherIdentity.AuthServer.Tests.Infrastructure;
 
 public class TestIdentityLinkGenerator : IdentityLinkGenerator
 {
     private readonly AuthenticationState _authenticationState;
-    private readonly LinkGenerator _linkGenerator;
 
     public TestIdentityLinkGenerator(
-        QueryStringSignatureHelper queryStringSignatureHelper,
         AuthenticationState authenticationState,
-        LinkGenerator linkGenerator)
-        : base(queryStringSignatureHelper)
+        LinkGenerator linkGenerator,
+        QueryStringSignatureHelper queryStringSignatureHelper)
+        : base(linkGenerator, queryStringSignatureHelper)
     {
         _authenticationState = authenticationState;
-        _linkGenerator = linkGenerator;
     }
 
-    protected override string Page(string pageName, bool authenticationJourneyRequired = true)
+    protected override bool TryGetAuthenticationState([NotNullWhen(true)] out AuthenticationState? authenticationState)
     {
-        return new Url(_linkGenerator.GetPathByPage(pageName))
-            .SetQueryParam(AuthenticationStateMiddleware.IdQueryParameterName, _authenticationState.JourneyId);
+        authenticationState = _authenticationState;
+        return true;
     }
 }


### PR DESCRIPTION
`IdentityLinkGenerator`'s abstract member is the method that returns a URL for a given Razor page name. In reality, the only part of this type we really need to customise is how the `AuthenticationState` is resolved. This changes the abstraction to make that the abstract part.

This came out of a larger change of refactoring the legacy TRN journey.