### PR TITLE
Update complete page for core journey

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -358,6 +358,7 @@ public class AuthenticationState
         }
 
         MobileNumberVerified = true;
+        FirstTimeSignInForEmail = user is null;
 
         if (user is not null)
         {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Complete.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Complete.cshtml
@@ -3,8 +3,8 @@
 @model TeacherIdentity.AuthServer.Pages.SignIn.CompleteModel
 @{
     ViewBag.Title = Model.FirstTimeSignInForEmail ?
-        (await Component.InvokeAsync("ClientScopedPartial", new { viewName = "_TrnLookup.EndBookend.FirstTimeSignIn.{0}.Title" })).RenderToString() :
-        "Your details";
+        "You’ve created a DfE Identity account" :
+        "You’ve signed in to your DfE Identity account";
 
     var responseMode = Model.ResponseMode!;
     var method = responseMode == ResponseModes.FormPost ? "post" : "get";
@@ -33,54 +33,12 @@
         }
     }
 
-    @if (Model.FirstTimeSignInForEmail)
+    @if (Model.JourneyType == AuthenticationJourneyType.LegacyTrn)
     {
-        <govuk-panel class="app-panel--interruption" data-testid="first-time-user-content">
-            <govuk-panel-title><span data-testid="first-time-user-postsigninmessage"></span>@ViewBag.Title</govuk-panel-title>
-
-            <govuk-panel-body>
-                @if (Model.GotTrn)
-                {
-                    <span data-testid="known-trn-content"></span>
-                    <p>Thank you, we’ve finished checking our records.</p>
-
-                    <p>If you need to come back to this service later you’ll only need to give us your email address <strong>(@Model.Email)</strong>.</p>
-                }
-                else
-                {
-                    <span data-testid="unknown-trn-content"></span>
-                    <vc:client-scoped-partial view-name="_TrnLookup.EndBookend.FirstTimeSignInWithoutTrn.{0}.Content" />
-                }
-
-                <govuk-button type="submit" class="app-button--inverse govuk-!-margin-bottom-0">Continue</govuk-button>
-            </govuk-panel-body>
-        </govuk-panel>
+        <vc:sign-in-complete journey-type="AuthenticationJourneyType.LegacyTrn" />
     }
     else
     {
-        <div class="govuk-grid-row" data-testid="known-user-content">
-            <div class="govuk-grid-column-two-thirds-from-desktop">
-                <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
-
-                <govuk-summary-list>
-                    <govuk-summary-list-row>
-                        <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
-                        <govuk-summary-list-row-value>@Model.Name</govuk-summary-list-row-value>
-                        <govuk-summary-list-row-actions>
-                            <govuk-summary-list-row-action visually-hidden-text="name" href="@LinkGenerator.UpdateName(returnUrl: LinkGenerator.CompleteAuthorization(), cancelUrl: LinkGenerator.CompleteAuthorization())">Change</govuk-summary-list-row-action>
-                        </govuk-summary-list-row-actions>
-                    </govuk-summary-list-row>
-                    <govuk-summary-list-row>
-                        <govuk-summary-list-row-key>Email address</govuk-summary-list-row-key>
-                        <govuk-summary-list-row-value class="empty-hyphens">@Html.ShyEmail(Model.Email!)</govuk-summary-list-row-value>
-                        <govuk-summary-list-row-actions>
-                            <govuk-summary-list-row-action visually-hidden-text="email" href="@LinkGenerator.UpdateEmail(returnUrl: LinkGenerator.CompleteAuthorization(), cancelUrl: LinkGenerator.CompleteAuthorization())">Change</govuk-summary-list-row-action>
-                        </govuk-summary-list-row-actions>
-                    </govuk-summary-list-row>
-                </govuk-summary-list>
-
-                <govuk-button type="submit">Continue</govuk-button>
-            </div>
-        </div>
+        <vc:sign-in-complete journey-type="AuthenticationJourneyType.Core" />
     }
 </form>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasQtsPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/HasQtsPage.cshtml.cs
@@ -54,7 +54,7 @@ public class HasQtsPage : PageModel
             return;
         }
 
-        if (authenticationState.StatedTrn is null)
+        if (authenticationState is { HasTrn: true, StatedTrn: null })
         {
             context.Result = new RedirectResult(_linkGenerator.RegisterTrn());
         }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/_SignIn.Complete.Default.Content.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/_SignIn.Complete.Default.Content.cshtml
