### PR TITLE
Improve ergonomics of ClaimsPrincipal extension methods

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/ClaimsPrincipalCurrentUserProvider.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/ClaimsPrincipalCurrentUserProvider.cs
@@ -26,7 +26,7 @@ public class ClaimsPrincipalCurrentUserProvider : ICurrentUserProvider
         get
         {
             var httpContext = _httpContextAccessor.HttpContext ?? throw new InvalidOperationException("No current HttpContext.");
-            return httpContext.User.GetUserId(throwIfMissing: false);
+            return httpContext.User.TryGetUserId(out var userId) ? userId : null;
         }
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
@@ -177,14 +177,14 @@ public class AuthorizationController : Controller
         var cookiesPrincipal = authenticateResult.Principal!;
 
         // If it's a Staff user verify their permissions
-        if (cookiesPrincipal.GetUserType(throwIfMissing: true) == UserType.Staff &&
+        if (cookiesPrincipal.GetUserType() == UserType.Staff &&
             !authenticationState.UserRequirements.VerifyStaffUserRequirements(cookiesPrincipal))
         {
             return Forbid(CookieAuthenticationDefaults.AuthenticationScheme);
         }
 
         var subject = cookiesPrincipal.FindFirst(Claims.Subject)!.Value;
-        var userId = cookiesPrincipal.GetUserId()!.Value;
+        var userId = cookiesPrincipal.GetUserId();
 
         // Retrieve the application details from the database.
         var application = await _applicationManager.FindByClientIdAsync(request.ClientId!) ??

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/UserInfoController.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/UserInfoController.cs
@@ -20,7 +20,7 @@ public class UserInfoController : Controller
     [HttpGet("~/connect/userinfo"), HttpPost("~/connect/userinfo"), Produces("application/json")]
     public async Task<IActionResult> UserInfo()
     {
-        var userId = User.GetUserId()!.Value;
+        var userId = User.GetUserId();
         var claims = await _userClaimHelper.GetPublicClaims(userId, User.HasScope);
 
         if (claims.Count == 0)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/HttpContextExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/HttpContextExtensions.cs
@@ -112,7 +112,7 @@ public static class HttpContextExtensions
         var clock = scope.ServiceProvider.GetRequiredService<IClock>();
         var dbContext = scope.ServiceProvider.GetRequiredService<TeacherIdentityServerDbContext>();
 
-        var userId = principal.GetUserId()!.Value;
+        var userId = principal.GetUserId();
         var user = await dbContext.Users.FindAsync(userId);
 
         dbContext.AddEvent(new Events.UserSignedInEvent()
@@ -132,7 +132,7 @@ public static class HttpContextExtensions
         var clock = scope.ServiceProvider.GetRequiredService<IClock>();
         var dbContext = scope.ServiceProvider.GetRequiredService<TeacherIdentityServerDbContext>();
 
-        var userId = principal.GetUserId()!.Value;
+        var userId = principal.GetUserId();
         var user = await dbContext.Users.FindAsync(userId);
 
         dbContext.AddEvent(new Events.UserSignedOutEvent()

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Confirm.cshtml.cs
@@ -40,7 +40,7 @@ public class Confirm : PageModel
 
     public async Task<IActionResult> OnPost()
     {
-        await UpdateUserDateOfBirth(User.GetUserId()!.Value);
+        await UpdateUserDateOfBirth(User.GetUserId());
         return Redirect(_linkGenerator.Account(ClientRedirectInfo));
     }
 
@@ -66,7 +66,7 @@ public class Confirm : PageModel
                 CreatedUtc = _clock.UtcNow,
                 Changes = changes,
                 User = user,
-                UpdatedByUserId = User.GetUserId()!.Value,
+                UpdatedByUserId = User.GetUserId(),
                 UpdatedByClientId = null
             });
 
@@ -96,9 +96,7 @@ public class Confirm : PageModel
 
     private async Task<bool> ChangeDateOfBirthEnabled()
     {
-        var trn = User.GetTrn(false);
-
-        if (trn is null)
+        if (!User.TryGetTrn(out var trn))
         {
             return true;
         }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Index.cshtml.cs
@@ -36,13 +36,12 @@ public class DateOfBirthPage : PageModel
 
     public async Task OnGet()
     {
-        var userId = User.GetUserId(true);
+        var userId = User.GetUserId();
 
         DateOfBirth = await _dbContext.Users
-       .Where(u => u.UserId == userId)
-       .Select(u => u.DateOfBirth)
-       .FirstOrDefaultAsync();
-
+           .Where(u => u.UserId == userId)
+           .Select(u => u.DateOfBirth)
+           .FirstOrDefaultAsync();
     }
 
     public IActionResult OnPost()
@@ -68,9 +67,7 @@ public class DateOfBirthPage : PageModel
 
     private async Task<bool> ChangeDateOfBirthEnabled()
     {
-        var trn = User.GetTrn(false);
-
-        if (trn is null)
+        if (!User.TryGetTrn(out var trn))
         {
             return true;
         }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Email/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Email/Confirm.cshtml.cs
@@ -60,7 +60,7 @@ public class Confirm : BasePinVerificationPageModel
             return await HandlePinVerificationFailed(verifyEmailPinFailedReasons);
         }
 
-        await UpdateUserEmail(User.GetUserId()!.Value);
+        await UpdateUserEmail(User.GetUserId());
         return Redirect(_linkGenerator.Account(ClientRedirectInfo));
     }
 
@@ -88,7 +88,7 @@ public class Confirm : BasePinVerificationPageModel
                 CreatedUtc = _clock.UtcNow,
                 Changes = changes,
                 User = user,
-                UpdatedByUserId = User.GetUserId()!.Value,
+                UpdatedByUserId = User.GetUserId(),
                 UpdatedByClientId = null
             });
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Email/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Email/Index.cshtml.cs
@@ -45,7 +45,7 @@ public class EmailPage : BaseEmailPageModel
 
         if (existingUser is not null)
         {
-            var errorMessage = existingUser.UserId == User.GetUserId()!.Value
+            var errorMessage = existingUser.UserId == User.GetUserId()
                 ? "Enter a different email address. The one you’ve entered is the same as the one already on your account"
                 : "This email address is already in use - Enter a different email address";
             ModelState.AddModelError(nameof(Email), errorMessage);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Email/Resend.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Email/Resend.cshtml.cs
@@ -49,7 +49,7 @@ public class Resend : BaseEmailPageModel
 
         if (existingUser is not null)
         {
-            var errorMessage = existingUser.UserId == User.GetUserId()!.Value
+            var errorMessage = existingUser.UserId == User.GetUserId()
                 ? "Enter a different email address. The one you’ve entered is the same as the one already on your account"
                 : "This email address is already in use - Enter a different email address";
             ModelState.AddModelError(nameof(NewEmail), errorMessage);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml.cs
@@ -39,7 +39,7 @@ public class IndexModel : PageModel
 
     public async Task OnGet()
     {
-        var userId = User.GetUserId()!.Value;
+        var userId = User.GetUserId();
 
         var user = await _dbContext.Users
             .Where(u => u.UserId == userId)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Confirm.cshtml.cs
@@ -39,7 +39,7 @@ public class Confirm : PageModel
 
     public async Task<IActionResult> OnPost()
     {
-        await UpdateUserName(User.GetUserId()!.Value);
+        await UpdateUserName(User.GetUserId());
         return Redirect(_linkGenerator.Account(ClientRedirectInfo));
     }
 
@@ -71,7 +71,7 @@ public class Confirm : PageModel
                 CreatedUtc = _clock.UtcNow,
                 Changes = changes,
                 User = user,
-                UpdatedByUserId = User.GetUserId()!.Value,
+                UpdatedByUserId = User.GetUserId(),
                 UpdatedByClientId = null
             });
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialDateOfBirth/CheckOfficialDateOfBirthChangeIsEnabledAttribute.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialDateOfBirth/CheckOfficialDateOfBirthChangeIsEnabledAttribute.cs
@@ -29,9 +29,7 @@ public class CheckOfficialDateOfBirthChangeIsEnabledAttribute : Attribute, IAsyn
 
     private async Task<bool> DateOfBirthChangeEnabled(HttpContext httpContext)
     {
-        var trn = httpContext.User.GetTrn(false);
-
-        if (trn is null)
+        if (!httpContext.User.TryGetTrn(out var trn))
         {
             return false;
         }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/CheckOfficialNameChangeIsEnabledAttribute.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/CheckOfficialNameChangeIsEnabledAttribute.cs
@@ -27,9 +27,7 @@ public class CheckOfficialNameChangeIsEnabledAttribute : Attribute, IAsyncPageFi
 
     private async Task<bool> OfficialNameChangeEnabled(HttpContext httpContext)
     {
-        var trn = httpContext.User.GetTrn(false);
-
-        if (trn is null)
+        if (!httpContext.User.TryGetTrn(out var trn))
         {
             return false;
         }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Confirm.cshtml.cs
@@ -61,7 +61,7 @@ public class Confirm : BasePinVerificationPageModel
             return await HandlePinVerificationFailed(smsPinFailedReasons);
         }
 
-        await UpdateUserPhone(User.GetUserId()!.Value);
+        await UpdateUserPhone(User.GetUserId());
         return Redirect(_linkGenerator.Account(ClientRedirectInfo));
     }
 
@@ -88,7 +88,7 @@ public class Confirm : BasePinVerificationPageModel
                 CreatedUtc = _clock.UtcNow,
                 Changes = changes,
                 User = user,
-                UpdatedByUserId = User.GetUserId()!.Value,
+                UpdatedByUserId = User.GetUserId(),
                 UpdatedByClientId = null
             });
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Index.cshtml.cs
@@ -34,13 +34,12 @@ public class PhonePage : BasePhonePageModel
 
     public async Task OnGet()
     {
-        var userId = User.GetUserId(true);
+        var userId = User.GetUserId();
 
         MobileNumber = await _dbContext.Users
-       .Where(u => u.UserId == userId)
-       .Select(u => u.MobileNumber)
-       .FirstOrDefaultAsync();
-
+           .Where(u => u.UserId == userId)
+           .Select(u => u.MobileNumber)
+           .FirstOrDefaultAsync();
     }
 
     public async Task<IActionResult> OnPost()
