### PR TITLE
Don't serialize default values for AuthenticationState

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -14,7 +14,10 @@ public class AuthenticationState
 {
     private static readonly TimeSpan _journeyLifetime = TimeSpan.FromMinutes(20);
 
-    private static readonly JsonSerializerOptions _jsonSerializerOptions = new();
+    private static readonly JsonSerializerOptions _jsonSerializerOptions = new()
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault
+    };
 
     public AuthenticationState(
         Guid journeyId,


### PR DESCRIPTION
These JSON-serialized objects end up in Redis; there's no sense in bloating the payload by having a load of null properties in there.