@@ -1,0 +1,23 @@
+@if (Model.FirstTimeSignInForEmail)
+{
+    <govuk-panel class="app-panel--interruption" data-testid="first-time-user-content">
+        <govuk-panel-title><span data-testid="first-time-user-postsigninmessage"></span>@ViewBag.Title</govuk-panel-title>
+
+        <govuk-panel-body>
+            <p>Next time, you can sign in just using your email @Model.Email.</p>
+            <p>Continue to <strong>@Model.ClientDisplayName</strong></p>
+            <govuk-button type="submit" class="app-button--inverse govuk-!-margin-bottom-0">Continue</govuk-button>
+        </govuk-panel-body>
+    </govuk-panel>
+}
+else
+{
+    <govuk-panel class="app-panel--interruption" data-testid="known-user-content">
+        <govuk-panel-title><span data-testid="first-time-user-postsigninmessage"></span>@ViewBag.Title</govuk-panel-title>
+
+        <govuk-panel-body>
+            <p>Continue to <strong>@Model.ClientDisplayName</strong></p>
+            <govuk-button type="submit" class="app-button--inverse govuk-!-margin-bottom-0">Continue</govuk-button>
+        </govuk-panel-body>
+    </govuk-panel>
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/_SignIn.Complete.LegacyTRN.Content.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/_SignIn.Complete.LegacyTRN.Content.cshtml
@@ -1,0 +1,54 @@
+@{
+    ViewData["Title"] = Model.FirstTimeSignInForEmail ?
+        (await Component.InvokeAsync("ClientScopedPartial", new { viewName = "_TrnLookup.EndBookend.FirstTimeSignIn.{0}.Title" })).RenderToString() :
+        "Your details";;
+}
+
+@if (Model.FirstTimeSignInForEmail)
+{
+    <govuk-panel class="app-panel--interruption" data-testid="legacy-first-time-user-content">
+        <govuk-panel-title><span data-testid="legacy-first-time-user-postsigninmessage"></span>@ViewBag.Title</govuk-panel-title>
+
+        <govuk-panel-body>
+            @if (Model.GotTrn)
+            {
+                <p>Thank you, we’ve finished checking our records.</p>
+
+                <p>If you need to come back to this service later you’ll only need to give us your email address <strong>(@Model.Email)</strong>.</p>
+            }
+            else
+            {
+                <vc:client-scoped-partial view-name="_TrnLookup.EndBookend.FirstTimeSignInWithoutTrn.{0}.Content"/>
+            }
+
+            <govuk-button type="submit" class="app-button--inverse govuk-!-margin-bottom-0">Continue</govuk-button>
+        </govuk-panel-body>
+    </govuk-panel>
+}
+else
+{
+    <div class="govuk-grid-row" data-testid="legacy-known-user-content">
+        <div class="govuk-grid-column-two-thirds-from-desktop">
+            <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
+
+            <govuk-summary-list>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.Name</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action visually-hidden-text="name" href="@LinkGenerator.UpdateName(returnUrl: LinkGenerator.CompleteAuthorization(), cancelUrl: LinkGenerator.CompleteAuthorization())">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Email address</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value class="empty-hyphens">@HtmlHelperExtensions.ShyEmail(Html, Model.Email!)</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action visually-hidden-text="email" href="@LinkGenerator.UpdateEmail(returnUrl: LinkGenerator.CompleteAuthorization(), cancelUrl: LinkGenerator.CompleteAuthorization())">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+            </govuk-summary-list>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </div>
+    </div>
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/ViewComponents/RenderSignInCompleteViewComponent.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/ViewComponents/RenderSignInCompleteViewComponent.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Html;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Microsoft.AspNetCore.Mvc.ViewComponents;
+
+namespace TeacherIdentity.AuthServer.ViewComponents;
+
+[ViewComponent(Name = "SignInComplete")]
+public class RenderSignInCompleteViewComponent : ViewComponent
+{
+    public Task<IViewComponentResult> InvokeAsync(AuthenticationJourneyType? journeyType)
+    {
+        if (journeyType is null)
+        {
+            throw new ArgumentNullException(nameof(journeyType));
+        }
+
+        return Task.FromResult<IViewComponentResult>(journeyType == AuthenticationJourneyType.LegacyTrn ?
+            View("~/Pages/SignIn/_SignIn.Complete.LegacyTRN.Content.cshtml") :
+            View("~/Pages/SignIn/_SignIn.Complete.Default.Content.cshtml"));
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/ViewComponents/RenderSignInCompleteViewComponent.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/ViewComponents/RenderSignInCompleteViewComponent.cs
@@ -1,7 +1,4 @@
-using Microsoft.AspNetCore.Html;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Rendering;
-using Microsoft.AspNetCore.Mvc.ViewComponents;
 
 namespace TeacherIdentity.AuthServer.ViewComponents;
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/HostFixture.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/HostFixture.cs
@@ -299,5 +299,5 @@ public class HostFixture : IAsyncLifetime
 
 public class LegacyClientHostFixture : HostFixture
 {
-    public override string TestClientId { get; }= "legacyClient";
+    public override string TestClientId { get; } = "legacyClient";
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/LegacyTrnJourney.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/LegacyTrnJourney.cs
@@ -6,11 +6,11 @@ using TeacherIdentity.AuthServer.Services.DqtApi;
 
 namespace TeacherIdentity.AuthServer.EndToEndTests;
 
-public class LegacyTrnJourney : IClassFixture<HostFixture>
+public class LegacyTrnJourney : IClassFixture<LegacyClientHostFixture>
 {
-    private readonly HostFixture _hostFixture;
+    private readonly LegacyClientHostFixture _hostFixture;
 
-    public LegacyTrnJourney(HostFixture hostFixture)
+    public LegacyTrnJourney(LegacyClientHostFixture hostFixture)
     {
         _hostFixture = hostFixture;
         _hostFixture.OnTestStarting();

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
@@ -18,7 +18,13 @@ public static class PageExtensions
     public static Task ClickChangeLinkForSummaryListRowWithKey(this IPage page, string key) =>
         page.Locator($".govuk-summary-list__row:has(> dt:text('{key}'))").GetByText("Change").ClickAsync();
 
-    public static Task ClickContinueButton(this IPage page) => page.ClickAsync(".govuk-button:text-is('Continue')");
+    private static Task ClickLink(this IPage page, string text) =>
+        page.Locator("a").GetByText(text).ClickAsync();
+
+    private static Task ClickButton(this IPage page, string text) =>
+        page.ClickAsync($".govuk-button:text-is('{text}')");
+
+    public static Task ClickContinueButton(this IPage page) => ClickButton(page, "Continue");
 
     public static async Task FillDateInput(this IPage page, DateOnly date)
     {
@@ -353,15 +359,49 @@ public static class PageExtensions
         await page.ClickContinueButton();
     }
 
+    public static async Task SubmitAccountExistsPage(this IPage page, bool isUsersAccount)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/register/account-exists");
+        await page.ClickAsync($"label:text-is('{(isUsersAccount ? "Yes, sign into this account" : "No, this is not my account")}')");  // Do you have a National Insurance number?
+        await page.ClickContinueButton();
+    }
+
+    public static async Task SubmitExistingAccountEmailConfirmationPage(this IPage page, bool cantAccessEmail = false)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/register/existing-account-email-confirmation");
+        await page.FillAsync("label:text-is('Confirmation code')", HostFixture.UserVerificationPin);
+        if (cantAccessEmail)
+        {
+            await page.ClickLink("I can’t access this email address");
+        }
+        else
+        {
+            await page.ClickContinueButton();
+        }
+    }
+
+    public static async Task SubmitExistingAccountPhonePage(this IPage page)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/register/existing-account-phone");
+        await page.ClickButton("Request security code");
+    }
+
+    public static async Task SubmitExistingAccountPhoneConfirmationPage(this IPage page)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/register/existing-account-phone-confirmation");
+        await page.FillAsync("label:text-is('Security code')", HostFixture.UserVerificationPin);
+        await page.ClickContinueButton();
+    }
+
     public static async Task SignInFromRegisterEmailExistsPage(this IPage page)
     {
         await page.WaitForUrlPathAsync("/sign-in/register/email-exists");
-        await page.ClickAsync("a:text-is('Sign in')");
+        await page.ClickLink("Sign in");
     }
 
     public static async Task SignInFromRegisterPhoneExistsPage(this IPage page)
     {
         await page.WaitForUrlPathAsync("/sign-in/register/phone-exists");
-        await page.ClickAsync("a:text-is('Sign in')");
+        await page.ClickLink("Sign in");
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
@@ -372,7 +372,7 @@ public static class PageExtensions
         await page.FillAsync("label:text-is('Confirmation code')", HostFixture.UserVerificationPin);
         if (cantAccessEmail)
         {
-            await page.ClickLink("I can’t access this email address");
+            await page.ClickAsync("a:text-is('I can’t access this email address')");
         }
         else
         {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
@@ -88,7 +88,7 @@ public static class PageExtensions
     public static async Task SubmitCompletePageForNewUserInLegacyTrnJourney(this IPage page)
     {
         await page.WaitForUrlPathAsync("/sign-in/complete");
-        Assert.Equal(1, await page.Locator("data-testid=first-time-user-content").CountAsync());
+        Assert.Equal(1, await page.Locator("data-testid=legacy-first-time-user-content").CountAsync());
         await page.ClickContinueButton();
     }
 
@@ -296,7 +296,7 @@ public static class PageExtensions
         await page.ClickContinueButton();
     }
 
-    public static async Task SubmitCheckAnswersPage(this IPage page, DateOnly dateOfBirth)
+    public static async Task SubmitCheckAnswersPage(this IPage page)
     {
         await page.WaitForUrlPathAsync("/sign-in/register/check-answers");
         await page.ClickContinueButton();
@@ -306,6 +306,50 @@ public static class PageExtensions
     {
         await page.WaitForUrlPathAsync("/sign-in/complete");
         Assert.Equal(1, await page.Locator("data-testid=first-time-user-content").CountAsync());
+        await page.ClickContinueButton();
+    }
+
+    public static async Task SubmitRegisterHasNinoPage(this IPage page, bool hasNino)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/register/has-nino");
+        await page.ClickAsync($"label:text-is('{(hasNino ? "Yes" : "No")}')");  // Do you have a National Insurance number?
+        await page.ClickContinueButton();
+    }
+
+    public static async Task SubmitRegisterNiNumberPage(this IPage page, string nationalInsuranceNumber)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/register/ni-number");
+        await page.FillAsync("text='What is your National Insurance number?'", nationalInsuranceNumber);
+        await page.ClickContinueButton();
+    }
+
+    public static async Task SubmitRegisterHasTrnPage(this IPage page, bool hasTrn)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/register/has-trn");
+        await page.ClickAsync($"label:text-is('{(hasTrn ? "Yes" : "No")}')");  // Do you have a National Insurance number?
+        await page.ClickContinueButton();
+    }
+
+    public static async Task SubmitRegisterTrnPage(this IPage page, string trn)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/register/trn");
+        await page.FillAsync("text=Enter your TRN", trn);
+        await page.ClickContinueButton();
+    }
+
+    public static async Task SubmitRegisterHasQtsPage(this IPage page, bool hasQts)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/register/has-qts");
+        await page.ClickAsync($"label:text-is('{(hasQts ? "Yes" : "No")}')");  // Have you been awarded qualified teacher status (QTS)?
+        await page.ClickContinueButton();
+    }
+
+    public static async Task SubmitRegisterIttProviderPageWithIttProvider(this IPage page, string ittProviderName)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/register/itt-provider");
+        await page.ClickAsync("label:text-is('Yes')");  // Did a university, SCITT or school award your QTS?
+        await page.FillAsync("label:text-is('Where did you get your QTS?')", ittProviderName);
+        await page.FocusAsync("button:text-is('Continue')");  // Un-focus accessible autocomplete
         await page.ClickContinueButton();
     }
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
@@ -372,7 +372,7 @@ public static class PageExtensions
         await page.FillAsync("label:text-is('Confirmation code')", HostFixture.UserVerificationPin);
         if (cantAccessEmail)
         {
-            await page.ClickAsync("a:text-is('I can’t access this email address')");
+            await page.ClickAsync("a:text-is('I cannot access this email address')");
         }
         else
         {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Register.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Register.cs
@@ -1,4 +1,7 @@
+using Moq;
 using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Oidc;
+using TeacherIdentity.AuthServer.Services.DqtApi;
 
 namespace TeacherIdentity.AuthServer.EndToEndTests;
 
@@ -13,7 +16,7 @@ public class Register : IClassFixture<HostFixture>
     }
 
     [Fact]
