### PR TITLE
Omit the dotnet-authserver prefix from files to lint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -68,8 +68,7 @@ jobs:
           INCLUDE_ARG=""
           if [ "$EVENT_NAME" == "pull_request" ]; then
             git fetch origin main --quiet --depth=1
-            CHANGED_FILES=$(git diff --name-only origin/main $GITHUB_SHA | { grep '^dotnet-authserver.*\.cs$' || true; })
-
+            CHANGED_FILES=$(git diff --name-only origin/main $GITHUB_SHA | { grep -oP '^dotnet-authserver\/\K.*\.cs$' || true; })
             if [ "$CHANGED_FILES" == "" ]; then
               echo "::warning::No changes to lint"
               exit 0


### PR DESCRIPTION
### Context

Github actions wasn't properly linting changed files due to incorrect relative filepath being used for dotnet-format. 

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
