### PR TITLE
Upgrade production Redis plan

### DIFF
--- a/terraform/workspace_variables/production.tfvars.json
+++ b/terraform/workspace_variables/production.tfvars.json
@@ -10,6 +10,9 @@
     "app_service_plan_sku": "P1v2",
     "worker_count": 3,
     "postgres_flexible_server_sku": "GP_Standard_D2s_v3",
+    "redis_service_sku": "Standard",
+    "redis_service_family": "C",
+    "redis_service_capacity": 1,
     "enable_postgres_high_availability": true,
     "statuscake_alerts": {
       "get-an-identity-prod": {


### PR DESCRIPTION
We've got some Redis timeout errors in the logs; this upgrades us to a more production-suitable SKU.