-    public async Task NewUserCanRegister()
+    public async Task NewUserWithoutTrnRequiredCanRegister()
     {
         var email = Faker.Internet.Email();
         var mobileNumber = _hostFixture.TestData.GenerateUniqueMobileNumber();
@@ -40,7 +43,7 @@ public class Register : IClassFixture<HostFixture>
 
         await page.SubmitDateOfBirthPage(dateOfBirth);
 
-        await page.SubmitCheckAnswersPage(dateOfBirth);
+        await page.SubmitCheckAnswersPage();
 
         await page.SubmitCompletePageForNewUser();
 
@@ -65,6 +68,93 @@ public class Register : IClassFixture<HostFixture>
             {
                 var userSignedInEvent = Assert.IsType<UserSignedInEvent>(e);
                 Assert.Equal(createdUserId, userSignedInEvent.User.UserId);
+            });
+    }
+
+    [Fact]
+    public async Task NewUserWithTrnRequiredCanRegister()
+    {
+        var email = Faker.Internet.Email();
+        var mobileNumber = _hostFixture.TestData.GenerateUniqueMobileNumber();
+        var firstName = Faker.Name.First();
+        var lastName = Faker.Name.Last();
+        var dateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
+        var nino = Faker.Identification.UkNationalInsuranceNumber();
+        var ittProvider = Faker.Company.Name();
+        var trn = _hostFixture.TestData.GenerateTrn();
+
+        _hostFixture.DqtApiClient
+            .Setup(mock => mock.GetIttProviders(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new GetIttProvidersResponse()
+            {
+                IttProviders = new[]
+                {
+                    new IttProvider()
+                    {
+                        ProviderName = "Provider 1",
+                        Ukprn = "123"
+                    },
+                    new IttProvider()
+                    {
+                        ProviderName = ittProvider,
+                        Ukprn = "234"
+                    }
+                }
+            });
+
+        await using var context = await _hostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.StartOAuthJourney(additionalScope: CustomScopes.DqtRead);
+
+        await page.RegisterFromLandingPage();
+
+        await page.SubmitRegisterEmailPage(email);
+
+        await page.SubmitRegisterEmailConfirmationPage();
+
+        await page.SubmitRegisterPhonePage(mobileNumber);
+
+        await page.SubmitRegisterPhoneConfirmationPage();
+
+        await page.SubmitRegisterNamePage(firstName, lastName);
+
+        await page.SubmitDateOfBirthPage(dateOfBirth);
+
+        await page.SubmitRegisterHasNinoPage(hasNino: true);
+
+        await page.SubmitRegisterNiNumberPage(nino);
+
+        await page.SubmitRegisterHasTrnPage(hasTrn: true);
+
+        await page.SubmitRegisterTrnPage(trn);
+
+        await page.SubmitRegisterHasQtsPage(hasQts: true);
+
+        await page.SubmitRegisterIttProviderPageWithIttProvider(ittProvider);
+
+        await page.SubmitCheckAnswersPage();
+
+        // Requires TrnLookup to have been completed for new TRN user.
+
+        // await page.SubmitCompletePageForNewUser();
+        //
+        // await page.AssertSignedInOnTestClient(email, trn: null, firstName, lastName);
+
+        Guid createdUserId = default;
+
+        _hostFixture.EventObserver.AssertEventsSaved(
+            e =>
+            {
+                var userRegisteredEvent = Assert.IsType<UserRegisteredEvent>(e);
+                Assert.Equal(_hostFixture.TestClientId, userRegisteredEvent.ClientId);
+                Assert.Equal(email, userRegisteredEvent.User.EmailAddress);
+                Assert.Equal(mobileNumber, userRegisteredEvent.User.MobileNumber);
+                Assert.Equal(firstName, userRegisteredEvent.User.FirstName);
+                Assert.Equal(lastName, userRegisteredEvent.User.LastName);
+                Assert.Equal(dateOfBirth, userRegisteredEvent.User.DateOfBirth);
+
+                createdUserId = userRegisteredEvent.User.UserId;
             });
     }
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Register.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Register.cs
@@ -183,4 +183,117 @@ public class Register : IClassFixture<HostFixture>
         _hostFixture.EventObserver.AssertEventsSaved(
             e => _hostFixture.AssertEventIsUserSignedIn(e, existingUser.UserId, expectOAuthProperties: true));
     }
