### PR TITLE
Only lint changed files for PR builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,19 +58,40 @@ jobs:
         with:
           dotnet-version: '7.0.202'
 
+      - name: Restore
+        run: dotnet restore
+        working-directory: dotnet-authserver
+
       - name: Lint
         if: github.event_name != 'push'
         run: |
-          #https://github.com/dotnet/format/issues/1433
-          dotnet tool install -g dotnet-format --version "7.*" --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json
-          dotnet-format --verify-no-changes
+          INCLUDE_ARG=""
+          if [ "$EVENT_NAME" == "pull_request" ]; then
+            git fetch origin main --quiet --depth=1
+            CHANGED_FILES=$(git diff --name-only origin/main $GITHUB_SHA | { grep '^dotnet-authserver.*\.cs$' || true; })
+
+            if [ "$CHANGED_FILES" == "" ]; then
+              echo "::warning::No changes to lint"
+              exit 0
+            fi
+
+            INCLUDE_ARG="--include $(echo "$CHANGED_FILES" | tr '\n' ' ')"
+            echo "::notice::Linting changed files only"
+          else
+            echo "::notice::Linting entire codebase"
+          fi
+
+          dotnet tool install -g dotnet-format --version "7.*" --add-source https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json >/dev/null
+          dotnet-format --no-restore --verify-no-changes $INCLUDE_ARG
+        env:
+          EVENT_NAME: ${{ github.event_name }}
         working-directory: dotnet-authserver
 
       - name: Install SASS
         run: npm install -g sass
 
       - name: Build
-        run: dotnet build --configuration Release
+        run: dotnet build --configuration Release --no-restore
         working-directory: dotnet-authserver
 
       - name: Unit tests


### PR DESCRIPTION
The lint step of our build is becoming slow, since we scan the entire solution. This change amends the step to only lint changed files for PR builds.