### PR TITLE
Update to use EntityFramework Exceptions nuget package

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Handlers/SetTeacherTrnHandler.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Handlers/SetTeacherTrnHandler.cs
@@ -82,7 +82,7 @@ public class SetTeacherTrnHandler : IRequestHandler<SetTeacherTrnRequest>
         {
             await _dbContext.SaveChangesAsync();
         }
-        catch (UniqueConstraintException ex) when (ex.IsUniqueIndexViolation("ix_users_trn"))
+        catch (UniqueConstraintException ex) when (ex.IsUniqueIndexViolation(User.TrnUniqueIndexName))
         {
             throw new ErrorException(ErrorRegistry.TrnIsAssignedToAnotherUser());
         }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Handlers/SetTeacherTrnHandler.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Handlers/SetTeacherTrnHandler.cs
@@ -1,3 +1,4 @@
+using EntityFramework.Exceptions.Common;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Api.V1.Requests;
@@ -81,7 +82,7 @@ public class SetTeacherTrnHandler : IRequestHandler<SetTeacherTrnRequest>
         {
             await _dbContext.SaveChangesAsync();
         }
-        catch (DbUpdateException dex) when (dex.IsUniqueIndexViolation("ix_users_trn"))
+        catch (UniqueConstraintException ex) when (ex.IsUniqueIndexViolation("ix_users_trn"))
         {
             throw new ErrorException(ErrorRegistry.TrnIsAssignedToAnotherUser());
         }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/ExceptionExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/ExceptionExtensions.cs
@@ -1,12 +1,11 @@
-using Microsoft.EntityFrameworkCore;
+using EntityFramework.Exceptions.Common;
 using Npgsql;
 
 namespace TeacherIdentity.AuthServer;
 
 public static class ExceptionExtensions
 {
-    public static bool IsUniqueIndexViolation(this DbUpdateException ex, string indexName) =>
+    public static bool IsUniqueIndexViolation(this UniqueConstraintException ex, string indexName) =>
         ex.InnerException is PostgresException pgException &&
-            pgException.SqlState == PostgresErrorCodes.UniqueViolation &&
             pgException.ConstraintName == indexName;
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
@@ -1,5 +1,5 @@
+using EntityFramework.Exceptions.Common;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Oidc;
 
 namespace TeacherIdentity.AuthServer.Journeys;
@@ -42,7 +42,7 @@ public class CoreSignInJourneyWithTrnLookup : CoreSignInJourney
                 }
             }
         }
-        catch (DbUpdateException dex) when (dex.IsUniqueIndexViolation("ix_users_trn"))
+        catch (UniqueConstraintException ex) when (ex.IsUniqueIndexViolation("ix_users_trn"))
         {
             // We don't currently handle duplicate TRNs in Core Sign In Journey
             return await CreateUserHelper.GeneratePinForExistingUserAccount(this, currentStep);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
@@ -1,6 +1,8 @@
 using EntityFramework.Exceptions.Common;
 using Microsoft.AspNetCore.Mvc;
+using Sentry;
 using TeacherIdentity.AuthServer.Oidc;
+using User = TeacherIdentity.AuthServer.Models.User;
 
 namespace TeacherIdentity.AuthServer.Journeys;
 
@@ -42,7 +44,7 @@ public class CoreSignInJourneyWithTrnLookup : CoreSignInJourney
                 }
             }
         }
-        catch (UniqueConstraintException ex) when (ex.IsUniqueIndexViolation("ix_users_trn"))
+        catch (UniqueConstraintException ex) when (ex.IsUniqueIndexViolation(User.TrnUniqueIndexName))
         {
             // We don't currently handle duplicate TRNs in Core Sign In Journey
             return await CreateUserHelper.GeneratePinForExistingUserAccount(this, currentStep);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
@@ -1,6 +1,5 @@
 using EntityFramework.Exceptions.Common;
 using Microsoft.AspNetCore.Mvc;
-using Sentry;
 using TeacherIdentity.AuthServer.Oidc;
 using User = TeacherIdentity.AuthServer.Models.User;
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/LegacyTrnJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/LegacyTrnJourney.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using EntityFramework.Exceptions.Common;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Models;
 
 namespace TeacherIdentity.AuthServer.Journeys;
 
@@ -31,7 +32,7 @@ public class LegacyTrnJourney : SignInJourney
             AuthenticationState.OnTrnLookupCompletedAndUserRegistered(user);
             await AuthenticationState.SignIn(HttpContext);
         }