+
+    [Fact]
+    public async Task UserWithMobileAlreadyExists_SignsInExistingUser()
+    {
+        var email = Faker.Internet.Email();
+        var existingUser = await _hostFixture.TestData.CreateUser(hasMobileNumber: true);
+
+        await using var context = await _hostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.StartOAuthJourney(additionalScope: null);
+
+        await page.RegisterFromLandingPage();
+
+        await page.SubmitRegisterEmailPage(email);
+
+        await page.SubmitRegisterEmailConfirmationPage();
+
+        await page.SubmitRegisterPhonePage(existingUser.MobileNumber!);
+
+        await page.SubmitRegisterPhoneConfirmationPage();
+
+        await page.SignInFromRegisterPhoneExistsPage();
+
+        await page.SubmitCompletePageForExistingUser();
+
+        await page.AssertSignedInOnTestClient(existingUser);
+
+        _hostFixture.EventObserver.AssertEventsSaved(
+            e => _hostFixture.AssertEventIsUserSignedIn(e, existingUser.UserId, expectOAuthProperties: true));
+    }
+
+    [Fact]
+    public async Task UserWithMatchingNameAndDob_SignsInExistingUserFromEmail()
+    {
+        var email = Faker.Internet.Email();
+        var mobileNumber = _hostFixture.TestData.GenerateUniqueMobileNumber();
+
+        var existingUser = await _hostFixture.TestData.CreateUser();
+
+        await using var context = await _hostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.StartOAuthJourney(additionalScope: null);
+
+        await page.RegisterFromLandingPage();
+
+        await page.SubmitRegisterEmailPage(email);
+
+        await page.SubmitRegisterEmailConfirmationPage();
+
+        await page.SubmitRegisterPhonePage(mobileNumber);
+
+        await page.SubmitRegisterPhoneConfirmationPage();
+
+        await page.SubmitRegisterNamePage(existingUser.FirstName, existingUser.LastName);
+
+        await page.SubmitDateOfBirthPage(existingUser.DateOfBirth!.Value);
+
+        await page.SubmitAccountExistsPage(isUsersAccount: true);
+
+        await page.SubmitExistingAccountEmailConfirmationPage();
+
+        await page.SubmitCompletePageForExistingUser();
+
+        await page.AssertSignedInOnTestClient(existingUser);
+
+        _hostFixture.EventObserver.AssertEventsSaved(
+            e => _hostFixture.AssertEventIsUserSignedIn(e, existingUser.UserId, expectOAuthProperties: true));
+    }
+
+    [Fact]
+    public async Task UserWithMatchingNameAndDob_SignsInExistingUserFromMobilePhone()
+    {
+        var email = Faker.Internet.Email();
+        var mobileNumber = _hostFixture.TestData.GenerateUniqueMobileNumber();
+
+        var existingUser = await _hostFixture.TestData.CreateUser();
+
+        await using var context = await _hostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.StartOAuthJourney(additionalScope: null);
+
+        await page.RegisterFromLandingPage();
+
+        await page.SubmitRegisterEmailPage(email);
+
+        await page.SubmitRegisterEmailConfirmationPage();
+
+        await page.SubmitRegisterPhonePage(mobileNumber);
+
+        await page.SubmitRegisterPhoneConfirmationPage();
+
+        await page.SubmitRegisterNamePage(existingUser.FirstName, existingUser.LastName);
+
+        await page.SubmitDateOfBirthPage(existingUser.DateOfBirth!.Value);
+
+        await page.SubmitAccountExistsPage(isUsersAccount: true);
+
+        await page.SubmitExistingAccountEmailConfirmationPage(cantAccessEmail: true);
+
+        await page.SubmitExistingAccountPhonePage();
+
+        await page.SubmitExistingAccountPhoneConfirmationPage();
+
+        await page.SubmitCompletePageForExistingUser();
+
+        await page.AssertSignedInOnTestClient(existingUser);
+
+        _hostFixture.EventObserver.AssertEventsSaved(
+            e => _hostFixture.AssertEventIsUserSignedIn(e, existingUser.UserId, expectOAuthProperties: true));
+    }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/appsettings.json
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/appsettings.json
@@ -12,15 +12,23 @@
       "UseFixedPin": true
     }
   },
