### PR TITLE
Update DoB validation to restrict past dates

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/DataAnnotationsExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/DataAnnotationsExtensions.cs
@@ -49,8 +49,8 @@ public class RegexIfTrueAttribute : RegularExpressionAttribute
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
 public class IsValidDateOfBirthAttribute : RangeAttribute
 {
-    public IsValidDateOfBirthAttribute(Type type)
-        : base(type, new DateTime(1900, 1, 1).ToShortDateString(), DateTime.Now.ToShortDateString())
+    public IsValidDateOfBirthAttribute()
+        : base(typeof(DateOnly), new DateTime(1900, 1, 1).ToShortDateString(), DateTime.Now.ToShortDateString())
     {
     }
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/DataAnnotationsExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/DataAnnotationsExtensions.cs
@@ -47,11 +47,34 @@ public class RegexIfTrueAttribute : RegularExpressionAttribute
 }
 
 [AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
-public class IsPastDateAttribute : RangeAttribute
+public class IsValidDateOfBirthAttribute : RangeAttribute
 {
-    public IsPastDateAttribute(Type type)
-        : base(type, DateTime.MinValue.ToShortDateString(), DateTime.Now.ToShortDateString())
+    public IsValidDateOfBirthAttribute(Type type)
+        : base(type, new DateTime(1900, 1, 1).ToShortDateString(), DateTime.Now.ToShortDateString())
     {
+    }
+
+    public override bool IsValid(object? value)
+    {
+        if (value is DateOnly dateValue)
+        {
+            var minimumDate = DateOnly.Parse(Minimum.ToString()!);
+            var maximumDate = DateOnly.Parse(Maximum.ToString()!);
+
+            if (dateValue < minimumDate)
+            {
+                ErrorMessage = "Enter a valid date of birth";
+                return false;
+            }
+
+            if (dateValue > maximumDate)
+            {
+                ErrorMessage = "Your date of birth must be in the past";
+                return false;
+            }
+        }
+
+        return base.IsValid(value);
     }
 }
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Index.cshtml.cs
@@ -31,7 +31,7 @@ public class DateOfBirthPage : PageModel
 
     [Display(Name = "Your date of birth", Description = "For example, 27 3 1987")]
     [Required(ErrorMessage = "Enter your date of birth")]
-    [IsPastDate(typeof(DateOnly), ErrorMessage = "Your date of birth must be in the past")]
+    [IsValidDateOfBirth(typeof(DateOnly))]
     public DateOnly? DateOfBirth { get; set; }
 
     public async Task OnGet()

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Index.cshtml.cs
@@ -31,7 +31,7 @@ public class DateOfBirthPage : PageModel
 
     [Display(Name = "Your date of birth", Description = "For example, 27 3 1987")]
     [Required(ErrorMessage = "Enter your date of birth")]
-    [IsValidDateOfBirth(typeof(DateOnly))]
+    [IsValidDateOfBirth]
     public DateOnly? DateOfBirth { get; set; }
 
     public async Task OnGet()

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialDateOfBirth/Details.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialDateOfBirth/Details.cshtml.cs
@@ -23,7 +23,7 @@ public class Details : PageModel
     [BindProperty(SupportsGet = true)]
     [Display(Name = "Date of birth", Description = "For example, 27 3 1987")]
     [Required(ErrorMessage = "Enter your date of birth")]
-    [IsPastDate(typeof(DateOnly), ErrorMessage = "Your date of birth must be in the past")]
+    [IsValidDateOfBirth(typeof(DateOnly))]
     public DateOnly? DateOfBirth { get; set; }
 
     [FromQuery(Name = "fileName")]

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialDateOfBirth/Details.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialDateOfBirth/Details.cshtml.cs
@@ -23,7 +23,7 @@ public class Details : PageModel
     [BindProperty(SupportsGet = true)]
     [Display(Name = "Date of birth", Description = "For example, 27 3 1987")]
     [Required(ErrorMessage = "Enter your date of birth")]
-    [IsValidDateOfBirth(typeof(DateOnly))]
+    [IsValidDateOfBirth]
     public DateOnly? DateOfBirth { get; set; }
 
     [FromQuery(Name = "fileName")]

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/DateOfBirthPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/DateOfBirthPage.cshtml.cs
@@ -28,7 +28,7 @@ public class DateOfBirthPage : PageModel
     [BindProperty]
     [Display(Name = "Your date of birth", Description = "For example, 27 3 1987")]
     [Required(ErrorMessage = "Enter your date of birth")]
-    [IsValidDateOfBirth(typeof(DateOnly))]
+    [IsValidDateOfBirth]
     public DateOnly? DateOfBirth { get; set; }
 
     public void OnGet()

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/DateOfBirthPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/DateOfBirthPage.cshtml.cs
@@ -28,7 +28,7 @@ public class DateOfBirthPage : PageModel
     [BindProperty]
     [Display(Name = "Your date of birth", Description = "For example, 27 3 1987")]
     [Required(ErrorMessage = "Enter your date of birth")]
-    [IsPastDate(typeof(DateOnly), ErrorMessage = "Your date of birth must be in the past")]
+    [IsValidDateOfBirth(typeof(DateOnly))]
     public DateOnly? DateOfBirth { get; set; }
 
     public void OnGet()

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/DateOfBirthPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/DateOfBirthPage.cshtml.cs
@@ -24,7 +24,7 @@ public class DateOfBirthPage : PageModel
 
     [Display(Name = "Your date of birth", Description = "For example, 27 3 1987")]
     [Required(ErrorMessage = "Enter your date of birth")]
-    [IsValidDateOfBirth(typeof(DateOnly))]
+    [IsValidDateOfBirth]
     public DateOnly? DateOfBirth { get; set; }
 
     public void OnGet()

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/DateOfBirthPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/DateOfBirthPage.cshtml.cs
@@ -24,7 +24,7 @@ public class DateOfBirthPage : PageModel
 
     [Display(Name = "Your date of birth", Description = "For example, 27 3 1987")]
     [Required(ErrorMessage = "Enter your date of birth")]
-    [IsPastDate(typeof(DateOnly), ErrorMessage = "Your date of birth must be in the past")]
+    [IsValidDateOfBirth(typeof(DateOnly))]
     public DateOnly? DateOfBirth { get; set; }
 
     public void OnGet()

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/DateOfBirth/DateOfBirthTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/DateOfBirth/DateOfBirthTests.cs
@@ -52,11 +52,13 @@ public class DateOfBirthTests : TestBase
         await AssertEx.HtmlResponseHasError(response, "DateOfBirth", "Enter your date of birth");
     }
 