-        catch (UniqueConstraintException ex) when (ex.IsUniqueIndexViolation("ix_users_trn"))
+        catch (UniqueConstraintException ex) when (ex.IsUniqueIndexViolation(User.TrnUniqueIndexName))
         {
             // TRN is already linked to an existing account
             return await CreateUserHelper.GeneratePinForExistingUserAccount(this, currentStep);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/LegacyTrnJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/LegacyTrnJourney.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
 using EntityFramework.Exceptions.Common;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Models;
 
 namespace TeacherIdentity.AuthServer.Journeys;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/LegacyTrnJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/LegacyTrnJourney.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using EntityFramework.Exceptions.Common;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -30,7 +31,7 @@ public class LegacyTrnJourney : SignInJourney
             AuthenticationState.OnTrnLookupCompletedAndUserRegistered(user);
             await AuthenticationState.SignIn(HttpContext);
         }
-        catch (DbUpdateException dex) when (dex.IsUniqueIndexViolation("ix_users_trn"))
+        catch (UniqueConstraintException ex) when (ex.IsUniqueIndexViolation("ix_users_trn"))
         {
             // TRN is already linked to an existing account
             return await CreateUserHelper.GeneratePinForExistingUserAccount(this, currentStep);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/TeacherIdentityServerDbContext.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/TeacherIdentityServerDbContext.cs
@@ -1,3 +1,4 @@
+using EntityFramework.Exceptions.PostgreSQL;
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Events;
 
@@ -22,6 +23,7 @@ public class TeacherIdentityServerDbContext : DbContext
         }
 
         optionsBuilder
+            .UseExceptionProcessor()
             .UseSnakeCaseNamingConvention()
             .UseOpenIddict<Application, Authorization, Scope, Token, string>();
     }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AddStaffUser.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AddStaffUser.cshtml.cs
@@ -81,7 +81,7 @@ public class AddStaffUserModel : PageModel
         {
             await _dbContext.SaveChangesAsync();
         }
