### PR TITLE
Create recurring job to purge expired confirmation pins

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Jobs/PurgeConfirmationPinsJob.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Jobs/PurgeConfirmationPinsJob.cs
@@ -1,0 +1,47 @@
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.Jobs;
+
+public class PurgeConfirmationPinsJob
+{
+    private static readonly TimeSpan _expiredPinGracePeriod = TimeSpan.FromDays(7);
+
+    private readonly TeacherIdentityServerDbContext _dbContext;
+
+    public PurgeConfirmationPinsJob(TeacherIdentityServerDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task Execute(CancellationToken cancellationToken)
+    {
+        await DeleteEmailConfirmationPins(cancellationToken);
+        await DeleteSmsConfirmationPins(cancellationToken);
+    }
+
+    private async Task DeleteEmailConfirmationPins(CancellationToken cancellationToken)
+    {
+        var expiredEmailConfirmationPins = _dbContext.EmailConfirmationPins
+            .Where(p => p.Expires < DateTime.UtcNow - _expiredPinGracePeriod)
+            .ToList();
+
+        if (expiredEmailConfirmationPins.Any())
+        {
+            _dbContext.EmailConfirmationPins.RemoveRange(expiredEmailConfirmationPins);
+            await _dbContext.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+    private async Task DeleteSmsConfirmationPins(CancellationToken cancellationToken)
+    {
+        var expiredSmsConfirmationPins = _dbContext.SmsConfirmationPins
+            .Where(p => p.Expires < DateTime.UtcNow - _expiredPinGracePeriod)
+            .ToList();
+
+        if (expiredSmsConfirmationPins.Any())
+        {
+            _dbContext.SmsConfirmationPins.RemoveRange(expiredSmsConfirmationPins);
+            await _dbContext.SaveChangesAsync(cancellationToken);
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Jobs/RegisterRecurringJobsHostedService.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Jobs/RegisterRecurringJobsHostedService.cs
@@ -29,5 +29,6 @@ public class RegisterRecurringJobsHostedService : IHostedService
     {
         _recurringJobManager.AddOrUpdate<PruneTokensJob>(nameof(PruneTokensJob), job => job.Execute(CancellationToken.None), Cron.Hourly);
         _recurringJobManager.AddOrUpdate<RefreshEstablishmentDomainsJob>(nameof(RefreshEstablishmentDomainsJob), job => job.Execute(CancellationToken.None), _giasOptions.Value.RefreshEstablishmentDomainsJobSchedule);
+        _recurringJobManager.AddOrUpdate<PurgeConfirmationPinsJob>(nameof(PurgeConfirmationPinsJob), job => job.Execute(CancellationToken.None), Cron.Daily);
     }
 }


### PR DESCRIPTION
### Context

We stash PINs for email and SMS verification in our DB but they’re never removed.

### Changes proposed in this pull request

Create a recurring Hangfire job that purges old rows from the email_confirmation_pins and sms_confirmation_pins tables. And old row is any row where the code expired at least 7 days ago.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