-    [Fact]
-    public async Task Post_FutureDateOfBirth_RedirectsToConfirmPage()
+    [Theory]
+    [InlineData("01/01/2100", "Your date of birth must be in the past")]
+    [InlineData("01/01/1899", "Enter a valid date of birth")]
+    public async Task Post_InvalidDateOfBirth_ReturnsError(string dateOfBirthString, string errorMessage)
     {
         // Arrange
-        var dateOfBirth = new DateOnly(2100, 1, 1);
+        var dateOfBirth = DateOnly.Parse(dateOfBirthString);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/account/date-of-birth")
         {
@@ -72,7 +74,7 @@ public class DateOfBirthTests : TestBase
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        await AssertEx.HtmlResponseHasError(response, "DateOfBirth", "Your date of birth must be in the past");
+        await AssertEx.HtmlResponseHasError(response, "DateOfBirth", errorMessage);
     }
 
     [Fact]

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialDateOfBirth/DetailsTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialDateOfBirth/DetailsTests.cs
@@ -84,11 +84,13 @@ public class DetailsTests : TestBase
         await AssertEx.HtmlResponseHasError(response, "DateOfBirth", "Enter your date of birth");
     }
 
-    [Fact]
-    public async Task Post_FutureDateOfBirth_ReturnsBadRequest()
+    [Theory]
+    [InlineData("01/01/2100", "Your date of birth must be in the past")]
+    [InlineData("01/01/1899", "Enter a valid date of birth")]
+    public async Task Post_InvalidDateOfBirth_ReturnsBadRequest(string dateOfBirthString, string errorMessage)
     {
         // Arrange
-        var dateOfBirth = new DateOnly(2100, 1, 1);
+        var dateOfBirth = DateOnly.Parse(dateOfBirthString);
 
         var request = new HttpRequestMessage(HttpMethod.Post, AppendQueryParameterSignature($"/account/official-date-of-birth/details"))
         {
@@ -104,7 +106,7 @@ public class DetailsTests : TestBase
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        await AssertEx.HtmlResponseHasError(response, "DateOfBirth", "Your date of birth must be in the past");
+        await AssertEx.HtmlResponseHasError(response, "DateOfBirth", errorMessage);
     }
 
     [Fact]

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/DateOfBirthPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/DateOfBirthPageTests.cs
@@ -93,11 +93,13 @@ public class DateOfBirthPageTests : TestBase
         await AssertEx.HtmlResponseHasError(response, "DateOfBirth", "Enter your date of birth");
     }
 