-  "Client": {
-    "ClientId": "testclient",
-    "ClientSecret": "super-secret",
-    "SignInAuthority": "http://localhost:55341",
-    "PostSignInMessage": "continue with the Test Client"
-  },
+  "ClientsSettings": [
+    {
+      "ClientId": "defaultClient",
+      "ClientSecret": "super-secret",
+      "SignInAuthority": "http://localhost:55341",
+      "PostSignInMessage": "continue with the Test Client"
+    },
+    {
+      "ClientId": "legacyClient",
+      "ClientSecret": "super-secret",
+      "SignInAuthority": "http://localhost:55341",
+      "PostSignInMessage": "continue with the Legacy Test Client"
+    }
+  ],
   "Clients": [
     {
-      "ClientId": "testclient",
+      "ClientId": "defaultClient",
       "ClientSecret": "super-secret",
       "DisplayName": "Development test client",
       "EnableAuthorizationCodeGrant": true,
@@ -33,6 +41,21 @@
       ],
       "Scopes": [ "trn", "user:read", "user:write", "dqt:read" ],
       "TrnRequirementType": "Required"
+    },
+    {
+      "ClientId": "legacyClient",
+      "ClientSecret": "super-secret",
+      "DisplayName": "Development test client",
+      "EnableAuthorizationCodeGrant": true,
+      "EnableClientCredentialsGrant": false,
+      "RedirectUris": [
+        "http://localhost:55342/oidc/callback"
+      ],
+      "PostLogoutRedirectUris": [
+        "http://localhost:55342/oidc/signout-callback"
+      ],
+      "Scopes": [ "trn", "user:read", "user:write", "dqt:read" ],
+      "TrnRequirementType": "Legacy"
     },
     {
       "ClientId": "testcc",

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
@@ -34,7 +34,7 @@ public sealed class AuthenticationStateHelper
     {
         var authenticationStateProvider = (TestAuthenticationStateProvider)hostFixture.Services.GetRequiredService<IAuthenticationStateProvider>();
 
-        client ??= TestClients.Client1;
+        client ??= TestClients.DefaultClient;
 
         var journeyId = Guid.NewGuid();
         var codeChallenge = Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes("12345")));

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/IndexTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/IndexTests.cs
@@ -17,7 +17,7 @@ public class IndexTests : TestBase
         var user = await TestData.CreateUser();
         HostFixture.SetUserId(user.UserId);
 
-        var client = TestClients.Client1;
+        var client = TestClients.DefaultClient;
         var redirectUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority);
         var signOutUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority) + "/sign-out";
 
@@ -39,7 +39,7 @@ public class IndexTests : TestBase
         var user = await TestData.CreateUser();
         HostFixture.SetUserId(user.UserId);
 
-        var client = TestClients.Client1;
+        var client = TestClients.DefaultClient;
         var signOutUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority) + "/sign-out";
 
         var request = new HttpRequestMessage(
@@ -60,7 +60,7 @@ public class IndexTests : TestBase
         var user = await TestData.CreateUser();
         HostFixture.SetUserId(user.UserId);
 
-        var client = TestClients.Client1;
+        var client = TestClients.DefaultClient;
         var redirectUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority);
 
         var request = new HttpRequestMessage(
@@ -277,7 +277,7 @@ public class IndexTests : TestBase
         var user = await TestData.CreateUser();
         HostFixture.SetUserId(user.UserId);
 
-        var client = TestClients.Client1;
+        var client = TestClients.DefaultClient;
         var redirectUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority);
         var signOutUri = client.RedirectUris.First().GetLeftPart(UriPartial.Authority) + "/sign-out";
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/TestBase.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/TestBase.cs
@@ -34,7 +34,7 @@ public partial class TestBase
 
     public SpyRegistry SpyRegistry => HostFixture.SpyRegistry;
 
