### PR TITLE
Add no account page for register journey

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -134,6 +134,8 @@ public abstract class IdentityLinkGenerator
 
     public string RegisterCheckAnswers() => Page("/SignIn/Register/CheckAnswers");
 
+    public string RegisterNoAccount() => Page("/SignIn/Register/NoAccount");
+
     public string UpdateEmail(string? returnUrl, string? cancelUrl) =>
         Page("/Authenticated/UpdateEmail/Index", authenticationJourneyRequired: false)
             .SetQueryParam("returnUrl", returnUrl)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourney.cs
@@ -32,6 +32,7 @@ public class CoreSignInJourney : SignInJourney
             Steps.Landing => !AuthenticationState.EmailAddressVerified,
             SignInJourney.Steps.Email => !AuthenticationState.EmailAddressVerified,
             SignInJourney.Steps.EmailConfirmation => AuthenticationState.EmailAddressSet,
+            Steps.NoAccount => AuthenticationState.EmailAddressVerified,
             Steps.Email => !AuthenticationState.EmailAddressVerified,
             Steps.EmailConfirmation => AuthenticationState.EmailAddressSet,
             Steps.ResendEmailConfirmation => AuthenticationState is { EmailAddressSet: true, EmailAddressVerified: false },
@@ -72,7 +73,8 @@ public class CoreSignInJourney : SignInJourney
         {
             (SignInJourney.Steps.Email, _) => SignInJourney.Steps.EmailConfirmation,
             (SignInJourney.Steps.EmailConfirmation, { IsComplete: true }) => Steps.EmailExists,
-            (SignInJourney.Steps.EmailConfirmation, { IsComplete: false }) => shouldCheckAnswers ? Steps.CheckAnswers : Steps.Phone,
+            (SignInJourney.Steps.EmailConfirmation, { IsComplete: false }) => shouldCheckAnswers ? Steps.CheckAnswers : Steps.NoAccount,
+            (Steps.NoAccount, _) => Steps.Phone,
             (Steps.Landing, _) => Steps.Email,
             (Steps.Email, _) => Steps.EmailConfirmation,
             (Steps.EmailConfirmation, { IsComplete: true }) => Steps.EmailExists,
@@ -99,6 +101,7 @@ public class CoreSignInJourney : SignInJourney
     {
         (SignInJourney.Steps.Email, _) => Steps.Landing,
         (SignInJourney.Steps.EmailConfirmation, _) => SignInJourney.Steps.Email,
+        (Steps.NoAccount, _) => SignInJourney.Steps.EmailConfirmation,
         (Steps.Email, _) => Steps.Landing,
         (Steps.EmailConfirmation, _) => Steps.Email,
         (Steps.ResendEmailConfirmation, _) => Steps.EmailConfirmation,
@@ -146,6 +149,7 @@ public class CoreSignInJourney : SignInJourney
         Steps.ResendExistingAccountPhone => LinkGenerator.RegisterResendExistingAccountPhone(),
         Steps.ChangeEmailRequest => LinkGenerator.RegisterChangeEmailRequest(),
         Steps.CheckAnswers => LinkGenerator.RegisterCheckAnswers(),
+        Steps.NoAccount => LinkGenerator.RegisterNoAccount(),
         _ => throw new ArgumentException($"Unknown step: '{step}'.")
     };
 
@@ -178,5 +182,6 @@ public class CoreSignInJourney : SignInJourney
         public const string ResendExistingAccountPhone = $"{nameof(CoreSignInJourney)}.{nameof(ResendExistingAccountPhone)}";
         public const string ChangeEmailRequest = $"{nameof(CoreSignInJourney)}.{nameof(ChangeEmailRequest)}";
         public const string CheckAnswers = $"{nameof(CoreSignInJourney)}.{nameof(CheckAnswers)}";
+        public const string NoAccount = $"{nameof(CoreSignInJourney)}.{nameof(NoAccount)}";
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/NoAccount.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/NoAccount.cshtml
@@ -1,0 +1,35 @@
+@page "/sign-in/register/no-account"
+@model TeacherIdentity.AuthServer.Pages.SignIn.Register.NoAccount
+@{
+    ViewBag.Title = "We could not find an account";
+}
+
+@section BeforeContent
+{
+    <govuk-back-link href="@Model.BackLink" />
+}
+
+<div class="govuk-panel app-panel--interruption" data-testid="landing-panel">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full" data-testid="landing-content">
+            <form action="@LinkGenerator.RegisterNoAccount()" method="post" asp-antiforgery="true">
+                <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
+                <p>We couldn't find a DfE Identity account belonging to @Html.ShyEmail(Model.EmailAddress!).</p>
+
+                <h2 class="govuk-heading-m">Create an account</h2>
+
+                <p>It will only take a few minutes and you’ll need your:</p>
+                <ul class="govuk-list govuk-list--bullet">
+                 <li>email address (used for contact and account security)</li>
+                 <li>mobile phone number (used for account security)</li>
+                 <li>name and date of birth</li>
+                </ul>
+
+                <p>Once you've created an account, you can continue to <strong>@Model.ClientDisplayName</strong>.</p>
+
+                <govuk-button type="submit" class="app-button--inverse govuk-!-margin-bottom-0">Create an account</govuk-button>
+            </form>
+        </div>
+    </div>
+</div>
+

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/NoAccount.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/NoAccount.cshtml.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeacherIdentity.AuthServer.Journeys;
+using TeacherIdentity.AuthServer.Oidc;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
+
+[CheckJourneyType(typeof(CoreSignInJourney), typeof(CoreSignInJourneyWithTrnLookup))]
+[CheckCanAccessStep(CurrentStep)]
+public class NoAccount : PageModel
+{
+    private const string CurrentStep = CoreSignInJourney.Steps.NoAccount;
+
+    private readonly SignInJourney _journey;
+    private readonly TeacherIdentityApplicationManager _applicationManager;
+
+    public NoAccount(SignInJourney journey, TeacherIdentityApplicationManager applicationManager)
+    {
+        _journey = journey;
+        _applicationManager = applicationManager;
+    }
+
+    public string BackLink => _journey.GetPreviousStepUrl(CurrentStep);
+
+    public string? EmailAddress => _journey.AuthenticationState.EmailAddress;
+
+    public string? ClientDisplayName;
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        return await _journey.Advance(CurrentStep);
+    }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        var clientId = _journey.AuthenticationState.OAuthState?.ClientId;
+        var client = await _applicationManager.FindByClientIdAsync(clientId!);
+        ClientDisplayName = await _applicationManager.GetDisplayNameAsync(client!);
+
+        await next();
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
@@ -263,8 +263,8 @@ public class EmailConfirmationTests : TestBase
     }
 
     [Theory]
-    [InlineData(null, null, "/sign-in/register/phone")]
-    [InlineData(CustomScopes.DqtRead, TrnRequirementType.Optional, "/sign-in/register/phone")]
+    [InlineData(null, null, "/sign-in/register/no-account")]
+    [InlineData(CustomScopes.DqtRead, TrnRequirementType.Optional, "/sign-in/register/no-account")]
     [InlineData(CustomScopes.DqtRead, TrnRequirementType.Legacy, "/sign-in/trn")]
     public async Task Post_ValidPinForNewUser_UpdatesAuthenticationStateAndRedirects(string? scope, TrnRequirementType? trnRequirementType, string expectedRedirectLocation)
     {


### PR DESCRIPTION
### Context

The core ID journey has separate login and register links. If a user goes to register but already has an account we show them an interstitial page telling them as much and signing them in. We need a similar page for when a user signs in but does not have an account and needs to register.

### Changes proposed in this pull request

Add an additional page at /sign-in/register/no-account following the designs at https://get-an-identity-prototype.herokuapp.com/auth/create-account-interstitial  and redirect there from /sign-in/email-confirmation if no user exists with the specified email.

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
