### PR TITLE
Use a single client in e2e tests

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -834,11 +834,7 @@ public class OAuthAuthorizationState
 
     public bool HasScope(string scope) => GetScopes().Contains(scope);
 
-    public bool HasAnyScope(IEnumerable<string> scopes) => GetScopes().Any(scopes.Contains);
-
-#pragma warning disable CS0618 // Type or member is obsolete
-    public bool RequiresTrnLookup => HasScope(CustomScopes.Trn) || HasScope(CustomScopes.DqtRead);
-#pragma warning restore CS0618 // Type or member is obsolete
+    public bool RequiresTrnLookup => CustomScopes.RequiresTrnLookup(GetScopes());
 
     public void SetAuthorizationResponse(
         IEnumerable<KeyValuePair<string, string>> responseParameters,

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Oidc/CustomScopes.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Oidc/CustomScopes.cs
@@ -22,4 +22,7 @@ public static class CustomScopes
         DqtRead,
         Trn
     };
+
+    public static bool RequiresTrnLookup(IEnumerable<string> scopes) =>
+        scopes.Any(s => s.Equals(Trn) || s.Equals(DqtRead));
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/LegacyTrnJourney.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/LegacyTrnJourney.cs
@@ -6,11 +6,11 @@ using TeacherIdentity.AuthServer.Services.DqtApi;
 
 namespace TeacherIdentity.AuthServer.EndToEndTests;
 
-public class LegacyTrnJourney : IClassFixture<LegacyClientHostFixture>
+public class LegacyTrnJourney : IClassFixture<HostFixture>
 {
-    private readonly LegacyClientHostFixture _hostFixture;
+    private readonly HostFixture _hostFixture;
 
-    public LegacyTrnJourney(LegacyClientHostFixture hostFixture)
+    public LegacyTrnJourney(HostFixture hostFixture)
     {
         _hostFixture = hostFixture;
         _hostFixture.OnTestStarting();
@@ -24,7 +24,7 @@ public class LegacyTrnJourney : IClassFixture<LegacyClientHostFixture>
         await using var context = await _hostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();
 
-        await page.StartOAuthJourney(CustomScopes.Trn);
+        await page.StartOAuthJourney(CustomScopes.Trn, TrnRequirementType.Legacy);
 
         await page.SubmitEmailPage(user.EmailAddress);
 
@@ -87,7 +87,7 @@ public class LegacyTrnJourney : IClassFixture<LegacyClientHostFixture>
         await using var context = await _hostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();
 
-        await page.StartOAuthJourney(additionalScope: CustomScopes.Trn);
+        await page.StartOAuthJourney(CustomScopes.Trn, TrnRequirementType.Legacy);
 
         await page.SubmitEmailPage(email);
 
@@ -137,7 +137,7 @@ public class LegacyTrnJourney : IClassFixture<LegacyClientHostFixture>
         await using var context = await _hostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();
 
-        await page.StartOAuthJourney(additionalScope: CustomScopes.Trn);
+        await page.StartOAuthJourney(CustomScopes.Trn, TrnRequirementType.Legacy);
 
         await page.SubmitEmailPage(email);
 
@@ -189,7 +189,7 @@ public class LegacyTrnJourney : IClassFixture<LegacyClientHostFixture>
         await using var context = await _hostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();
 
-        await page.StartOAuthJourney(CustomScopes.Trn);
+        await page.StartOAuthJourney(CustomScopes.Trn, TrnRequirementType.Legacy);
 
         await page.SubmitEmailPage(user.EmailAddress);
 
@@ -210,7 +210,7 @@ public class LegacyTrnJourney : IClassFixture<LegacyClientHostFixture>
     {
         ConfigureDqtApiFindTeachersRequest(result: null);
 
-        await page.StartOAuthJourney(additionalScope: CustomScopes.Trn);
+        await page.StartOAuthJourney(CustomScopes.Trn, TrnRequirementType.Legacy);
 
         await page.SubmitEmailPage(email);
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
@@ -1,3 +1,4 @@
+using Flurl;
 using Microsoft.Playwright;
 using TeacherIdentity.AuthServer.Models;
 
@@ -33,9 +34,29 @@ public static class PageExtensions
         await page.FillAsync("label:text-is('Year')", date.Year.ToString());
     }
 
-    public static async Task StartOAuthJourney(this IPage page, string? additionalScope = null)
+    public static async Task StartOAuthJourney(this IPage page, string? additionalScope = null, TrnRequirementType? trnRequirement = null)
     {
-        await page.GotoAsync($"/profile?scope=email+openid+profile{(additionalScope is not null ? "+" + Uri.EscapeDataString(additionalScope) : string.Empty)}");
+        var allScopes = new List<string>()
+        {
+            "email",
+            "openid",
+            "profile"
+        };
+
+        if (additionalScope is not null)
+        {
+            allScopes.Add(additionalScope);
+        }
+
+        var url = new Url("/profile")
+            .SetQueryParam("scope", string.Join("+", allScopes), isEncoded: true);
+
+        if (trnRequirement is not null)
+        {
+            url.SetQueryParam("trn_requirement", trnRequirement);
+        }
+
+        await page.GotoAsync(url);
     }
 
     public static async Task AssertOnTestClient(this IPage page)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/appsettings.json
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/appsettings.json
@@ -12,23 +12,15 @@
       "UseFixedPin": true
     }
   },
-  "ClientsSettings": [
-    {
-      "ClientId": "defaultClient",
-      "ClientSecret": "super-secret",
-      "SignInAuthority": "http://localhost:55341",
-      "PostSignInMessage": "continue with the Test Client"
-    },
-    {
-      "ClientId": "legacyClient",
-      "ClientSecret": "super-secret",
-      "SignInAuthority": "http://localhost:55341",
-      "PostSignInMessage": "continue with the Legacy Test Client"
-    }
-  ],
+  "TestClient": {
+    "ClientId": "testclient",
+    "ClientSecret": "super-secret",
+    "SignInAuthority": "http://localhost:55341",
+    "PostSignInMessage": "continue with the Test Client"
+  },
   "Clients": [
     {
-      "ClientId": "defaultClient",
+      "ClientId": "testclient",
       "ClientSecret": "super-secret",
       "DisplayName": "Development test client",
       "EnableAuthorizationCodeGrant": true,
@@ -41,21 +33,6 @@
       ],
       "Scopes": [ "trn", "user:read", "user:write", "dqt:read" ],
       "TrnRequirementType": "Required"
-    },
-    {
-      "ClientId": "legacyClient",
-      "ClientSecret": "super-secret",
-      "DisplayName": "Development test client",
-      "EnableAuthorizationCodeGrant": true,
-      "EnableClientCredentialsGrant": false,
-      "RedirectUris": [
-        "http://localhost:55342/oidc/callback"
-      ],
-      "PostLogoutRedirectUris": [
-        "http://localhost:55342/oidc/signout-callback"
-      ],
-      "Scopes": [ "trn", "user:read", "user:write", "dqt:read" ],
-      "TrnRequirementType": "Legacy"
     },
     {
       "ClientId": "testcc",


### PR DESCRIPTION
Now that we can pass `TrnRequirement` as a query parameter we don't need more than one client in e2e tests.

Also adds a few more scope/TRN requirement combinations to existing tests.