### PR TITLE
Add register complete holding page

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Complete.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Complete.cshtml
@@ -26,7 +26,10 @@
 
 @if (Model.TrnRequirementType == TrnRequirementType.Required && Model.TrnLookupStatus != TrnLookupStatus.Found)
 {
-    <vc:sign-in-complete trn-requirement-type="@Model.TrnRequirementType" trn-lookup-status="@Model.TrnLookupStatus" />
+    <vc:sign-in-complete
+        trn-requirement-type="@Model.TrnRequirementType"
+        trn-lookup-status="@Model.TrnLookupStatus"
+        trn-lookup-support-ticket-created="@Model.TrnLookupSupportTicketCreated" />
 }
 else
 {
@@ -41,6 +44,7 @@ else
 
         <vc:sign-in-complete
             trn-requirement-type="@Model.TrnRequirementType"
-            trn-lookup-status="@Model.TrnLookupStatus" />
+            trn-lookup-status="@Model.TrnLookupStatus"
+            trn-lookup-support-ticket-created="@Model.TrnLookupSupportTicketCreated" />
     </form>
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Complete.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Complete.cshtml.cs
@@ -75,7 +75,7 @@ public class CompleteModel : PageModel
         TrnLookupStatus = authenticationState.TrnLookupStatus;
         TrnRequirementType = authenticationState.OAuthState?.TrnRequirementType;
 
-        var user = await _dbContext.Users.SingleOrDefaultAsync(u => u.UserId == authenticationState.UserId);
+        var user = await _dbContext.Users.SingleAsync(u => u.UserId == authenticationState.UserId);
         TrnLookupSupportTicketCreated = user?.TrnLookupSupportTicketCreated == true;
 
         var clientId = authenticationState.OAuthState?.ClientId;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Complete.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Complete.cshtml.cs
@@ -1,6 +1,7 @@
 using Dfe.Analytics.AspNetCore;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Journeys;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Oidc;
@@ -13,11 +14,16 @@ public class CompleteModel : PageModel
 {
     private readonly SignInJourney _journey;
     private readonly TeacherIdentityApplicationManager _applicationManager;
+    private readonly TeacherIdentityServerDbContext _dbContext;
 
-    public CompleteModel(SignInJourney journey, TeacherIdentityApplicationManager applicationManager)
+    public CompleteModel(
+        SignInJourney journey,
+        TeacherIdentityApplicationManager applicationManager,
+        TeacherIdentityServerDbContext dbContext)
     {
         _journey = journey;
         _applicationManager = applicationManager;
+        _dbContext = dbContext;
     }
 
     public string? Email { get; set; }
@@ -48,6 +54,8 @@ public class CompleteModel : PageModel
 
     public string? ClientDisplayName { get; set; }
 
+    public bool TrnLookupSupportTicketCreated { get; set; }
+
     public async Task OnGet()
     {
         var authenticationState = HttpContext.GetAuthenticationState();
@@ -66,6 +74,9 @@ public class CompleteModel : PageModel
         Scope = authenticationState.OAuthState?.Scope;
         TrnLookupStatus = authenticationState.TrnLookupStatus;
         TrnRequirementType = authenticationState.OAuthState?.TrnRequirementType;
+
+        var user = await _dbContext.Users.SingleOrDefaultAsync(u => u.UserId == authenticationState.UserId);
+        TrnLookupSupportTicketCreated = user?.TrnLookupSupportTicketCreated == true;
 
         var clientId = authenticationState.OAuthState?.ClientId;
         var client = await _applicationManager.FindByClientIdAsync(clientId!);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/_SignIn.Complete.Core.TrnSupportTicketPending.Content.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/_SignIn.Complete.Core.TrnSupportTicketPending.Content.cshtml
@@ -1,0 +1,12 @@
+@{
+    ViewData["Title"] = "You cannot access this service yet";
+}
+
+<govuk-panel class="app-panel--interruption" data-testid="trn-support-ticket-pending-content">
+    <govuk-panel-title><span data-testid="trn-support-ticket-pending-postsigninmessage"></span>@ViewBag.Title</govuk-panel-title>
+
+    <govuk-panel-body>
+        <p>We need to find your details in our records so you can use this service.</p>
+        <p>To fix this problem, please email our support team QTS.enquiries@education.gov.uk</p>
+    </govuk-panel-body>
+</govuk-panel>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/ViewComponents/RenderSignInCompleteViewComponent.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/ViewComponents/RenderSignInCompleteViewComponent.cs
@@ -13,16 +13,24 @@ public class RenderSignInCompleteViewComponent : ViewComponent
         _viewComponentHelper = viewComponentHelper;
     }
 
-    public IViewComponentResult Invoke(TrnRequirementType? trnRequirementType, TrnLookupStatus? trnLookupStatus)
+    public IViewComponentResult Invoke(
+        TrnRequirementType? trnRequirementType,
+        TrnLookupStatus? trnLookupStatus,
+        bool trnLookupSupportTicketCreated)
     {
         if (trnRequirementType is null)
         {
-            return View($"~/Pages/SignIn/_SignIn.Complete.Core.NoTrnLookup.cshtml");
+            return View("~/Pages/SignIn/_SignIn.Complete.Core.NoTrnLookup.cshtml");
         }
 
         if (trnRequirementType == TrnRequirementType.Legacy)
         {
             return View("~/Pages/SignIn/_SignIn.Complete.LegacyTRN.Content.cshtml");
+        }
+
+        if (trnRequirementType == TrnRequirementType.Required && trnLookupStatus == TrnLookupStatus.Pending && trnLookupSupportTicketCreated)
+        {
+            return View("~/Pages/SignIn/_SignIn.Complete.Core.TRNSupportTicketPending.Content.cshtml");
         }
 
         var trnState = trnLookupStatus switch

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TestData.CreateUser.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TestData.CreateUser.cs
@@ -15,8 +15,7 @@ public partial class TestData
             bool trnLookupSupportTicketCreated = false,
             string? firstName = null,
             string[]? staffRoles = null,
-            bool? hasMobileNumber = null,
-            bool trnLookupSupportTicketCreated = false) =>
+            bool? hasMobileNumber = null) =>
         WithDbContext(async dbContext =>
         {
             if (hasTrn == true && userType != UserType.Default)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TestData.CreateUser.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TestData.CreateUser.cs
@@ -15,7 +15,8 @@ public partial class TestData
             bool trnLookupSupportTicketCreated = false,
             string? firstName = null,
             string[]? staffRoles = null,
-            bool? hasMobileNumber = null) =>
+            bool? hasMobileNumber = null,
+            bool trnLookupSupportTicketCreated = false) =>
         WithDbContext(async dbContext =>
         {
             if (hasTrn == true && userType != UserType.Default)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/CompleteTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/CompleteTests.cs
@@ -44,11 +44,12 @@ public class CompleteTests : TestBase
         bool isFirstTimeSignIn,
         TrnLookupStatus? trnLookupStatus,
         bool expectCallbackForm,
+        bool trnLookupSupportTicketCreated,
         string expectedContentBlock,
         string[] expectedContent)
     {
         // Arrange
-        var user = await TestData.CreateUser(hasTrn: trnLookupStatus == TrnLookupStatus.Found, trnLookupStatus: trnLookupStatus);
+        var user = await TestData.CreateUser(hasTrn: trnLookupStatus == TrnLookupStatus.Found, trnLookupStatus: trnLookupStatus, trnLookupSupportTicketCreated: trnLookupSupportTicketCreated);
 
         var authStateHelper = await CreateAuthenticationStateHelper(c => c.Completed(user, firstTimeSignIn: isFirstTimeSignIn), additionalScopes, trnRequirementType, client);
 
@@ -77,7 +78,7 @@ public class CompleteTests : TestBase
         }
     }
 
-    public static TheoryData<TeacherIdentityApplicationDescriptor, string?, TrnRequirementType?, bool, TrnLookupStatus?, bool, string, string[]> SignInCompleteState => new()
+    public static TheoryData<TeacherIdentityApplicationDescriptor, string?, TrnRequirementType?, bool, TrnLookupStatus?, bool, bool, string, string[]> SignInCompleteState => new()
     {
         {
             // Core journey, trn optional client, first time sign in, no TRN lookup
@@ -87,6 +88,7 @@ public class CompleteTests : TestBase
             true,
             (TrnLookupStatus?)null,
             true,
+            false,
             "first-time-user-content",
             new[]
             {
@@ -103,6 +105,7 @@ public class CompleteTests : TestBase
             true,
             TrnLookupStatus.Found,
             true,
+            false,
             "first-time-user-content",
             new[]
             {
@@ -120,6 +123,7 @@ public class CompleteTests : TestBase
             true,
             TrnLookupStatus.Failed,
             true,
+            false,
             "first-time-user-content",
             new[]
             {
@@ -137,6 +141,7 @@ public class CompleteTests : TestBase
             true,
             TrnLookupStatus.Pending,
             true,
+            false,
             "first-time-user-content",
             new[]
             {
@@ -154,6 +159,7 @@ public class CompleteTests : TestBase
             false,
             (TrnLookupStatus?)null,
             true,
+            false,
             "known-user-content",
             new[]
             {
@@ -169,6 +175,7 @@ public class CompleteTests : TestBase
             false,
             TrnLookupStatus.Found,
             true,
+            false,
             "known-user-content",
             new[]
             {
@@ -184,6 +191,7 @@ public class CompleteTests : TestBase
             false,
             TrnLookupStatus.Failed,
             true,
+            false,
             "known-user-content",
             new[]
             {
@@ -199,6 +207,7 @@ public class CompleteTests : TestBase
             false,
             TrnLookupStatus.Pending,
             true,
+            false,
             "known-user-content",
             new[]
             {
@@ -214,6 +223,7 @@ public class CompleteTests : TestBase
             true,
             TrnLookupStatus.Found,
             true,
+            false,
             "first-time-user-content",
             new[]
             {
@@ -231,6 +241,7 @@ public class CompleteTests : TestBase
             true,
             TrnLookupStatus.Failed,
             false,
+            false,
             "first-time-user-content",
             new[]
             {
@@ -246,6 +257,7 @@ public class CompleteTests : TestBase
             TrnRequirementType.Required,
             true,
             TrnLookupStatus.Pending,
+            false,
             false,
             "first-time-user-content",
             new[]
@@ -264,6 +276,7 @@ public class CompleteTests : TestBase
             false,
             TrnLookupStatus.Found,
             true,
+            false,
             "known-user-content",
             new[]
             {
@@ -278,6 +291,7 @@ public class CompleteTests : TestBase
             TrnRequirementType.Required,
             false,
             TrnLookupStatus.Failed,
+            false,
             false,
             "known-user-content",
             new[]
@@ -295,6 +309,7 @@ public class CompleteTests : TestBase
             false,
             TrnLookupStatus.Pending,
             false,
+            false,
             "known-user-content",
             new[]
             {
@@ -305,6 +320,22 @@ public class CompleteTests : TestBase
             }
         },
         {
+            // Core journey, trn required client, TRN pending, support ticket created
+            TestClients.DefaultClient,
+            CustomScopes.DqtRead,
+            TrnRequirementType.Required,
+            false,
+            TrnLookupStatus.Pending,
+            false,
+            true,
+            "trn-support-ticket-pending-content",
+            new[]
+            {
+                "We need to find your details in our records so you can use this service.",
+                "To fix this problem, please email our support team QTS.enquiries@education.gov.uk",
+            }
+        },
+        {
             // legacy TRN journey, default client, first time sign-in with trn found
             TestClients.DefaultClient,
             CustomScopes.DqtRead,
@@ -312,6 +343,7 @@ public class CompleteTests : TestBase
             true,
             TrnLookupStatus.Found,
             true,
+            false,
             "legacy-first-time-user-content",
             new[]
             {
@@ -328,6 +360,7 @@ public class CompleteTests : TestBase
             true,
             TrnLookupStatus.Failed,
             true,
+            false,
             "legacy-first-time-user-content",
             new[]
             {
@@ -344,6 +377,7 @@ public class CompleteTests : TestBase
             false,
             TrnLookupStatus.Found,
             true,
+            false,
             "legacy-known-user-content",
             new[]
             {
@@ -360,6 +394,7 @@ public class CompleteTests : TestBase
             true,
             TrnLookupStatus.Failed,
             true,
+            false,
             "legacy-first-time-user-content",
             new[]
             {
@@ -376,6 +411,7 @@ public class CompleteTests : TestBase
             true,
             TrnLookupStatus.Failed,
             true,
+            false,
             "legacy-first-time-user-content",
             new[]
             {


### PR DESCRIPTION
### Context

Until now we’ve not been raising support tickets when we can’t automatically find a user’s TRN. When these users return, they would be stuck if they tried to enter a service that requires a TRN since their TrnLookupStatus will never move on from Pending.

### Changes proposed in this pull request

Amend the /SignIn/Complete page for returning users whose TrnLookupStatus is Pending and TrnLookupSupportTicketCreated is false and the client’s TrnRequirementType is Required.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
