### PR TITLE
Add links to the TestClient for each journey type

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.TestClient/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.TestClient/Program.cs
@@ -62,6 +62,12 @@ public class Program
                         ctx.ProtocolMessage.Scope = customScope;
                     }
 
+                    var trnRequirement = ctx.HttpContext.Request.Query["trn_requirement"].ToString();
+                    if (!string.IsNullOrEmpty(trnRequirement))
+                    {
+                        ctx.ProtocolMessage.SetParameter("trn_requirement", trnRequirement);
+                    }
+
                     return Task.CompletedTask;
                 };
 

--- a/dotnet-authserver/src/TeacherIdentity.TestClient/Views/Home/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.TestClient/Views/Home/Index.cshtml
@@ -1,3 +1,30 @@
+<div class="govuk-!-margin-bottom-8">
+    <h3 class="govuk-heading-s">Journeys</h3>
+    <ul class="govuk-list">
+        <li>
+            <a asp-action="Profile" asp-route-scope="email openid profile trn" asp-route-trn_requirement="Legacy" class="govuk-link">
+                Legacy TRN (NPQ)
+            </a>
+        </li>
+        <li>
+            <a asp-action="Profile" asp-route-scope="email openid profile" class="govuk-link">
+                Core (Apply for QTS)
+            </a>
+        </li>
+        <li>
+            <a asp-action="Profile" asp-route-scope="email openid profile dqt:read" asp-route-trn_requirement="Required" class="govuk-link">
+                Core + TRN lookup (Access your teaching qualifications)
+            </a>
+        </li>
+        <li>
+            <a asp-action="Profile" asp-route-scope="email openid profile dqt:read" asp-route-trn_requirement="Optional" class="govuk-link">
+                Core + TRN lookup (NPQ)
+            </a>
+        </li>
+    </ul>
+</div>
+
+<h3 class="govuk-heading-s">Custom</h3>
 <form asp-action="Profile" method="get">
     <govuk-input name="scope" value="email openid profile dqt:read" input-class="govuk-input--width-20">
         <govuk-input-label>Scope</govuk-input-label>


### PR DESCRIPTION
Our TestClient isn't super friendly today; you have to know what combination of scopes to enter for each journey and it's also somewhat dependent on how the TestClient is configured.

This PR makes two changes; the first is to allow overriding the `TrnRequirementType` for a client by adding an additional query parameter to the authorize endpoint. With that a single client can support every journey. The second is to add links for each journey that are pre-decorated with the correct `scope` and `trn_requirement`.

There's a separate PR in-flight that adds tests for the authorize endpoint and another that reduces the number of clients we use in our tests (now that we can use `trn_requirement` instead of multiple clients).