### PR TITLE
Handle trn_token query parameter in authorize endpoint

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -158,6 +158,7 @@ public class AuthenticationState
         User? user,
         string postSignInUrl,
         DateTime startedAt,
+        string? trn,
         string? sessionId = null,
         OAuthAuthorizationState? oAuthState = null,
         bool? firstTimeSignInForEmail = null)
@@ -171,7 +172,7 @@ public class AuthenticationState
             FirstName = user?.FirstName,
             LastName = user?.LastName,
             DateOfBirth = user?.DateOfBirth,
-            Trn = user?.Trn,
+            Trn = trn ?? user?.Trn,
             HaveCompletedTrnLookup = user?.CompletedTrnLookup is not null,
             TrnLookup = user?.CompletedTrnLookup is not null ? TrnLookupState.Complete : TrnLookupState.None,
             UserType = user?.UserType,

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
@@ -26,6 +26,7 @@ public class AuthorizationController : Controller
     private readonly UserClaimHelper _userClaimHelper;
     private readonly TeacherIdentityServerDbContext _dbContext;
     private readonly IConfiguration _configuration;
+    private readonly IClock _clock;
     public AuthorizationController(
         TeacherIdentityApplicationManager applicationManager,
         IOpenIddictAuthorizationManager authorizationManager,
@@ -33,7 +34,7 @@ public class AuthorizationController : Controller
         SignInJourneyProvider signInJourneyProvider,
         UserClaimHelper userClaimHelper,
         TeacherIdentityServerDbContext dbContext,
-        IConfiguration configuration)
+        IConfiguration configuration, IClock clock)
     {
         _applicationManager = applicationManager;
         _authorizationManager = authorizationManager;
@@ -42,6 +43,7 @@ public class AuthorizationController : Controller
         _userClaimHelper = userClaimHelper;
         _dbContext = dbContext;
         _configuration = configuration;
+        _clock = clock;
     }
 
     [HttpGet("~/connect/authorize")]
@@ -125,7 +127,7 @@ public class AuthorizationController : Controller
 
                 if (_configuration.GetValue("RegisterWithTrnTokenEnabled", false) && requestedTrnToken.HasValue)
                 {
-                    var trnToken = await _dbContext.TrnTokens.SingleOrDefaultAsync(t => t.TrnToken == requestedTrnToken.Value.Value as string && t.ExpiresUtc > DateTime.UtcNow);
+                    var trnToken = await _dbContext.TrnTokens.SingleOrDefaultAsync(t => t.TrnToken == requestedTrnToken.Value.Value as string && t.ExpiresUtc > _clock.UtcNow);
                     if (trnToken is not null)
                     {
                         if (await _dbContext.Users.FirstOrDefaultAsync(u => u.Trn == trnToken.Trn) is null)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
@@ -26,7 +26,6 @@ public class AuthorizationController : Controller
     private readonly UserClaimHelper _userClaimHelper;
     private readonly TeacherIdentityServerDbContext _dbContext;
     private readonly IConfiguration _configuration;
-    
     public AuthorizationController(
         TeacherIdentityApplicationManager applicationManager,
         IOpenIddictAuthorizationManager authorizationManager,

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Production.json
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Production.json
@@ -47,5 +47,6 @@
   },
   "WebHooks": {
     "WebHooksCacheDurationSeconds": 120
-  }
+  },
+  "RegisterWithTrnTokenEnabled": false
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.json
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.json
@@ -28,5 +28,6 @@
   "Gias": {
     "BaseDownloadAddress": "https://ea-edubase-api-prod.azurewebsites.net/edubase/downloads/public/",
     "RefreshEstablishmentDomainsJobSchedule": "0 2 * * *"
-  }
+  },
+  "RegisterWithTrnTokenEnabled": true
 }

--- a/dotnet-authserver/src/TeacherIdentity.TestClient/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.TestClient/Program.cs
@@ -75,6 +75,12 @@ public class Program
                         ctx.ProtocolMessage.SetParameter("trn_requirement", trnRequirement);
                     }
 
+                    var trnToken = ctx.HttpContext.Request.Query["trn_token"].ToString();
+                    if (!string.IsNullOrEmpty(trnToken))
+                    {
+                        ctx.ProtocolMessage.SetParameter("trn_token", trnToken);
+                    }
+
                     ctx.ProtocolMessage.SetParameter("session_id", ctx.HttpContext.Session.Id);
 
                     return Task.CompletedTask;

--- a/dotnet-authserver/src/TeacherIdentity.TestClient/Views/Home/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.TestClient/Views/Home/Index.cshtml
@@ -30,5 +30,9 @@
         <govuk-input-label>Scope</govuk-input-label>
     </govuk-input>
 
+    <govuk-input name="trn_token" value="" input-class="govuk-input--width-20">
+        <govuk-input-label>Trn Token</govuk-input-label>
+    </govuk-input>
+
     <govuk-button type="submit">My profile</govuk-button>
 </form>

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TestData.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TestData.cs
@@ -1,5 +1,6 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
+using System.Security.Cryptography;
 using Microsoft.Extensions.DependencyInjection;
 using TeacherIdentity.AuthServer.Models;
 