@@ -55,7 +54,7 @@ public class PhonePage : BasePhonePageModel
 
         if (existingUser is not null)
         {
-            var errorMessage = existingUser.UserId == User.GetUserId()!.Value
+            var errorMessage = existingUser.UserId == User.GetUserId()
                 ? "Enter a different mobile phone number. The one you’ve entered is the same as the one already on your account"
                 : "This mobile phone number is already in use - Enter a different mobile phone number";
             ModelState.AddModelError(nameof(MobileNumber), errorMessage);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Resend.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Resend.cshtml.cs
@@ -50,7 +50,7 @@ public class Resend : BasePhonePageModel
 
         if (existingUser is not null)
         {
-            var errorMessage = existingUser.UserId == User.GetUserId()!.Value
+            var errorMessage = existingUser.UserId == User.GetUserId()
                 ? "Enter a different mobile phone number. The one you’ve entered is the same as the one already on your account"
                 : "This mobile phone number is already in use - Enter a different mobile phone number";
             ModelState.AddModelError(nameof(NewMobileNumber), errorMessage);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AddClient.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AddClient.cshtml.cs
@@ -127,7 +127,7 @@ public class AddClientModel : PageModel
 
             dbContext.AddEvent(new ClientAddedEvent()
             {
-                AddedByUserId = User.GetUserId()!.Value,
+                AddedByUserId = User.GetUserId(),
                 Client = Client.FromDescriptor(descriptor),
                 CreatedUtc = _clock.UtcNow
             });

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AddStaffUser.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AddStaffUser.cshtml.cs
@@ -71,7 +71,7 @@ public class AddStaffUserModel : PageModel
 
         _dbContext.AddEvent(new StaffUserAddedEvent()
         {
-            AddedByUserId = User.GetUserId()!.Value,
+            AddedByUserId = User.GetUserId(),
             CreatedUtc = _clock.UtcNow,
             User = Events.User.FromModel(user)
         });

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AddUserImport.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AddUserImport.cshtml.cs
@@ -95,7 +95,7 @@ public class AddUserImportModel : PageModel
             OriginalFilename = originalFilename,
             UserImportJobStatus = UserImportJobStatus.New,
             Uploaded = DateTime.UtcNow,
-            UploadedByUserId = User.GetUserId()!.Value
+            UploadedByUserId = User.GetUserId()
         };
 
         _dbContext.UserImportJobs.Add(userImportJob);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AddWebHook.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AddWebHook.cshtml.cs
@@ -68,7 +68,7 @@ public class AddWebHookModel : PageModel
 
         _dbContext.AddEvent(new WebHookAddedEvent()
         {
-            AddedByUserId = User.GetUserId()!.Value,
+            AddedByUserId = User.GetUserId(),
             CreatedUtc = _clock.UtcNow,
             Enabled = Enabled,
             Endpoint = Endpoint!,

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Confirm.cshtml.cs
@@ -77,7 +77,7 @@ public class ConfirmModel : PageModel
             CreatedUtc = _clock.UtcNow,
             Changes = changes,
             User = Events.User.FromModel(user),
-            UpdatedByUserId = User.GetUserId()!.Value,
+            UpdatedByUserId = User.GetUserId(),
             UpdatedByClientId = null
         });
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/NoTrn.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/NoTrn.cshtml.cs
@@ -54,7 +54,7 @@ public class NoTrn : PageModel
             Changes = Events.UserUpdatedEventChanges.TrnLookupStatus,
             User = Events.User.FromModel(user),
             UpdatedByClientId = null,
-            UpdatedByUserId = User.GetUserId()!.Value
+            UpdatedByUserId = User.GetUserId()
         });
 
         await _dbContext.SaveChangesAsync();

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditClient.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditClient.cshtml.cs
@@ -177,7 +177,7 @@ public class EditClientModel : PageModel
 
                 dbContext.AddEvent(new ClientUpdatedEvent()
                 {
-                    UpdatedByUserId = User.GetUserId()!.Value,
+                    UpdatedByUserId = User.GetUserId(),
                     Client = client,
                     CreatedUtc = _clock.UtcNow,
                     Changes = changes

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditStaffUser.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditStaffUser.cshtml.cs
@@ -93,7 +93,7 @@ public class EditStaffUserModel : PageModel
         {
             _dbContext.AddEvent(new StaffUserUpdatedEvent()
             {
-                UpdatedByUserId = User.GetUserId()!.Value,
+                UpdatedByUserId = User.GetUserId(),
                 CreatedUtc = _clock.UtcNow,
                 User = Events.User.FromModel(user),
                 Changes = changes
@@ -117,7 +117,7 @@ public class EditStaffUserModel : PageModel
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (UserId == User.GetUserId()!.Value)
+        if (UserId == User.GetUserId())
         {
             context.Result = Forbid();
         }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditUserEmail.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditUserEmail.cshtml.cs
@@ -54,7 +54,7 @@ public class EditUserEmailModel : PageModel
             {
                 Source = UserUpdatedEventSource.SupportUi,
                 UpdatedByClientId = null,
-                UpdatedByUserId = User.GetUserId()!.Value,
+                UpdatedByUserId = User.GetUserId(),
                 CreatedUtc = _clock.UtcNow,
                 User = Events.User.FromModel(user),
                 Changes = changes

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditUserName.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditUserName.cshtml.cs
@@ -64,7 +64,7 @@ public class EditUserNameModel : PageModel
             _dbContext.AddEvent(new UserUpdatedEvent()
             {
                 Source = UserUpdatedEventSource.SupportUi,
-                UpdatedByUserId = User.GetUserId()!.Value,
+                UpdatedByUserId = User.GetUserId(),
                 UpdatedByClientId = null,
                 CreatedUtc = _clock.UtcNow,
                 User = Events.User.FromModel(user),

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditWebHook.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditWebHook.cshtml.cs
@@ -108,7 +108,7 @@ public class EditWebHookModel : PageModel
                 CreatedUtc = _clock.UtcNow,
                 Enabled = Enabled,
                 Endpoint = Endpoint!,
-                UpdatedByUserId = User.GetUserId()!.Value,
+                UpdatedByUserId = User.GetUserId(),
                 WebHookId = WebHookId,
                 WebHookMessageTypes = WebHookMessageTypes
             });

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/MergeUser/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/MergeUser/Confirm.cshtml.cs
@@ -117,7 +117,7 @@ public class Confirm : PageModel
             CreatedUtc = _clock.UtcNow,
             Changes = Events.UserUpdatedEventChanges.Trn,
             User = user,
-            UpdatedByUserId = HttpContext.User.GetUserId()!.Value,
+            UpdatedByUserId = HttpContext.User.GetUserId(),
             UpdatedByClientId = null
         });
     }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Staff.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Staff.cshtml
@@ -17,7 +17,7 @@
         {
             <tr class="govuk-table__row">
                 <td class="govuk-table__cell">
-                    @if (user.UserId != User.GetUserId()!.Value)
+                    @if (user.UserId != User.GetUserId())
                     {
                         <a asp-page="EditStaffUser" asp-route-userId="@user.UserId">@user.FirstName @user.LastName</a>
                     }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Authenticated/UpdateEmail/Confirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Authenticated/UpdateEmail/Confirmation.cshtml.cs
@@ -101,7 +101,7 @@ public class ConfirmationModel : PageModel
             return this.PageWithErrors();
         }
 
-        var userId = User.GetUserId()!.Value;
+        var userId = User.GetUserId();
         var user = await _dbContext.Users.SingleAsync(u => u.UserId == userId);
 
         var safeReturnUrl = !string.IsNullOrEmpty(ReturnUrl) && Url.IsLocalUrl(ReturnUrl) ?
@@ -119,7 +119,7 @@ public class ConfirmationModel : PageModel
                 CreatedUtc = _clock.UtcNow,
                 Changes = Events.UserUpdatedEventChanges.EmailAddress,
                 User = Events.User.FromModel(user),
-                UpdatedByUserId = User.GetUserId()!.Value,
+                UpdatedByUserId = User.GetUserId(),
                 UpdatedByClientId = null
             });
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Authenticated/UpdateEmail/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Authenticated/UpdateEmail/Index.cshtml.cs
@@ -46,7 +46,7 @@ public class IndexModel : BaseEmailPageModel
 
         if (existingUser is not null)
         {
-            var errorMessage = existingUser.UserId == User.GetUserId()!.Value
+            var errorMessage = existingUser.UserId == User.GetUserId()
                 ? "Enter a different email address. The one you’ve entered is the same as the one already on your account"
                 : "This email address is already in use - Enter a different email address";
             ModelState.AddModelError(nameof(Email), errorMessage);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Authenticated/UpdateName.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Authenticated/UpdateName.cshtml.cs
@@ -44,7 +44,7 @@ public class UpdateNameModel : PageModel
 
     public async Task OnGet()
     {
-        var userId = User.GetUserId()!.Value;
+        var userId = User.GetUserId();
         var user = await _dbContext.Users.SingleAsync(u => u.UserId == userId);
 
         FirstName = user.FirstName;
@@ -58,7 +58,7 @@ public class UpdateNameModel : PageModel
             return this.PageWithErrors();
         }
 
-        var userId = User.GetUserId()!.Value;
+        var userId = User.GetUserId();
         var user = await _dbContext.Users.SingleAsync(u => u.UserId == userId);
 
         UserUpdatedEventChanges changes = UserUpdatedEventChanges.None;
@@ -90,7 +90,7 @@ public class UpdateNameModel : PageModel
                 CreatedUtc = _clock.UtcNow,
                 Changes = changes,
                 User = Events.User.FromModel(user),
-                UpdatedByUserId = User.GetUserId()!.Value,
+                UpdatedByUserId = User.GetUserId(),
                 UpdatedByClientId = null
             });
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Common/BaseEmailPageModel.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Common/BaseEmailPageModel.cs
@@ -46,6 +46,6 @@ public class BaseEmailPageModel : BaseEmailPinGenerationPageModel
     public async Task<User?> FindUserByEmailAddress(string email)
     {
         return await DbContext.Users.SingleOrDefaultAsync(u => u.EmailAddress == email);
-        // return userWithNewEmail is not null && userWithNewEmail.UserId != User.GetUserId()!.Value;
+        // return userWithNewEmail is not null && userWithNewEmail.UserId != User.GetUserId();
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/UserRequirements.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/UserRequirements.cs
@@ -108,7 +108,7 @@ public static class UserRequirementsExtensions
             throw new InvalidOperationException($"{nameof(UserRequirements)} does not contain {UserRequirements.StaffUserType}.");
         }
 
-        if (principal.GetUserType(throwIfMissing: true) != UserType.Staff)
+        if (principal.GetUserType() != UserType.Staff)
         {
             return false;
         }


### PR DESCRIPTION
The previous approach of having a single method with a parameter to control whether the claim is required ended up with a lot of nasty `!.Value` code. This reverts to more usual `GetXxx()` that throws if the claim is missing with `TryGetXxx(out)` methods where we need them.