-    public ClientRedirectInfo CreateClientRedirectInfo() => CreateClientRedirectInfo(TestClients.Client1);
+    public ClientRedirectInfo CreateClientRedirectInfo() => CreateClientRedirectInfo(TestClients.DefaultClient);
 
     public ClientRedirectInfo CreateClientRedirectInfo(TeacherIdentityApplicationDescriptor client)
     {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AddClientTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AddClientTests.cs
@@ -54,7 +54,7 @@ public class AddClientTests : TestBase
     public async Task Post_ClientAlreadyExistsWithId_RendersError()
     {
         // Arrange
-        var clientId = TestClients.Client1.ClientId!;
+        var clientId = TestClients.DefaultClient.ClientId!;
         var clientSecret = "s3cret";
         var displayName = Faker.Company.Name();
         var serviceUrl = $"https://{Faker.Internet.DomainName()}/";

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/TestBase.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/TestBase.cs
@@ -41,7 +41,7 @@ public class TestBase
         var userClaimHelper = scope.ServiceProvider.GetRequiredService<UserClaimHelper>();
 
         var userId = TestUsers.AdminUserWithAllRoles.UserId;
-        var client = TestClients.Client1;
+        var client = TestClients.DefaultClient;
 
         var allScopes = new[] { "email", "profile", "openid" }.Concat(scopes).ToHashSet(StringComparer.OrdinalIgnoreCase);
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/Users/GetUserDetailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/Users/GetUserDetailTests.cs
@@ -45,7 +45,7 @@ public class GetUserDetailTests : TestBase
         // Arrange
         var httpClient = await CreateHttpClientWithToken(scope);
 
-        var registeredWithClient = TestClients.Client1;
+        var registeredWithClient = TestClients.DefaultClient;
         var user = await TestData.CreateUser(hasTrn: true, registeredWithClientId: registeredWithClient.ClientId);
         var mergedUser = await TestData.CreateUser(hasTrn: true, registeredWithClientId: registeredWithClient.ClientId, mergedWithUserId: user.UserId);
 
@@ -79,7 +79,7 @@ public class GetUserDetailTests : TestBase
         // Arrange
         var httpClient = await CreateHttpClientWithToken(scope);
 
-        var registeredWithClient = TestClients.Client1;
+        var registeredWithClient = TestClients.DefaultClient;
         var user = await TestData.CreateUser(hasTrn: true, registeredWithClientId: registeredWithClient.ClientId);
 
         // Act

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/Users/SetTeacherTrnTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/Users/SetTeacherTrnTests.cs
@@ -198,7 +198,7 @@ public class SetTeacherTrnTests : TestBase
                 Assert.Equal(Clock.UtcNow, userUpdatedEvent.CreatedUtc);
                 Assert.Equal(UserUpdatedEventSource.Api, userUpdatedEvent.Source);
                 Assert.Equal(UserUpdatedEventChanges.Trn | UserUpdatedEventChanges.TrnLookupStatus, userUpdatedEvent.Changes);
-                Assert.Equal(TestClients.Client1.ClientId, userUpdatedEvent.UpdatedByClientId);
+                Assert.Equal(TestClients.DefaultClient.ClientId, userUpdatedEvent.UpdatedByClientId);
                 Assert.Equal(user.UserId, userUpdatedEvent.User.UserId);
                 Assert.Equal(TestUsers.AdminUserWithAllRoles.UserId, userUpdatedEvent.UpdatedByUserId);
             });
@@ -244,7 +244,7 @@ public class SetTeacherTrnTests : TestBase
                 Assert.Equal(Clock.UtcNow, userUpdatedEvent.CreatedUtc);
                 Assert.Equal(UserUpdatedEventSource.Api, userUpdatedEvent.Source);
                 Assert.Equal(UserUpdatedEventChanges.TrnLookupStatus, userUpdatedEvent.Changes);
-                Assert.Equal(TestClients.Client1.ClientId, userUpdatedEvent.UpdatedByClientId);
+                Assert.Equal(TestClients.DefaultClient.ClientId, userUpdatedEvent.UpdatedByClientId);
                 Assert.Equal(user.UserId, userUpdatedEvent.User.UserId);
                 Assert.Equal(TestUsers.AdminUserWithAllRoles.UserId, userUpdatedEvent.UpdatedByUserId);
             });

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/Users/UpdateUserTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/Users/UpdateUserTests.cs
@@ -173,7 +173,7 @@ public class UpdateUserTests : TestBase
                 Assert.Equal(UserUpdatedEventSource.Api, userUpdatedEvent.Source);
                 Assert.Equal(UserUpdatedEventChanges.EmailAddress | UserUpdatedEventChanges.FirstName | UserUpdatedEventChanges.LastName, userUpdatedEvent.Changes);
                 Assert.Equal(user.UserId, userUpdatedEvent.User.UserId);
-                Assert.Equal(TestClients.Client1.ClientId, userUpdatedEvent.UpdatedByClientId);
+                Assert.Equal(TestClients.DefaultClient.ClientId, userUpdatedEvent.UpdatedByClientId);
                 Assert.Equal(TestUsers.AdminUserWithAllRoles.UserId, userUpdatedEvent.UpdatedByUserId);
             });
     }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/CompleteTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/CompleteTests.cs
@@ -1,4 +1,3 @@
-using TeacherIdentity.AuthServer.Events;
 using TeacherIdentity.AuthServer.Oidc;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn;

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/CompleteTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/CompleteTests.cs
@@ -1,3 +1,4 @@
+using TeacherIdentity.AuthServer.Events;
 using TeacherIdentity.AuthServer.Oidc;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn;
@@ -42,71 +43,21 @@ public class CompleteTests : TestBase
         await JourneyMilestoneHasPassed_RedirectsToStartOfNextMilestone(milestone, HttpMethod.Get, "/sign-in/complete");
     }
 