-    [Fact]
-    public async Task Post_FutureDateOfBirth_ReturnsError()
+    [Theory]
+    [InlineData("01/01/2100", "Your date of birth must be in the past")]
+    [InlineData("01/01/1899", "Enter a valid date of birth")]
+    public async Task Post_FutureDateOfBirth_ReturnsError(string dateOfBirthString, string errorMessage)
     {
         // Arrange
-        var dateOfBirth = new DateOnly(2100, 1, 1);
+        var dateOfBirth = DateOnly.Parse(dateOfBirthString);
 
         var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/date-of-birth?{authStateHelper.ToQueryParam()}")
@@ -114,7 +116,7 @@ public class DateOfBirthPageTests : TestBase
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        await AssertEx.HtmlResponseHasError(response, "DateOfBirth", "Your date of birth must be in the past");
+        await AssertEx.HtmlResponseHasError(response, "DateOfBirth", errorMessage);
     }
 
     [Theory]

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/DateOfBirthPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/DateOfBirthPageTests.cs
@@ -125,11 +125,13 @@ public class DateOfBirthPageTests : TestBase
         await AssertEx.HtmlResponseHasError(response, "DateOfBirth", "Enter your date of birth");
     }
 
-    [Fact]
-    public async Task Post_FutureDateOfBirth_ReturnsError()
+    [Theory]
+    [InlineData("01/01/2100", "Your date of birth must be in the past")]
+    [InlineData("01/01/1899", "Enter a valid date of birth")]
+    public async Task Post_InvalidDateOfBirth_ReturnsError(string dateOfBirthString, string errorMessage)
     {
         // Arrange
-        var dateOfBirth = new DateOnly(2100, 1, 1);
+        var dateOfBirth = DateOnly.Parse(dateOfBirthString);
 
         var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.Trn, TrnRequirementType.Legacy);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/date-of-birth?{authStateHelper.ToQueryParam()}")
@@ -146,7 +148,7 @@ public class DateOfBirthPageTests : TestBase
         var response = await HttpClient.SendAsync(request);
 
         // Assert
-        await AssertEx.HtmlResponseHasError(response, "DateOfBirth", "Your date of birth must be in the past");
+        await AssertEx.HtmlResponseHasError(response, "DateOfBirth", errorMessage);
     }
 
     [Fact]


### PR DESCRIPTION
### Context

We’ve had an error in prod when a user entered a very old DOB (in 1687) and the CRM API itself has blown up because the date is out of range of the type it uses to represent dates. We should pre-validate DOBs to make sure they look sane before calling the API.

### Changes proposed in this pull request

Add validation to the /sign-in/register/date-of-birth and /sign-in/trn/date-of-birth pages. If the DOB entered is before 01/01/1900, show an error ‘Enter a valid date of birth’.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