@@ -13,6 +14,7 @@ public partial class TestData
     private static readonly ConcurrentBag<string> _trns = new();
     private static readonly ConcurrentBag<string> _emails = new();
     private static readonly ConcurrentBag<string> _mobileNumbers = new();
+    private static readonly ConcurrentBag<string> _trnTokens = new();
 
     public TestData(IServiceProvider serviceProvider)
     {
@@ -91,6 +93,21 @@ public partial class TestData
             _mobileNumbers.Add(mobileNumber);
             return mobileNumber;
         }
+    }
+
+    public string GenerateUniqueTrnTokenValue()
+    {
+        string trnToken;
+
+        do
+        {
+            var buffer = new byte[64];
+            RandomNumberGenerator.Fill(buffer);
+            trnToken = Convert.ToHexString(buffer);
+        } while (_trnTokens.Contains(trnToken));
+
+        _trnTokens.Add(trnToken);
+        return trnToken;
     }
 
     public async Task<T> WithDbContext<T>(Func<TeacherIdentityServerDbContext, Task<T>> action)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateTests.cs
@@ -39,6 +39,7 @@ public partial class AuthenticationStateTests
             user,
             postSignInUrl: "/",
             startedAt: DateTime.UtcNow,
+            trn: null,
             oAuthState: null,
             firstTimeSignInForEmail: firstTimeSignInForEmail);
 
@@ -86,6 +87,7 @@ public partial class AuthenticationStateTests
             user,
             postSignInUrl: "/",
             startedAt: DateTime.UtcNow,