-    [Fact]
-    public async Task Get_FirstTimeSignInForEmailWithTrn_RendersExpectedContent()
-    {
-        // Arrange
-        var user = await TestData.CreateUser(hasTrn: true);
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Completed(user, firstTimeSignIn: true), additionalScopes: null);
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/complete?{authStateHelper.ToQueryParam()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Act
-        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
-
-        var doc = await response.GetDocument();
-        Assert.NotNull(doc.GetElementByTestId("first-time-user-content"));
-        Assert.NotNull(doc.GetElementByTestId("known-trn-content"));
-        Assert.Null(doc.GetElementByTestId("unknown-trn-content"));
-    }
-
-    [Fact]
-    public async Task Get_FirstTimeSignInForEmailWithoutTrn_RendersExpectedContent()
-    {
-        // Arrange
-        var user = await TestData.CreateUser(hasTrn: false);
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Completed(user, firstTimeSignIn: true), additionalScopes: null);
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/complete?{authStateHelper.ToQueryParam()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Act
-        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
-        var doc = await response.GetDocument();
-        Assert.Null(doc.GetElementByTestId("known-trn-content"));
-        Assert.NotNull(doc.GetElementByTestId("unknown-trn-content"));
-    }
-
-    [Fact]
-    public async Task Get_KnownUser_RendersExpectedContent()
-    {
-        // Arrange
-        var user = await TestData.CreateUser();
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Completed(user, firstTimeSignIn: false), additionalScopes: null);
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/complete?{authStateHelper.ToQueryParam()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Act
-        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
-
-        var doc = await response.GetDocument();
-        Assert.NotNull(doc.GetElementByTestId("known-user-content"));
-    }
-
     [Theory]
-    [MemberData(nameof(FirstTimeSignInForRegisterForNpqData))]
-    public async Task Get_FirstTimeSignInForEmailWithoutTrnUsingRegisterForNpqClient_RendersExpectedContent(
-        string additionalScopes,
+    [MemberData(nameof(SignInCompleteState))]
+    public async Task Get_ValidRequest_RendersExpectedContent(
+        TeacherIdentityApplicationDescriptor client,
+        string? additionalScopes,
+        bool isFirstTimeSignIn,
+        bool gotTrn,
+        string expectedContentBlock,
         string[] expectedContent)
     {
         // Arrange
-        var user = await TestData.CreateUser(hasTrn: false);
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Completed(user, firstTimeSignIn: true), additionalScopes, TestClients.RegisterForNpq);
+        var user = await TestData.CreateUser(hasTrn: gotTrn);
+
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Completed(user, firstTimeSignIn: isFirstTimeSignIn), additionalScopes: additionalScopes, client: client);
+
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/complete?{authStateHelper.ToQueryParam()}");
 
         // Act
@@ -114,10 +65,8 @@ public class CompleteTests : TestBase
 
         // Act
         Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
-
         var doc = await response.GetDocument();
-        var content = doc.GetElementByTestId("first-time-user-content")?.InnerHtml;
-        Assert.Contains("Continue to register for an NPQ", content);
+        var content = doc.GetElementByTestId(expectedContentBlock)?.InnerHtml;
 
         foreach (var block in expectedContent)
         {
@@ -125,43 +74,130 @@ public class CompleteTests : TestBase
         }
     }
 