-        catch (UniqueConstraintException ex) when (ex.IsUniqueIndexViolation("ix_users_email_address"))
+        catch (UniqueConstraintException ex) when (ex.IsUniqueIndexViolation(Models.User.EmailAddressUniqueIndexName))
         {
             ModelState.AddModelError(nameof(Email), "A user already exists with the specified email address");
             return this.PageWithErrors();

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AddStaffUser.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AddStaffUser.cshtml.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using EntityFramework.Exceptions.Common;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -80,7 +81,7 @@ public class AddStaffUserModel : PageModel
         {
             await _dbContext.SaveChangesAsync();
         }
-        catch (DbUpdateException ex) when (ex.IsUniqueIndexViolation("ix_users_email_address"))
+        catch (UniqueConstraintException ex) when (ex.IsUniqueIndexViolation("ix_users_email_address"))
         {
             ModelState.AddModelError(nameof(Email), "A user already exists with the specified email address");
             return this.PageWithErrors();

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditStaffUser.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditStaffUser.cshtml.cs
@@ -104,7 +104,7 @@ public class EditStaffUserModel : PageModel
             {
                 await _dbContext.SaveChangesAsync();
             }
-            catch (UniqueConstraintException ex) when (ex.IsUniqueIndexViolation("ix_users_email_address"))
+            catch (UniqueConstraintException ex) when (ex.IsUniqueIndexViolation(Models.User.EmailAddressUniqueIndexName))
             {
                 ModelState.AddModelError(nameof(Email), "Another user has the specified email address");
                 return this.PageWithErrors();

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditStaffUser.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditStaffUser.cshtml.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using EntityFramework.Exceptions.Common;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
@@ -103,7 +104,7 @@ public class EditStaffUserModel : PageModel
             {
                 await _dbContext.SaveChangesAsync();
             }
-            catch (DbUpdateException ex) when (ex.IsUniqueIndexViolation("ix_users_email_address"))
+            catch (UniqueConstraintException ex) when (ex.IsUniqueIndexViolation("ix_users_email_address"))
             {
                 ModelState.AddModelError(nameof(Email), "Another user has the specified email address");
                 return this.PageWithErrors();

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditUserEmail.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditUserEmail.cshtml.cs
@@ -1,4 +1,5 @@
 using System.ComponentModel.DataAnnotations;
+using EntityFramework.Exceptions.Common;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
@@ -64,7 +65,7 @@ public class EditUserEmailModel : PageModel
             {
                 await _dbContext.SaveChangesAsync();
             }
-            catch (DbUpdateException ex) when (ex.IsUniqueIndexViolation("ix_users_email_address"))
+            catch (UniqueConstraintException ex) when (ex.IsUniqueIndexViolation("ix_users_email_address"))
             {
                 ModelState.AddModelError(nameof(Email), "This email address is already in use - Enter a different email address");
                 return this.PageWithErrors();

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditUserEmail.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditUserEmail.cshtml.cs
@@ -65,7 +65,7 @@ public class EditUserEmailModel : PageModel
             {
                 await _dbContext.SaveChangesAsync();
             }
-            catch (UniqueConstraintException ex) when (ex.IsUniqueIndexViolation("ix_users_email_address"))
+            catch (UniqueConstraintException ex) when (ex.IsUniqueIndexViolation(Models.User.EmailAddressUniqueIndexName))
             {
                 ModelState.AddModelError(nameof(Email), "This email address is already in use - Enter a different email address");
                 return this.PageWithErrors();

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/TeacherIdentity.AuthServer.csproj
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/TeacherIdentity.AuthServer.csproj
@@ -17,6 +17,7 @@
     <PackageReference Include="CsvHelper" Version="30.0.1" />
     <PackageReference Include="Dfe.Analytics.AspNetCore" Version="0.1.0" />
     <PackageReference Include="EFCore.NamingConventions" Version="7.0.2" />
+    <PackageReference Include="EntityFrameworkCore.Exceptions.PostgreSQL" Version="6.0.3" />
     <PackageReference Include="FluentValidation.DependencyInjectionExtensions" Version="11.5.1" />
     <PackageReference Include="Flurl" Version="3.0.7" />
     <PackageReference Include="GovUk.Frontend.AspNetCore" Version="1.0.0" />

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Email/EmailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Email/EmailTests.cs
@@ -1,5 +1,4 @@
 using EntityFramework.Exceptions.Common;
-using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Tests.Infrastructure;
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Email/EmailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Email/EmailTests.cs
@@ -1,3 +1,4 @@
+using EntityFramework.Exceptions.Common;
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Tests.Infrastructure;
@@ -198,7 +199,7 @@ public class EmailTests : TestBase
                 dbContext.EstablishmentDomains.Add(establishmentDomain);
                 await dbContext.SaveChangesAsync();
             }
-            catch (DbUpdateException ex) when (ex.IsUniqueIndexViolation("pk_establishment_domains"))
+            catch (UniqueConstraintException ex) when (ex.IsUniqueIndexViolation("pk_establishment_domains"))
             {
             }
         });

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Email/ResendTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Email/ResendTests.cs
@@ -1,5 +1,4 @@
 using EntityFramework.Exceptions.Common;
-using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Tests.Infrastructure;
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Email/ResendTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Email/ResendTests.cs
@@ -1,3 +1,4 @@
+using EntityFramework.Exceptions.Common;
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Tests.Infrastructure;
@@ -212,7 +213,7 @@ public class ResendTests : TestBase
                 dbContext.EstablishmentDomains.Add(establishmentDomain);
                 await dbContext.SaveChangesAsync();
             }
-            catch (DbUpdateException ex) when (ex.IsUniqueIndexViolation("pk_establishment_domains"))
+            catch (UniqueConstraintException ex) when (ex.IsUniqueIndexViolation("pk_establishment_domains"))
             {
             }
         });

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Authenticated/UpdateEmail/IndexTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Authenticated/UpdateEmail/IndexTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Encodings.Web;
+using EntityFramework.Exceptions.Common;
 using Flurl;
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Models;
@@ -189,7 +190,7 @@ public class IndexTests : TestBase
                 dbContext.EstablishmentDomains.Add(establishmentDomain);
                 await dbContext.SaveChangesAsync();
             }
-            catch (DbUpdateException ex) when (ex.IsUniqueIndexViolation("pk_establishment_domains"))
+            catch (UniqueConstraintException ex) when (ex.IsUniqueIndexViolation("pk_establishment_domains"))
             {
             }
         });

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Authenticated/UpdateEmail/IndexTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Authenticated/UpdateEmail/IndexTests.cs
@@ -1,7 +1,6 @@
 using System.Text.Encodings.Web;
 using EntityFramework.Exceptions.Common;
 using Flurl;
-using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Tests.Infrastructure;
 


### PR DESCRIPTION
### Context

There’s a library that gives more-specific exceptions when database errors occur. By using this we could clean up some our exception handling code.

### Changes proposed in this pull request

Replace our catch (DbUpdateException) code with the specific exception type. 

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
