### PR TITLE
Handle existing user found with TRN in Core journey

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/ResendTrnOwnerEmailConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/ResendTrnOwnerEmailConfirmation.cshtml.cs
@@ -5,7 +5,6 @@ using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn;
 
-[CheckJourneyType(typeof(LegacyTrnJourney))]
 [CheckCanAccessStep(CurrentStep)]
 public class ResendTrnOwnerEmailConfirmationModel : PageModel
 {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnInUse.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnInUse.cshtml.cs
@@ -5,7 +5,6 @@ using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn;
 
-[CheckJourneyType(typeof(LegacyTrnJourney))]
 [CheckCanAccessStep(CurrentStep)]
 public class TrnInUseModel : BaseEmailConfirmationPageModel
 {
@@ -38,11 +37,11 @@ public class TrnInUseModel : BaseEmailConfirmationPageModel
             return this.PageWithErrors();
         }
 
-        var VerifyEmailPinFailedReasons = await UserVerificationService.VerifyEmailPin(Email!, Code!);
+        var verifyEmailPinFailedReasons = await UserVerificationService.VerifyEmailPin(Email!, Code!);
 
-        if (VerifyEmailPinFailedReasons != PinVerificationFailedReasons.None)
+        if (verifyEmailPinFailedReasons != PinVerificationFailedReasons.None)
         {
-            return await HandlePinVerificationFailed(VerifyEmailPinFailedReasons);
+            return await HandlePinVerificationFailed(verifyEmailPinFailedReasons);
         }
 
         _journey.AuthenticationState.OnEmailVerifiedOfExistingAccountForTrn();

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnInUseChooseEmail.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnInUseChooseEmail.cshtml.cs
@@ -7,7 +7,6 @@ using TeacherIdentity.AuthServer.Models;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn;
 
-[CheckJourneyType(typeof(LegacyTrnJourney))]
 [CheckCanAccessStep(CurrentStep)]
 public class TrnInUseChooseEmailModel : PageModel
 {


### PR DESCRIPTION
### Context

When we lookup a TRN we may find it’s linked to an existing account. Instead of creating another account, we should prompt the user to sign in to the existing account and then choose the email they want to use going forward.

### Changes proposed in this pull request

Handle the exception caused when trying to create a new account with a TRN that’s already allocated, send a confirmation code to the existing account’s email address then redirect to /sign-in/trn/different-email. Ensure the existing pages work correctly with this new journey.

Add an e2e test that covers this scenario.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