-    [Fact]
-    public async Task Get_FirstTimeSignInForEmailWithoutTrnUsingDefaultClient_RendersExpectedContent()
-    {
-        // Arrange
-        var user = await TestData.CreateUser(hasTrn: false);
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Completed(user, firstTimeSignIn: true), additionalScopes: null);
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/complete?{authStateHelper.ToQueryParam()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Act
-        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
-
-        var doc = await response.GetDocument();
-        Assert.Contains("We’ve finished checking our records", doc.GetElementByTestId("first-time-user-content")!.InnerHtml);
-        Assert.Contains("You can continue anyway and we’ll try to find your record. Someone may be in touch to ask for more information.", doc.GetElementByTestId("first-time-user-content")!.InnerHtml);
-    }
-
-    public static TheoryData<string, string[]> FirstTimeSignInForRegisterForNpqData => new()
+    public static TheoryData<TeacherIdentityApplicationDescriptor, string?, bool, bool, string, string[]> SignInCompleteState => new()
     {
         {
-#pragma warning disable CS0618 // Type or member is obsolete
-            CustomScopes.Trn,
-#pragma warning restore CS0618 // Type or member is obsolete
+            // Core journey, default client, first time sign in with TRN
+            TestClients.DefaultClient,
+            CustomScopes.DqtRead,
+            true,
+            false,
+            "first-time-user-content",
             new[]
             {
-                "Although we could not find your record, you can continue to register for an NPQ.",
-                "You’ll need to enter some of your details again."
+                "You’ve created a DfE Identity account",
+                "Next time, you can sign in just using your email",
+                $"Continue to <strong>{TestClients.DefaultClient.DisplayName}"
             }
         },
         {
-            CustomScopes.DqtRead,
+            // Core journey, default client, first time sign in without TRN
+            TestClients.DefaultClient,
+            null,
+            true,
+            false,
+            "first-time-user-content",
             new[]
             {
+                "You’ve created a DfE Identity account",
+                "Next time, you can sign in just using your email",
+                $"Continue to <strong>{TestClients.DefaultClient.DisplayName}</strong>"
+            }
+        },
+        {
+            // Core journey, default client, known user with TRN
+            TestClients.DefaultClient,
+            CustomScopes.DqtRead,
+            false,
+            false,
+            "known-user-content",
+            new[]
+            {
+                "You’ve signed in to your DfE Identity account",
+                $"Continue to <strong>{TestClients.DefaultClient.DisplayName}</strong>"
+            }
+        },
+        {
+            // Core journey, default client, known user without TRN
+            TestClients.DefaultClient,
+            null,
+            false,
+            false,
+            "known-user-content",
+            new[]
+            {
+                "You’ve signed in to your DfE Identity account",
+                $"Continue to <strong>{TestClients.DefaultClient.DisplayName}</strong>"
+            }
+        },
+        {
+            // legacy TRN journey, default client, first time sign-in with trn found
+            TestClients.LegacyTrnClient,
+            CustomScopes.DqtRead,
+            true,
+            true,
+            "legacy-first-time-user-content",
+            new[]
+            {
+                "We’ve finished checking our records",
+                "Thank you, we’ve finished checking our records.",
+                "If you need to come back to this service later you’ll only need to give us your email address",
+            }
+        },
+        {
+            // legacy TRN journey, default client, first time sign-in with trn not found
+            TestClients.LegacyTrnClient,
+            CustomScopes.DqtRead,
+            true,
+            false,
+            "legacy-first-time-user-content",
+            new[]
+            {
+                "We’ve finished checking our records",
                 "You can continue anyway and we’ll try to find your record. Someone may be in touch to ask for more information.",
-                "If you need to come back to this service later you’ll only need to give us your email address"
+                "If you need to come back to this service later you’ll only need to give us your email address",
+            }
+        },
+        {
+            // legacy TRN journey, default client, known user
+            TestClients.LegacyTrnClient,
+            CustomScopes.DqtRead,
+            false,
+            false,
+            "legacy-known-user-content",
+            new[]
+            {
+                "Your details",
+                "<dt class=\"govuk-summary-list__key\">Name</dt>",
+                "<dt class=\"govuk-summary-list__key\">Email address</dt>",
+            }
+        },
+        {
+            // legacy TRN journey, Register For NPQ Client, first time sign-in without trn not found
+            TestClients.RegisterForNpq,
+            CustomScopes.Trn,
+            true,
+            false,
+            "legacy-first-time-user-content",
+            new[]
+            {
+                "Continue to register for an NPQ",
+                "Although we could not find your record, you can continue to register for an NPQ.",
+                "You’ll need to enter some of your details again.",
+            }
+        },
+        {
+            // legacy TRN journey, Register For NPQ Client, first time sign-in without trn not found
+            TestClients.RegisterForNpq,
+            CustomScopes.DqtRead,
+            true,
+            false,
+            "legacy-first-time-user-content",
+            new[]
+            {
+                "Continue to register for an NPQ",
+                "You can continue anyway and we’ll try to find your record. Someone may be in touch to ask for more information.",
+                "If you need to come back to this service later you’ll only need to give us your email address",
             }
         }
     };

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/TestClients.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/TestClients.cs
@@ -1,4 +1,5 @@
 using OpenIddict.Abstractions;
+using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Oidc;
 using static OpenIddict.Abstractions.OpenIddictConstants;
 
@@ -6,11 +7,11 @@ namespace TeacherIdentity.AuthServer.Tests;
 
 public static class TestClients
 {
-    public static OpenIddictApplicationDescriptor[] All => new[] { Client1, ApplyForQts, RegisterForNpq };
+    public static OpenIddictApplicationDescriptor[] All => new[] { DefaultClient, LegacyTrnClient, ApplyForQts, RegisterForNpq };
 
-    public static TeacherIdentityApplicationDescriptor Client1 { get; } = new TeacherIdentityApplicationDescriptor()
+    public static TeacherIdentityApplicationDescriptor DefaultClient { get; } = new TeacherIdentityApplicationDescriptor()
     {
-        ClientId = "testclient1",
+        ClientId = "default-client",
         ClientSecret = "secret",
         ConsentType = ConsentTypes.Implicit,
         DisplayName = "Sample TeacherIdentity.TestClient app",
@@ -38,7 +39,42 @@ public static class TestClients
         Requirements =
         {
             Requirements.Features.ProofKeyForCodeExchange
-        }
+        },
+        TrnRequirementType = TrnRequirementType.Optional
+    };
+
+    public static TeacherIdentityApplicationDescriptor LegacyTrnClient { get; } = new TeacherIdentityApplicationDescriptor()
+    {
+        ClientId = "legacy-trn-client",
+        ClientSecret = "secret",
+        ConsentType = ConsentTypes.Implicit,
+        DisplayName = "Sample Legacy TeacherIdentity.TestClient app",
+        RedirectUris =
+        {
+            new Uri("https://localhost:1234/oidc/callback")
+        },
+        Permissions =
+        {
+            Permissions.Endpoints.Authorization,
+            Permissions.Endpoints.Token,
+            Permissions.GrantTypes.AuthorizationCode,
+            Permissions.GrantTypes.Password,
+            Permissions.ResponseTypes.Code,
+            Permissions.Scopes.Email,
+            Permissions.Scopes.Profile,
+            $"{Permissions.Prefixes.Scope}{CustomScopes.DqtRead}",
+            $"{Permissions.Prefixes.Scope}{CustomScopes.GetAnIdentitySupport}",
+            $"{Permissions.Prefixes.Scope}{CustomScopes.UserRead}",
+            $"{Permissions.Prefixes.Scope}{CustomScopes.UserWrite}",
+#pragma warning disable CS0618 // Type or member is obsolete
+            $"{Permissions.Prefixes.Scope}{CustomScopes.Trn}",
+#pragma warning restore CS0618 // Type or member is obsolete
+        },
+        Requirements =
+        {
+            Requirements.Features.ProofKeyForCodeExchange
+        },
+        TrnRequirementType = TrnRequirementType.Legacy
     };
 
     public static TeacherIdentityApplicationDescriptor ApplyForQts { get; } = new TeacherIdentityApplicationDescriptor()


### PR DESCRIPTION
### Context

The /sign-in/complete page is a shared page used by all journeys when inside an OAuth sign in. The content should be different depending on the journey, however. We’re missing the content for the core journey.

### Changes proposed in this pull request

Amend the /sign-in/complete page so it matches the designs in the prototype.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
