### PR TITLE
Add preferred_name claim

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
@@ -359,6 +359,7 @@ public class AuthorizationController : Controller
             case Claims.GivenName:
             case Claims.FamilyName:
             case Claims.Birthdate:
+            case CustomClaims.PreferredName:
                 if (principal.HasScope(Scopes.Profile))
                 {
                     yield return Destinations.IdentityToken;
@@ -386,12 +387,10 @@ public class AuthorizationController : Controller
 
             case CustomClaims.Trn:
             case CustomClaims.TrnLookupStatus:
-#pragma warning disable CS0618 // Type or member is obsolete
                 if (principal.HasScope(CustomScopes.Trn) || principal.HasScope(CustomScopes.DqtRead))
                 {
                     yield return Destinations.IdentityToken;
                 }
-#pragma warning restore CS0618 // Type or member is obsolete
 
                 yield break;
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Oidc/CustomClaims.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Oidc/CustomClaims.cs
@@ -5,8 +5,8 @@ public static class CustomClaims
     public const string DateFormat = "yyyy-MM-dd";
 
     public const string Trn = "trn";
-    public const string TrnLookupStatus = "trn-lookup-status";
-    public const string HaveCompletedTrnLookup = "completed-trn-lookup";
-    public const string UserType = "user-type";
-    public const string PreviousUserId = "previous-user-id";
+    public const string TrnLookupStatus = "trn_lookup_status";
+    public const string UserType = "user_type";
+    public const string PreviousUserId = "previous_user_id";
+    public const string PreferredName = "preferred_name";
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
@@ -419,7 +419,12 @@ public class Program
                 options.DisableAccessTokenEncryption();
                 options.SetAccessTokenLifetime(TimeSpan.FromHours(1));
 
-                options.RegisterClaims(CustomClaims.Trn);
+                options.RegisterClaims(
+                    CustomClaims.Trn,
+                    CustomClaims.TrnLookupStatus,
+                    CustomClaims.PreviousUserId,
+                    CustomClaims.PreferredName);
+
                 options.RegisterScopes(
                     CustomScopes.All
                         .Append(Scopes.Email)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/UserClaimHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/UserClaimHelper.cs
@@ -61,6 +61,7 @@ public class UserClaimHelper
             new Claim(Claims.Email, user.EmailAddress),
             new Claim(Claims.EmailVerified, bool.TrueString),
             new Claim(Claims.Name, $"{user.FirstName} {user.LastName}"),
+            new Claim(CustomClaims.PreferredName, $"{user.FirstName} {user.LastName}"),
             new Claim(Claims.GivenName, user.FirstName),
             new Claim(Claims.FamilyName, user.LastName),
         };

--- a/dotnet-authserver/src/TeacherIdentity.TestClient/Controllers/HomeController.cs
+++ b/dotnet-authserver/src/TeacherIdentity.TestClient/Controllers/HomeController.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -16,11 +17,12 @@ public class HomeController : Controller
     {
         var model = new ProfileModel()
         {
-            Email = User.FindFirst("email")?.Value,
-            UserId = User.FindFirst("sub")?.Value,
-            FirstName = User.FindFirst("given_name")?.Value,
-            LastName = User.FindFirst("family_name")?.Value,
-            Trn = User.FindFirst("trn")?.Value
+            Email = User.FindFirstValue("email"),
+            UserId = User.FindFirstValue("sub"),
+            FirstName = User.FindFirstValue("given_name"),
+            LastName = User.FindFirstValue("family_name"),
+            PreferredName = User.FindFirstValue("preferred-name"),
+            Trn = User.FindFirstValue("trn")
         };
 
         return View(model);

--- a/dotnet-authserver/src/TeacherIdentity.TestClient/Models/ProfileModel.cs
+++ b/dotnet-authserver/src/TeacherIdentity.TestClient/Models/ProfileModel.cs
@@ -6,5 +6,6 @@ public class ProfileModel
     public string? Email { get; set; }
     public string? FirstName { get; set; }
     public string? LastName { get; set; }
+    public string? PreferredName { get; set; }
     public string? Trn { get; set; }
 }

--- a/dotnet-authserver/src/TeacherIdentity.TestClient/Views/Home/Profile.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.TestClient/Views/Home/Profile.cshtml
@@ -1,4 +1,4 @@
-﻿@model ProfileModel
+@model ProfileModel
 
 <p class="govuk-body">
   Hi
@@ -10,4 +10,5 @@
   Email: <span data-testid="email">@Model.Email</span><br />
   User ID: @Model.UserId<br />
   TRN: <span data-testid="trn">@Model.Trn</span><br />
+  Preferred name: <span data-testid="preferred-name">@Model.PreferredName</span><br />
 </p>

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/UserClaimHelperTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/UserClaimHelperTests.cs
@@ -39,6 +39,7 @@ public class UserClaimHelperTests : IClassFixture<DbFixture>
             new Claim(Claims.Email, user.EmailAddress),
             new Claim(Claims.EmailVerified, bool.TrueString),
             new Claim(Claims.Name, user.FirstName + " " + user.LastName),
+            new Claim(CustomClaims.PreferredName, user.FirstName + " " + user.LastName),
             new Claim(Claims.GivenName, user.FirstName),
             new Claim(Claims.FamilyName, user.LastName),
             new Claim(Claims.Birthdate, user.DateOfBirth!.Value.ToString("yyyy-MM-dd")),
@@ -79,11 +80,9 @@ public class UserClaimHelperTests : IClassFixture<DbFixture>
         var userClaimHelper = new UserClaimHelper(dbContext);
 
         // Act
-#pragma warning disable CS0618 // Type or member is obsolete
         var result = await userClaimHelper.GetPublicClaims(
             user.UserId,
             hasScope: scope => false);
-#pragma warning restore CS0618 // Type or member is obsolete
 
         // Assert
         if (hasMergedUsers)


### PR DESCRIPTION
In the future we're going to add a separate preferred name field for ID accounts. We'll be sending this as an additional optional claim. So that services can begin to prepare for this claim being added, add it now but populate it with `name`.

I've also fixed up the naming format for our custom claims; I've checked and nobody externally is depending on these names just yet.