### PR TITLE
Update core sign in journey to better handle updating mobile number

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -138,6 +138,8 @@ public class AuthenticationState
     public bool AwardedQtsSet => AwardedQts.HasValue;
     [JsonIgnore]
     public bool HasIttProviderSet => HasIttProvider.HasValue;
+    [JsonIgnore]
+    public bool ContactDetailsVerified => EmailAddressVerified && MobileNumberVerified;
 
     public static ClaimsPrincipal CreatePrincipal(IEnumerable<Claim> claims)
     {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourney.cs
@@ -41,8 +41,8 @@ public class CoreSignInJourney : SignInJourney
             Steps.PhoneConfirmation => AuthenticationState.MobileNumberSet,
             Steps.ResendPhoneConfirmation => AuthenticationState is { MobileNumberSet: true, MobileNumberVerified: false },
             Steps.PhoneExists => AuthenticationState.IsComplete,
-            Steps.Name => AuthenticationState.MobileNumberVerified,
-            Steps.DateOfBirth => AuthenticationState.PreferredNameSet,
+            Steps.Name => AuthenticationState.ContactDetailsVerified,
+            Steps.DateOfBirth => AuthenticationState is { PreferredNameSet: true, ContactDetailsVerified: true },
             Steps.AccountExists => AuthenticationState.ExistingAccountFound,
             Steps.ExistingAccountEmailConfirmation => AuthenticationState is { ExistingAccountFound: true, ExistingAccountChosen: true },
             Steps.ResendExistingAccountEmail => AuthenticationState is { ExistingAccountFound: true, ExistingAccountChosen: true },
@@ -51,7 +51,7 @@ public class CoreSignInJourney : SignInJourney
             Steps.ResendExistingAccountPhone => AuthenticationState is { ExistingAccountFound: true, ExistingAccountChosen: true, ExistingAccountMobileNumber: { } },
             Steps.ChangeEmailRequest => AuthenticationState is { ExistingAccountFound: true, ExistingAccountChosen: false },
             Steps.CheckAnswers => AreAllQuestionsAnswered(),
-            _ => throw new ArgumentOutOfRangeException(nameof(step), step, null)
+            _ => false
         };
     }
 
@@ -154,12 +154,15 @@ public class CoreSignInJourney : SignInJourney
     };
 
     protected virtual bool AreAllQuestionsAnswered() =>
-        AuthenticationState.EmailAddressSet &&
-        AuthenticationState.EmailAddressVerified &&
-        AuthenticationState.MobileNumberSet &&
-        AuthenticationState.MobileNumberVerified &&
-        AuthenticationState.PreferredNameSet &&
-        AuthenticationState.DateOfBirthSet;
+        AuthenticationState is
+        {
+            EmailAddressSet: true,
+            EmailAddressVerified: true,
+            MobileNumberSet: true,
+            MobileNumberVerified: true,
+            PreferredNameSet: true,
+            DateOfBirthSet: true
+        };
 
     public new static class Steps
     {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
@@ -86,7 +86,7 @@ public class CoreSignInJourneyWithTrnLookup : CoreSignInJourney
         Steps.NiNumber => AuthenticationState is { HasNationalInsuranceNumber: true, ContactDetailsVerified: true },
         Steps.HasTrn => (AuthenticationState is ({ NationalInsuranceNumberSet: true } or { HasNationalInsuranceNumberSet: true, HasNationalInsuranceNumber: false }) and { ContactDetailsVerified: true }),
         Steps.Trn => AuthenticationState is { HasTrn: true, ContactDetailsVerified: true },
-        Steps.HasQts => AuthenticationState is ({ StatedTrn: {} } or { HasTrnSet: true, HasTrn: false }) and { ContactDetailsVerified: true },
+        Steps.HasQts => AuthenticationState is ({ StatedTrn: { } } or { HasTrnSet: true, HasTrn: false }) and { ContactDetailsVerified: true },
         Steps.IttProvider => AuthenticationState is { AwardedQts: true, ContactDetailsVerified: true },
         SignInJourney.Steps.TrnInUse => AuthenticationState.TrnLookup == AuthenticationState.TrnLookupState.ExistingTrnFound,
         SignInJourney.Steps.TrnInUseResendTrnOwnerEmailConfirmation => AuthenticationState.TrnLookup == AuthenticationState.TrnLookupState.ExistingTrnFound,

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
@@ -82,12 +82,12 @@ public class CoreSignInJourneyWithTrnLookup : CoreSignInJourney
     public override bool CanAccessStep(string step) => step switch
     {
         CoreSignInJourney.Steps.CheckAnswers => AreAllQuestionsAnswered() || FoundATrn,
-        Steps.HasNiNumber => AuthenticationState.DateOfBirthSet,
-        Steps.NiNumber => AuthenticationState.HasNationalInsuranceNumber == true,
-        Steps.HasTrn => AuthenticationState.NationalInsuranceNumberSet || AuthenticationState is { HasNationalInsuranceNumberSet: true, HasNationalInsuranceNumber: false },
-        Steps.Trn => AuthenticationState.HasTrn == true,
-        Steps.HasQts => AuthenticationState.StatedTrn is not null || AuthenticationState is { HasTrnSet: true, HasTrn: false },
-        Steps.IttProvider => AuthenticationState.AwardedQts == true,
+        Steps.HasNiNumber => AuthenticationState is { DateOfBirthSet: true, ContactDetailsVerified: true },
+        Steps.NiNumber => AuthenticationState is { HasNationalInsuranceNumber: true, ContactDetailsVerified: true },
+        Steps.HasTrn => (AuthenticationState is ({ NationalInsuranceNumberSet: true } or { HasNationalInsuranceNumberSet: true, HasNationalInsuranceNumber: false }) and { ContactDetailsVerified: true }),
+        Steps.Trn => AuthenticationState is { HasTrn: true, ContactDetailsVerified: true },
+        Steps.HasQts => AuthenticationState is ({ StatedTrn: {} } or { HasTrnSet: true, HasTrn: false }) and { ContactDetailsVerified: true },
+        Steps.IttProvider => AuthenticationState is { AwardedQts: true, ContactDetailsVerified: true },
         SignInJourney.Steps.TrnInUse => AuthenticationState.TrnLookup == AuthenticationState.TrnLookupState.ExistingTrnFound,
         SignInJourney.Steps.TrnInUseResendTrnOwnerEmailConfirmation => AuthenticationState.TrnLookup == AuthenticationState.TrnLookupState.ExistingTrnFound,
         SignInJourney.Steps.TrnInUseChooseEmail => AuthenticationState.TrnLookup == AuthenticationState.TrnLookupState.EmailOfExistingAccountForTrnVerified,

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/NiNumberPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/NiNumberPageTests.cs
@@ -80,7 +80,7 @@ public class NiNumberPageTests : TestBase
     public async Task Post_HaveNationalInsuranceNumberNotSet_RedirectsToHasNiNumberPage()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.DateOfBirthSet(), CustomScopes.DqtRead);
+        var authStateHelper = await CreateAuthenticationStateHelper(_previousPageAuthenticationState(), CustomScopes.DqtRead);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/ni-number?{authStateHelper.ToQueryParam()}");
 


### PR DESCRIPTION
### Context

In the core journey we allow a user to go back to the phone page to change their number from the Check answers page. If they were to change their number, but not verify it, then go back to Check answers (using the browser’s back button) they could create an account with an unverified phone number.

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