+            trn: null,
             oAuthState: null,
             firstTimeSignInForEmail: firstTimeSignInForEmail);
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Oidc/AuthorizeTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Oidc/AuthorizeTests.cs
@@ -269,7 +269,7 @@ public class AuthorizeTests : TestBase
     {
         // Arrange
         var trn = TestData.GenerateTrn();
-        var trnToken = await GenerateTrnToken(trn, expires: DateTime.UtcNow.AddDays(1));
+        var trnToken = await GenerateTrnToken(trn, expires: Clock.UtcNow.AddDays(1));
 
         var authorizeEndpoint = GetAuthorizeEndpoint(scope: "email profile openid dqt:read") +
                                 $"&trn_token={trnToken}";
@@ -302,7 +302,7 @@ public class AuthorizeTests : TestBase
     {
         // Arrange
         var trn = TestData.GenerateTrn();
-        var trnToken = await GenerateTrnToken(trn, expires: DateTime.UtcNow.AddDays(-1));
+        var trnToken = await GenerateTrnToken(trn, expires: Clock.UtcNow.AddDays(-1));
 
         var authorizeEndpoint = GetAuthorizeEndpoint(scope: "email profile openid dqt:read") +
                                 $"&trn_token={trnToken}";
@@ -320,7 +320,7 @@ public class AuthorizeTests : TestBase
     {
         // Arrange
         var user = await TestData.CreateUser(hasTrn: true);
-        var trnToken = await GenerateTrnToken(user.Trn!, expires: DateTime.UtcNow.AddDays(1));
+        var trnToken = await GenerateTrnToken(user.Trn!, expires: Clock.UtcNow.AddDays(1));
 
         var authorizeEndpoint = GetAuthorizeEndpoint(scope: "email profile openid dqt:read") +
                                 $"&trn_token={trnToken}";
@@ -338,7 +338,7 @@ public class AuthorizeTests : TestBase
     {
         // Arrange
         var trn = TestData.GenerateTrn();
-        var trnToken = await GenerateTrnToken(trn, expires: DateTime.UtcNow.AddDays(1));
+        var trnToken = await GenerateTrnToken(trn, expires: Clock.UtcNow.AddDays(1));
 
         var authorizeEndpoint = GetAuthorizeEndpoint(scope: "email profile openid") +
                                 $"&trn_token={trnToken}";
@@ -411,7 +411,7 @@ public class AuthorizeTests : TestBase
             TrnToken = TestData.GenerateUniqueTrnTokenValue(),
             Trn = trn,
             Email = TestData.GenerateUniqueEmail(),
-            CreatedUtc = DateTime.UtcNow,
+            CreatedUtc = Clock.UtcNow,
             ExpiresUtc = expires
         };
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Oidc/AuthorizeTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Oidc/AuthorizeTests.cs
@@ -264,6 +264,94 @@ public class AuthorizeTests : TestBase
         Assert.Null(authenticationState.OAuthState.TrnRequirementType);
     }
 
+    [Fact]
+    public async Task ValidTrnToken_SetsTrnOnAuthenticationState()
+    {
+        // Arrange
+        var trn = TestData.GenerateTrn();
+        var trnToken = await GenerateTrnToken(trn, expires: DateTime.UtcNow.AddDays(1));
+
+        var authorizeEndpoint = GetAuthorizeEndpoint(scope: "email profile openid dqt:read") +
+                                $"&trn_token={trnToken}";
+        // Act
+        var response = await HttpClient.GetAsync(authorizeEndpoint);
+
+        // Assert
+        AssertResponseIsNotErrorCallback(response, out Guid journeyId);
+        var authenticationState = AuthenticationStateProvider.GetAuthenticationState(journeyId);
+        Assert.Equal(trn, authenticationState?.Trn);
+    }
+
+    [Fact]
+    public async Task TrnTokenSpecifiedButNotFound_DoesNotSetTrnOnAuthenticationState()
+    {
+        // Arrange
+        var authorizeEndpoint = GetAuthorizeEndpoint(scope: "email profile openid dqt:read") +
+                                $"&trn_token={TestData.GenerateUniqueTrnTokenValue()}";
+        // Act
+        var response = await HttpClient.GetAsync(authorizeEndpoint);
+
+        // Assert
+        AssertResponseIsNotErrorCallback(response, out Guid journeyId);
+        var authenticationState = AuthenticationStateProvider.GetAuthenticationState(journeyId);
+        Assert.Null(authenticationState?.Trn);
+    }
+
+    [Fact]
+    public async Task TrnTokenSpecifiedButExpired_DoesNotSetTrnOnAuthenticationState()
+    {
+        // Arrange
+        var trn = TestData.GenerateTrn();
+        var trnToken = await GenerateTrnToken(trn, expires: DateTime.UtcNow.AddDays(-1));
+
+        var authorizeEndpoint = GetAuthorizeEndpoint(scope: "email profile openid dqt:read") +
+                                $"&trn_token={trnToken}";
+        // Act
+        var response = await HttpClient.GetAsync(authorizeEndpoint);
+
+        // Assert
+        AssertResponseIsNotErrorCallback(response, out Guid journeyId);
+        var authenticationState = AuthenticationStateProvider.GetAuthenticationState(journeyId);
+        Assert.Null(authenticationState?.Trn);
+    }
+
+    [Fact]
+    public async Task TrnTokenSpecifiedButTrnExists_DoesNotSetTrnOnAuthenticationState()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(hasTrn: true);
+        var trnToken = await GenerateTrnToken(user.Trn!, expires: DateTime.UtcNow.AddDays(1));
+
+        var authorizeEndpoint = GetAuthorizeEndpoint(scope: "email profile openid dqt:read") +
+                                $"&trn_token={trnToken}";
+        // Act
+        var response = await HttpClient.GetAsync(authorizeEndpoint);
+
+        // Assert
+        AssertResponseIsNotErrorCallback(response, out Guid journeyId);
+        var authenticationState = AuthenticationStateProvider.GetAuthenticationState(journeyId);
+        Assert.Null(authenticationState?.Trn);
+    }
+
+    [Fact]
+    public async Task TrnTokenSpecifiedForNonTrnLookupRequiringJourney_DoesNotSetTrnOnAuthenticationState()
+    {
+        // Arrange
+        var trn = TestData.GenerateTrn();
+        var trnToken = await GenerateTrnToken(trn, expires: DateTime.UtcNow.AddDays(1));
+
+        var authorizeEndpoint = GetAuthorizeEndpoint(scope: "email profile openid") +
+                                $"&trn_token={trnToken}";
+
+        // Act
+        var response = await HttpClient.GetAsync(authorizeEndpoint);
+
+        // Assert
+        AssertResponseIsNotErrorCallback(response, out Guid journeyId);
+        var authenticationState = AuthenticationStateProvider.GetAuthenticationState(journeyId);
+        Assert.Null(authenticationState?.Trn);
+    }
+
     private static void AssertResponseIsErrorCallback(
         HttpResponseMessage response,
         string expectedError,
@@ -314,5 +402,25 @@ public class AuthorizeTests : TestBase
             throw new Exception("URL is missing journey ID parameter.");
 
         return Guid.Parse(asid);
+    }
+
+    private async Task<string> GenerateTrnToken(string trn, DateTime expires)
+    {
+        var trnToken = new TrnTokenModel()
+        {
+            TrnToken = TestData.GenerateUniqueTrnTokenValue(),
+            Trn = trn,
+            Email = TestData.GenerateUniqueEmail(),
+            CreatedUtc = DateTime.UtcNow,
+            ExpiresUtc = expires
+        };
+
+        await TestData.WithDbContext(async dbContext =>
+        {
+            dbContext.TrnTokens.Add(trnToken);
+            await dbContext.SaveChangesAsync();
+        });
+
+        return trnToken.TrnToken;
     }
 }


### PR DESCRIPTION
### Context

We’re adding magic link support to the authorize endpoint so that we can send users whose TRN we know a link to a registration journey that won’t require them to enter information that we already know.

### Changes proposed in this pull request

Amend the authorize endpoint to look for a trn_token request parameter

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
