### PR TITLE
Added support for UserCreated web hook message type

### DIFF
--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -26,7 +26,28 @@ Notifications are sent as JSON and have a common outer schema called the envelop
 
 ## Message types
 
-The are two notification messages types currently; one is for when a user is changed (name, email address etc.) and the other is for when two users are merged.
+The are 3 notification messages types currently; one is for when a new user is registered, one is for when a user is changed (name, email address etc.) and the other is for when two users are merged.
+
+### `UserCreated`
+
+`UserCreated` is generated when a new DfE Identity account is created via the UI. It has the following message schema:
+
+```json
+{
+  "user": {
+    "userId": "",
+    "emailAddress": "",
+    "firstName": "",
+    "lastName": "",
+    "dateOfBirth": "",
+    "trn": "",
+    "mobileNumber": "",
+    "trnLookupStatus": "None|Pending|Found|Failed"
+  }
+}
+```
+
+The `user` object contains the complete set of user information. `trn` may be `null`.
 
 ### `UserUpdated`
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/WebHookMessageTypes.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/WebHookMessageTypes.cs
@@ -7,6 +7,7 @@ public enum WebHookMessageTypes
 
     UserUpdated = 1 << 0,
     UserMerged = 1 << 1,
+    UserCreated = 1 << 2,
 
-    All = UserUpdated | UserMerged
+    All = UserUpdated | UserMerged | UserCreated
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Notifications/Messages/UserCreatedMessage.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Notifications/Messages/UserCreatedMessage.cs
@@ -1,0 +1,8 @@
+namespace TeacherIdentity.AuthServer.Notifications.Messages;
+
+public record UserCreatedMessage : INotificationMessage
+{
+    public const string MessageTypeName = "UserCreated";
+
+    public required User User { get; init; }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Notifications/PublishNotificationsEventObserver.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Notifications/PublishNotificationsEventObserver.cs
@@ -79,5 +79,23 @@ public class PublishNotificationsEventObserver : IEventObserver
                 TimeUtc = userMerged.CreatedUtc
             };
         }
+        else if (@event is UserRegisteredEvent userCreated)
+        {
+            if (userCreated.User.UserType == Models.UserType.Staff)
+            {
+                yield break;
+            }
+
+            yield return new NotificationEnvelope()
+            {
+                NotificationId = Guid.NewGuid(),
+                Message = new UserCreatedMessage()
+                {
+                    User = userCreated.User
+                },
+                MessageType = UserCreatedMessage.MessageTypeName,
+                TimeUtc = userCreated.CreatedUtc
+            };
+        }
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Notifications/WebHooks/WebHookNotificationPublisher.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Notifications/WebHooks/WebHookNotificationPublisher.cs
@@ -80,6 +80,7 @@ public class WebHookNotificationPublisher : INotificationPublisher
         {
             UserUpdatedMessage.MessageTypeName => WebHookMessageTypes.UserUpdated,
             UserMergedMessage.MessageTypeName => WebHookMessageTypes.UserMerged,
+            UserCreatedMessage.MessageTypeName => WebHookMessageTypes.UserCreated,
             _ => WebHookMessageTypes.All,
         };
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AddWebHook.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AddWebHook.cshtml
@@ -18,6 +18,7 @@
         <govuk-checkboxes-fieldset>
             <govuk-checkboxes-fieldset-legend class="govuk-fieldset__legend--m" />
 
+            <govuk-checkboxes-item value="@WebHookMessageTypes.UserCreated" checked="@Model.WebHookMessageTypes.HasFlag(WebHookMessageTypes.UserCreated)">@UserCreatedMessage.MessageTypeName</govuk-checkboxes-item>
             <govuk-checkboxes-item value="@WebHookMessageTypes.UserUpdated" checked="@Model.WebHookMessageTypes.HasFlag(WebHookMessageTypes.UserUpdated)">@UserUpdatedMessage.MessageTypeName</govuk-checkboxes-item>
             <govuk-checkboxes-item value="@WebHookMessageTypes.UserMerged" checked="@Model.WebHookMessageTypes.HasFlag(WebHookMessageTypes.UserMerged)">@UserMergedMessage.MessageTypeName</govuk-checkboxes-item>
         </govuk-checkboxes-fieldset>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditWebHook.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditWebHook.cshtml
@@ -22,6 +22,7 @@
         <govuk-checkboxes-fieldset>
             <govuk-checkboxes-fieldset-legend class="govuk-fieldset__legend--m" />
 
+            <govuk-checkboxes-item value="@WebHookMessageTypes.UserCreated" checked="@Model.WebHookMessageTypes.HasFlag(WebHookMessageTypes.UserCreated)">@UserCreatedMessage.MessageTypeName</govuk-checkboxes-item>
             <govuk-checkboxes-item value="@WebHookMessageTypes.UserUpdated" checked="@Model.WebHookMessageTypes.HasFlag(WebHookMessageTypes.UserUpdated)">@UserUpdatedMessage.MessageTypeName</govuk-checkboxes-item>
             <govuk-checkboxes-item value="@WebHookMessageTypes.UserMerged" checked="@Model.WebHookMessageTypes.HasFlag(WebHookMessageTypes.UserMerged)">@UserMergedMessage.MessageTypeName</govuk-checkboxes-item>
         </govuk-checkboxes-fieldset>


### PR DESCRIPTION
### Context

We send out a webhook message when users are updated, or when users are merged. We don’t currently have a message for when users are created. We need this for syncing user data with DQT.

### Changes proposed in this pull request

Support for publishing "UserCreated" webhook message + filtering in UI

### Guidance to review

N/A

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
