### PR TITLE
Remove soft hyphens from email addresses

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/ModelBinding/RemoveSoftHyphensModelBinderWrapper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/ModelBinding/RemoveSoftHyphensModelBinderWrapper.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace TeacherIdentity.AuthServer.Infrastructure.ModelBinding;
+
+public class RemoveSoftHyphensModelBinderWrapper : IModelBinder
+{
+    private readonly IModelBinder _innerBinder;
+
+    public RemoveSoftHyphensModelBinderWrapper(IModelBinder innerBinder)
+    {
+        _innerBinder = innerBinder;
+    }
+
+    public async Task BindModelAsync(ModelBindingContext bindingContext)
+    {
+        await _innerBinder.BindModelAsync(bindingContext);
+
+        if (bindingContext.Result.IsModelSet)
+        {
+            var value = (string?)bindingContext.Result.Model;
+            var withoutSoftHyphens = value?.Replace("\u00AD", "");
+            bindingContext.Result = ModelBindingResult.Success(withoutSoftHyphens);
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/ModelBinding/SimpleTypeModelBinderProviderWrapper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Infrastructure/ModelBinding/SimpleTypeModelBinderProviderWrapper.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Metadata;
+
+namespace TeacherIdentity.AuthServer.Infrastructure.ModelBinding;
+
+public class SimpleTypeModelBinderProviderWrapper : IModelBinderProvider
+{
+    private readonly SimpleTypeModelBinderProvider _innerProvider;
+
+    public SimpleTypeModelBinderProviderWrapper(SimpleTypeModelBinderProvider innerProvider)
+    {
+        _innerProvider = innerProvider;
+    }
+
+    public IModelBinder? GetBinder(ModelBinderProviderContext context)
+    {
+        var innerBinder = _innerProvider.GetBinder(context);
+
+        if (innerBinder is not null &&
+            context.Metadata is DefaultModelMetadata defaultModelMetadata &&
+            defaultModelMetadata.Attributes.Attributes.OfType<EmailAddressAttribute>().Any())
+        {
+            return new RemoveSoftHyphensModelBinderWrapper(innerBinder);
+        }
+
+        return innerBinder;
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
@@ -17,6 +17,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Abstractions;
 using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
+using Microsoft.AspNetCore.Mvc.ModelBinding.Binders;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Distributed;
@@ -440,6 +441,12 @@ public class Program
                 options.Conventions.Add(new Infrastructure.ApplicationModel.ApiControllerConvention());
 
                 options.ModelBinderProviders.Insert(0, new DateOnlyModelBinderProvider());
+
+                {
+                    var simpleTypeModelBinderProvider = options.ModelBinderProviders.OfType<SimpleTypeModelBinderProvider>().Single();
+                    options.ModelBinderProviders[options.ModelBinderProviders.IndexOf(simpleTypeModelBinderProvider)] =
+                        new SimpleTypeModelBinderProviderWrapper(simpleTypeModelBinderProvider);
+                }
             })
             .AddSessionStateTempDataProvider();
 


### PR DESCRIPTION
We use soft hyphens when displaying emails so that they format better when wrapping over multiple lines. When copy/pasting them though we retain those special characters and our email validation fails.

This change wraps the standard model binder for strings with something that removes soft hyphens if the property is decorated with our `EmailAddressAttribute`.

There's been some talk about auto-trimming all string fields; this approach of wrapping built-in binders could also be used to do that in future.