### PR TITLE
Update API validation to use new EmailAddress object

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Requests/PostTrnTokensRequest.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Requests/PostTrnTokensRequest.cs
@@ -1,4 +1,3 @@
-using System.ComponentModel.DataAnnotations;
 using MediatR;
 using TeacherIdentity.AuthServer.Api.V1.Responses;
 
@@ -6,9 +5,7 @@ namespace TeacherIdentity.AuthServer.Api.V1.Requests;
 
 public record PostTrnTokensRequest : IRequest<PostTrnTokenResponse>
 {
-    [RegularExpression(@"^\d{7}$", ErrorMessage = "TRN must be 7 digits")]
     public required string Trn { get; init; }
 
-    [EmailAddress]
     public required string Email { get; init; }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Validators/PostTrnTokensRequestValidator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Validators/PostTrnTokensRequestValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+using TeacherIdentity.AuthServer.Api.V1.Requests;
+using TeacherIdentity.AuthServer.Api.Validation;
+
+namespace TeacherIdentity.AuthServer.Api.V1.Validators;
+
+public class PostTrnTokensRequestValidator : AbstractValidator<PostTrnTokensRequest>
+{
+    public PostTrnTokensRequestValidator()
+    {
+        RuleFor(r => r.Trn)
+            .Must(trn => trn is null || (trn.Length == 7 && trn.All(Char.IsAsciiDigit)))
+            .WithMessage("TRN is not valid.");
+
+        RuleFor(r => r.Email)
+            .IdentityEmailAddress();
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Validators/PostTrnTokensRequestValidator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Validators/PostTrnTokensRequestValidator.cs
@@ -13,6 +13,7 @@ public class PostTrnTokensRequestValidator : AbstractValidator<PostTrnTokensRequ
             .WithMessage("TRN is not valid.");
 
         RuleFor(r => r.Email)
+            .Cascade(CascadeMode.Stop)
             .IdentityEmailAddress();
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Validators/UpdateUserRequestValidator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Validators/UpdateUserRequestValidator.cs
@@ -10,6 +10,7 @@ public class UpdateUserRequestValidator : AbstractValidator<UpdateUserRequest>
     public UpdateUserRequestValidator()
     {
         RuleFor(r => r.Body.Email)
+            .Cascade(CascadeMode.Stop)
             .IdentityEmailAddress()
             .When(r => r.Body.EmailSet);
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Validators/UpdateUserRequestValidator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Validators/UpdateUserRequestValidator.cs
@@ -1,5 +1,6 @@
 using FluentValidation;
 using TeacherIdentity.AuthServer.Api.V1.Requests;
+using TeacherIdentity.AuthServer.Api.Validation;
 using TeacherIdentity.AuthServer.Models;
 
 namespace TeacherIdentity.AuthServer.Api.V1.Validators;
@@ -9,11 +10,7 @@ public class UpdateUserRequestValidator : AbstractValidator<UpdateUserRequest>
     public UpdateUserRequestValidator()
     {
         RuleFor(r => r.Body.Email)
-            .Cascade(CascadeMode.Stop)
-            .EmailAddress()
-                .WithMessage("Email is not valid.")
-            .MaximumLength(User.EmailAddressMaxLength)
-                .WithMessage($"Email must be {User.EmailAddressMaxLength} characters or less.")
+            .IdentityEmailAddress()
             .When(r => r.Body.EmailSet);
 
         RuleFor(r => r.Body.FirstName)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/Validation/ValidationExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/Validation/ValidationExtensions.cs
@@ -7,9 +7,9 @@ public static class ValidationExtensions
     public static IRuleBuilderOptions<T, string?> IdentityEmailAddress<T>(this IRuleBuilder<T, string?> ruleBuilder)
     {
         return ruleBuilder
-            .Must(email => Models.EmailAddress.TryParse(email, out _))
-            .WithMessage("Email is not valid.")
             .MaximumLength(Models.EmailAddress.EmailAddressMaxLength)
-            .WithMessage($"Email must be {Models.EmailAddress.EmailAddressMaxLength} characters or less.");
+            .WithMessage($"Email must be {Models.EmailAddress.EmailAddressMaxLength} characters or less.")
+            .Must(email => Models.EmailAddress.TryParse(email, out _))
+            .WithMessage("Email is not valid.");
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/Validation/ValidationExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/Validation/ValidationExtensions.cs
@@ -1,0 +1,15 @@
+using FluentValidation;
+
+namespace TeacherIdentity.AuthServer.Api.Validation;
+
+public static class ValidationExtensions
+{
+    public static IRuleBuilderOptions<T, string?> IdentityEmailAddress<T>(this IRuleBuilder<T, string?> ruleBuilder)
+    {
+        return ruleBuilder
+            .Must(email => Models.EmailAddress.TryParse(email, out _))
+            .WithMessage("Email is not valid.")
+            .MaximumLength(Models.EmailAddress.EmailAddressMaxLength)
+            .WithMessage($"Email must be {Models.EmailAddress.EmailAddressMaxLength} characters or less.");
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/EmailAddress.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/EmailAddress.cs
@@ -11,6 +11,8 @@ namespace TeacherIdentity.AuthServer.Models;
 [DebuggerDisplay("{_normalizedValue}")]
 public sealed class EmailAddress : IEquatable<EmailAddress>, IParsable<EmailAddress>
 {
+    public const int EmailAddressMaxLength = 200;
+
     private const string ValidLocalChars = @"a-zA-Z0-9.!#$%&'*+/=?^_`{|}~\-";
     private const string EmailRegexPattern = @"^[" + ValidLocalChars + @"]+@([^.@][^@\s]+)$";
 
@@ -27,7 +29,7 @@ public sealed class EmailAddress : IEquatable<EmailAddress>, IParsable<EmailAddr
         _normalizedValue = normalizedValue;
     }
 
-    public static EmailAddress Parse(string emailAddress)
+    public static EmailAddress Parse(string? emailAddress)
     {
         if (!TryParseCore(emailAddress, out var result, out var error))
         {
@@ -37,10 +39,10 @@ public sealed class EmailAddress : IEquatable<EmailAddress>, IParsable<EmailAddr
         return result;
     }
 
-    public static bool TryParse(string emailAddress, [MaybeNullWhen(false)] out EmailAddress result) =>
+    public static bool TryParse(string? emailAddress, [MaybeNullWhen(false)] out EmailAddress result) =>
         TryParseCore(emailAddress, out result, out _);
 
-    static EmailAddress IParsable<EmailAddress>.Parse(string s, IFormatProvider? provider) => Parse(s);
+    static EmailAddress IParsable<EmailAddress>.Parse(string? s, IFormatProvider? provider) => Parse(s);
 
     static bool IParsable<EmailAddress>.TryParse(
         string? s,
@@ -57,10 +59,17 @@ public sealed class EmailAddress : IEquatable<EmailAddress>, IParsable<EmailAddr
     }
 
     private static bool TryParseCore(
-        string emailAddress,
+        string? emailAddress,
         [MaybeNullWhen(false)] out EmailAddress result,
         [MaybeNullWhen(true)] out FormatException error)
     {
+        if (emailAddress is null)
+        {
+            error = new FormatException("Email address must have a value.");
+            result = default;
+            return false;
+        }
+
         var normalizedEmailAddress = StripAndRemoveObscureWhitespace(emailAddress);
         Match match = Regex.Match(normalizedEmailAddress, EmailRegexPattern);
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/Mappings/UserMapping.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/Mappings/UserMapping.cs
@@ -11,7 +11,7 @@ public class UserMapping : IEntityTypeConfiguration<User>
             "users",
             t => t.HasCheckConstraint("ck_trn_lookup_status", "(completed_trn_lookup is null and trn is null) or trn_lookup_status is not null"));
         builder.HasKey(u => u.UserId);
-        builder.Property(u => u.EmailAddress).HasMaxLength(User.EmailAddressMaxLength).IsRequired().UseCollation("case_insensitive");
+        builder.Property(u => u.EmailAddress).HasMaxLength(EmailAddress.EmailAddressMaxLength).IsRequired().UseCollation("case_insensitive");
         builder.HasIndex(u => u.EmailAddress).IsUnique().HasDatabaseName(User.EmailAddressUniqueIndexName).HasFilter("is_deleted = false");
         builder.HasIndex(u => u.Trn).IsUnique().HasFilter("is_deleted = false and trn is not null");
         builder.Property(u => u.FirstName).HasMaxLength(User.FirstNameMaxLength).IsRequired();

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/User.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/User.cs
@@ -2,7 +2,6 @@ namespace TeacherIdentity.AuthServer.Models;
 
 public class User
 {
-    public const int EmailAddressMaxLength = 200;
     public const int FirstNameMaxLength = 200;
     public const int LastNameMaxLength = 200;
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditStaffUser.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditStaffUser.cshtml.cs
@@ -29,7 +29,7 @@ public class EditStaffUserModel : PageModel
     [Display(Name = "Email address")]
     [Required(ErrorMessage = "Enter the user’s email address")]
     [EmailAddress(ErrorMessage = "Enter a valid email address")]
-    [MaxLength(Models.User.EmailAddressMaxLength, ErrorMessage = "Email address must be 200 characters or less")]
+    [MaxLength(Models.EmailAddress.EmailAddressMaxLength, ErrorMessage = "Email address must be 200 characters or less")]
     public string? Email { get; set; }
 
     [Display(Name = "First name")]

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/UserImport/UserImportProcessor.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/UserImport/UserImportProcessor.cs
@@ -86,9 +86,9 @@ public class UserImportProcessor : IUserImportProcessor
                 {
                     errors.Add($"{UserImportRow.EmailAddressHeader} field is empty");
                 }
-                else if (row.EmailAddress.Length > User.EmailAddressMaxLength)
+                else if (row.EmailAddress.Length > EmailAddress.EmailAddressMaxLength)
                 {
-                    errors.Add($"{UserImportRow.EmailAddressHeader} field should have a maximum of {User.EmailAddressMaxLength} characters");
+                    errors.Add($"{UserImportRow.EmailAddressHeader} field should have a maximum of {EmailAddress.EmailAddressMaxLength} characters");
                 }
                 else
                 {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Services/UserImport/UserImportProcessorTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Services/UserImport/UserImportProcessorTests.cs
@@ -136,7 +136,7 @@ public class UserImportProcessorTests : IClassFixture<DbFixture>
             {
                 ExistingUsers = null,
                 Id = "UserImportProcessorTests7",
-                EmailAddress = $"{new string('a', User.EmailAddressMaxLength + 1)}@email.com",
+                EmailAddress = $"{new string('a', EmailAddress.EmailAddressMaxLength + 1)}@email.com",
                 FirstName = Faker.Name.First(),
                 LastName = Faker.Name.Last(),
                 DateOfBirth = "05021970",
@@ -145,7 +145,7 @@ public class UserImportProcessorTests : IClassFixture<DbFixture>
                 UseMockUserSearchService = true,
                 ExpectUserToBeInserted = false,
                 ExpectUserImportedEventToBeInserted = false,
-                ExpectedNotes = new [] { $"{UserImportRow.EmailAddressHeader} field should have a maximum of {User.EmailAddressMaxLength} characters" },
+                ExpectedNotes = new [] { $"{UserImportRow.EmailAddressHeader} field should have a maximum of {EmailAddress.EmailAddressMaxLength} characters" },
                 ExpectedUserImportRowResult = UserImportRowResult.Invalid
             },
             // 8. Invalid format EMAIL_ADDRESS field


### PR DESCRIPTION
### Context

We’ve added improved email validation the mirrors what Notify does. We need to update the API to use these improvements.

### Changes proposed in this pull request

Amend the UpdateUserRequestValidator to use EmailAddress.TryParse instead of FluentValidation’s built-in email validator.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
