### PR TITLE
Add trn lookup support ticket created flag to user

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Events/TrnLookupSupportTicketCreatedEvent.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Events/TrnLookupSupportTicketCreatedEvent.cs
@@ -1,0 +1,8 @@
+namespace TeacherIdentity.AuthServer.Events;
+
+public record TrnLookupSupportTicketCreatedEvent : EventBase
+{
+    public required long TicketId { get; init; }
+    public required string TicketComment { get; init; }
+    public required Guid UserId { get; init; }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CreateUserHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CreateUserHelper.cs
@@ -161,7 +161,7 @@ public class CreateUserHelper
             }
         }); ;
 
-        var user = await _dbContext.Users.SingleAsync(u => u.UserId == authenticationState.UserId);
+        var user = await _dbContext.Users.Where(u => u.UserId == authenticationState.UserId).SingleAsync();
         user.TrnLookupSupportTicketCreated = true;
         _dbContext.AddEvent(new Events.TrnLookupSupportTicketCreatedEvent()
         {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CreateUserHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CreateUserHelper.cs
@@ -126,13 +126,9 @@ public class CreateUserHelper
         return new RedirectResult(journey.GetNextStepUrl(currentStep));
     }
 
-    public Task CreateTrnResolutionZendeskTicket(AuthenticationState authenticationState) =>
-        _zendeskApiWrapper.CreateTicketAsync(new()
-        {
-            Subject = $"[Get an identity] - Support request from {authenticationState.GetPreferredName() ?? authenticationState.GetOfficialName()}",
-            Comment = new TicketComment()
-            {
-                Body = $"""
+    public async Task CreateTrnResolutionZendeskTicket(AuthenticationState authenticationState)
+    {
+        var ticketComment = $"""
                 A user has submitted a request to find their TRN. Their information is:
                 Name: {authenticationState.GetOfficialName()}
                 Email: {authenticationState.EmailAddress}
@@ -141,7 +137,14 @@ public class CreateUserHelper
                 NI number: {authenticationState.NationalInsuranceNumber ?? "Not provided"}
                 ITT provider: {authenticationState.IttProviderName ?? "Not provided"}
                 User-provided TRN: {authenticationState.StatedTrn ?? "Not provided"}
-                """
+                """;
+
+        var ticketResponse = await _zendeskApiWrapper.CreateTicketAsync(new()
+        {
+            Subject = $"[Get an identity] - Support request from {authenticationState.GetPreferredName() ?? authenticationState.GetOfficialName()}",
+            Comment = new TicketComment()
+            {
+                Body = ticketComment
             },
             Requester = new()
             {
@@ -156,5 +159,18 @@ public class CreateUserHelper
                     Value = "request_from_identity_auth_service"
                 }
             }
+        }); ;
+
+        var user = await _dbContext.Users.SingleAsync(u => u.UserId == authenticationState.UserId);
+        user.TrnLookupSupportTicketCreated = true;
+        _dbContext.AddEvent(new Events.TrnLookupSupportTicketCreatedEvent()
+        {
+            TicketId = ticketResponse.Ticket.Id,
+            TicketComment = ticketComment,
+            UserId = user.UserId,
+            CreatedUtc = _clock.UtcNow,
         });
+
+        await _dbContext.SaveChangesAsync();
+    }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Users.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Users.cshtml
@@ -37,14 +37,9 @@
                                         <govuk-checkboxes-item value="@status">
                                             @status
                                             <govuk-checkboxes-item-conditional>
-                                                <govuk-radios asp-for="SupportTicketCreated" class="govuk-radios--small">
-                                                    <govuk-radios-fieldset>
-                                                        <govuk-radios-fieldset-legend class="govuk-fieldset__legend--s" />
-                                                        <govuk-radios-item value="@TeacherIdentity.AuthServer.Pages.Admin.UsersModel.SupportTicketCreatedStatus.All">All</govuk-radios-item>
-                                                        <govuk-radios-item value="@TeacherIdentity.AuthServer.Pages.Admin.UsersModel.SupportTicketCreatedStatus.SupportTicketCreated">Created</govuk-radios-item>
-                                                        <govuk-radios-item value="@TeacherIdentity.AuthServer.Pages.Admin.UsersModel.SupportTicketCreatedStatus.SupportTicketNotCreated">Not created</govuk-radios-item>
-                                                    </govuk-radios-fieldset>
-                                                </govuk-radios>
+                                                <govuk-checkboxes asp-for="WithSupportTicket" class="govuk-checkboxes--small">
+                                                    <govuk-checkboxes-item value="@true">@Html.DisplayNameFor(m => m.WithSupportTicket)</govuk-checkboxes-item>
+                                                </govuk-checkboxes>
                                             </govuk-checkboxes-item-conditional>
                                          </govuk-checkboxes-item>
                                     }
@@ -101,7 +96,7 @@
                         <tr class="govuk-table__row">
                             <th scope="col" class="govuk-table__header">Name</th>
                             <th scope="col" class="govuk-table__header">Email</th>
-                            <th scope="col" class="govuk-table__header">Support ticket created</th>
+                            <th scope="col" class="govuk-table__header">Support ticket</th>
                             <th scope="col" class="govuk-table__header"></th>
                             <th scope="col" class="govuk-table__header"></th>
                         </tr>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Users.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Users.cshtml
@@ -28,7 +28,26 @@
                                 <govuk-checkboxes-fieldset-legend class="govuk-fieldset__legend--s"/>
                                 @foreach (var status in Enum.GetValues(typeof(TrnLookupStatus)))
                                 {
-                                    <govuk-checkboxes-item value="@status">@status</govuk-checkboxes-item>
+                                    if ((TrnLookupStatus)status != TrnLookupStatus.Pending)
+                                    {
+                                        <govuk-checkboxes-item value="@status">@status</govuk-checkboxes-item>
+                                    }
+                                    else
+                                    {
+                                        <govuk-checkboxes-item value="@status">
+                                            @status
+                                            <govuk-checkboxes-item-conditional>
+                                                <govuk-radios asp-for="SupportTicketCreated" class="govuk-radios--small">
+                                                    <govuk-radios-fieldset>
+                                                        <govuk-radios-fieldset-legend class="govuk-fieldset__legend--s" />
+                                                        <govuk-radios-item value="@TeacherIdentity.AuthServer.Pages.Admin.UsersModel.SupportTicketCreatedStatus.All">All</govuk-radios-item>
+                                                        <govuk-radios-item value="@TeacherIdentity.AuthServer.Pages.Admin.UsersModel.SupportTicketCreatedStatus.SupportTicketCreated">Created</govuk-radios-item>
+                                                        <govuk-radios-item value="@TeacherIdentity.AuthServer.Pages.Admin.UsersModel.SupportTicketCreatedStatus.SupportTicketNotCreated">Not created</govuk-radios-item>
+                                                    </govuk-radios-fieldset>
+                                                </govuk-radios>
+                                            </govuk-checkboxes-item-conditional>
+                                         </govuk-checkboxes-item>
+                                    }
                                 }
 
                             </govuk-checkboxes-fieldset>
@@ -82,6 +101,7 @@
                         <tr class="govuk-table__row">
                             <th scope="col" class="govuk-table__header">Name</th>
                             <th scope="col" class="govuk-table__header">Email</th>
+                            <th scope="col" class="govuk-table__header">Support ticket created</th>
                             <th scope="col" class="govuk-table__header"></th>
                             <th scope="col" class="govuk-table__header"></th>
                         </tr>
@@ -92,6 +112,7 @@
                             <tr class="govuk-table__row" data-testid="user-@user.UserId">
                                 <td class="govuk-table__cell"><a asp-page="User" asp-route-userId="@user.UserId">@user.Name</a></td>
                                 <td class="govuk-table__cell empty-hyphens">@Html.ShyEmail(user.EmailAddress)</td>
+                                <td class="govuk-table__cell">@(user.TrnLookupSupportTicketCreated ? "Yes" : "No")</td>
                                 @if (user.Trn is null)
                                 {
                                     <td class="govuk-table__cell"><a asp-page="AssignTrn/Trn" asp-route-userId="@user.UserId">Add a DQT record</a></td>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Users.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Users.cshtml.cs
@@ -22,7 +22,8 @@ public class UsersModel : PageModel
         EmailAddress = user.EmailAddress,
         Name = user.FirstName + " " + user.LastName,
         Trn = user.Trn,
-        TrnLookupStatus = user.TrnLookupStatus
+        TrnLookupStatus = user.TrnLookupStatus,
+        TrnLookupSupportTicketCreated = user.TrnLookupSupportTicketCreated
     };
 
     private readonly TeacherIdentityServerDbContext _dbContext;
@@ -35,6 +36,10 @@ public class UsersModel : PageModel
     [Display(Name = "TRN lookup status")]
     [FromQuery(Name = "LookupStatus")]
     public TrnLookupStatus?[]? LookupStatus { get; set; }
+
+    [Display(Name = "Support ticket status")]
+    [FromQuery(Name = "SupportTicketCreated")]
+    public SupportTicketCreatedStatus SupportTicketCreated { get; set; }
 
     [Display(Name = "Search")]
     [FromQuery(Name = "UserSearch")]
@@ -121,6 +126,14 @@ public class UsersModel : PageModel
         public required string Name { get; init; }
         public required string? Trn { get; init; }
         public required TrnLookupStatus? TrnLookupStatus { get; init; }
+        public required bool TrnLookupSupportTicketCreated { get; init; }
+    }
+
+    public enum SupportTicketCreatedStatus
+    {
+        All,
+        SupportTicketCreated,
+        SupportTicketNotCreated
     }
 
     private async Task<Expression<Func<User, bool>>> GetFilterPredicate(TrnLookupStatus?[] lookupStatus, string? userSearch)
@@ -129,7 +142,25 @@ public class UsersModel : PageModel
 
         if (lookupStatus.Length > 0)
         {
-            filterPredicate.And(user => lookupStatus.Contains(user.TrnLookupStatus));
+            var lookupStatusWithoutPending = lookupStatus.Where(s => s != TrnLookupStatus.Pending).ToArray();
+            var lookupStatusPredicate = PredicateBuilder.New<User>(user => lookupStatusWithoutPending.Contains(user.TrnLookupStatus));
+
+            if (lookupStatus.Contains(TrnLookupStatus.Pending))
+            {
+                var pendingStatusPredicate = PredicateBuilder.New<User>(user => user.TrnLookupStatus == TrnLookupStatus.Pending);
+                if (SupportTicketCreated == SupportTicketCreatedStatus.SupportTicketCreated)
+                {
+                    pendingStatusPredicate.And(user => user.TrnLookupSupportTicketCreated == true);
+                }
+                else if (SupportTicketCreated == SupportTicketCreatedStatus.SupportTicketNotCreated)
+                {
+                    pendingStatusPredicate.And(user => user.TrnLookupSupportTicketCreated == false);
+                }
+
+                lookupStatusPredicate.Or(pendingStatusPredicate);
+            }
+
+            filterPredicate.And(lookupStatusPredicate);
         }
 
         if (!string.IsNullOrEmpty(userSearch))

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Users.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/Users.cshtml.cs
@@ -37,9 +37,9 @@ public class UsersModel : PageModel
     [FromQuery(Name = "LookupStatus")]
     public TrnLookupStatus?[]? LookupStatus { get; set; }
 
-    [Display(Name = "Support ticket status")]
-    [FromQuery(Name = "SupportTicketCreated")]
-    public SupportTicketCreatedStatus SupportTicketCreated { get; set; }
+    [Display(Name = "With support ticket")]
+    [FromQuery(Name = "WithSupportTicket")]
+    public bool WithSupportTicket { get; set; }
 
     [Display(Name = "Search")]
     [FromQuery(Name = "UserSearch")]
@@ -129,13 +129,6 @@ public class UsersModel : PageModel
         public required bool TrnLookupSupportTicketCreated { get; init; }
     }
 
-    public enum SupportTicketCreatedStatus
-    {
-        All,
-        SupportTicketCreated,
-        SupportTicketNotCreated
-    }
-
     private async Task<Expression<Func<User, bool>>> GetFilterPredicate(TrnLookupStatus?[] lookupStatus, string? userSearch)
     {
         var filterPredicate = PredicateBuilder.New<User>(user => user.UserType == UserType.Default);
@@ -148,13 +141,9 @@ public class UsersModel : PageModel
             if (lookupStatus.Contains(TrnLookupStatus.Pending))
             {
                 var pendingStatusPredicate = PredicateBuilder.New<User>(user => user.TrnLookupStatus == TrnLookupStatus.Pending);
-                if (SupportTicketCreated == SupportTicketCreatedStatus.SupportTicketCreated)
+                if (WithSupportTicket)
                 {
                     pendingStatusPredicate.And(user => user.TrnLookupSupportTicketCreated == true);
-                }
-                else if (SupportTicketCreated == SupportTicketCreatedStatus.SupportTicketNotCreated)
-                {
-                    pendingStatusPredicate.And(user => user.TrnLookupSupportTicketCreated == false);
                 }
 
                 lookupStatusPredicate.Or(pendingStatusPredicate);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/Zendesk/FakeZendeskApiWrapper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/Zendesk/FakeZendeskApiWrapper.cs
@@ -1,4 +1,6 @@
+using ZendeskApi.Client.Models;
 using ZendeskApi.Client.Requests;
+using ZendeskApi.Client.Responses;
 
 namespace TeacherIdentity.AuthServer.Services.Zendesk;
 
@@ -11,9 +13,9 @@ public class FakeZendeskApiWrapper : IZendeskApiWrapper
         _logger = logger;
     }
 
-    public Task CreateTicketAsync(TicketCreateRequest ticket, CancellationToken cancellationToken = default)
+    public Task<TicketResponse> CreateTicketAsync(TicketCreateRequest ticket, CancellationToken cancellationToken = default)
     {
         _logger.LogInformation("FakeZendeskApiWrapper received request to create Zendesk ticket: {@TicketRequest}", ticket);
-        return Task.CompletedTask;
+        return Task.FromResult(new TicketResponse() { Ticket = new Ticket() { Id = 1234567 } });
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/Zendesk/IZendeskApiWrapper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/Zendesk/IZendeskApiWrapper.cs
@@ -1,8 +1,9 @@
 using ZendeskApi.Client.Requests;
+using ZendeskApi.Client.Responses;
 
 namespace TeacherIdentity.AuthServer.Services.Zendesk;
 
 public interface IZendeskApiWrapper
 {
-    Task CreateTicketAsync(TicketCreateRequest ticket, CancellationToken cancellationToken = default);
+    Task<TicketResponse> CreateTicketAsync(TicketCreateRequest ticket, CancellationToken cancellationToken = default);
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/Zendesk/ZendeskApiWrapper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/Zendesk/ZendeskApiWrapper.cs
@@ -1,5 +1,6 @@
 using ZendeskApi.Client;
 using ZendeskApi.Client.Requests;
+using ZendeskApi.Client.Responses;
 
 namespace TeacherIdentity.AuthServer.Services.Zendesk;
 
@@ -12,6 +13,6 @@ public class ZendeskApiWrapper : IZendeskApiWrapper
         _zendeskClient = zendeskClient;
     }
 
-    public Task CreateTicketAsync(TicketCreateRequest ticket, CancellationToken cancellationToken = default) =>
+    public Task<TicketResponse> CreateTicketAsync(TicketCreateRequest ticket, CancellationToken cancellationToken = default) =>
         _zendeskClient.Tickets.CreateAsync(ticket, cancellationToken);
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TestData.CreateUser.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TestData.CreateUser.cs
@@ -12,6 +12,7 @@ public partial class TestData
             string? registeredWithClientId = null,
             Guid? mergedWithUserId = null,
             TrnLookupStatus? trnLookupStatus = null,
+            bool trnLookupSupportTicketCreated = false,
             string? firstName = null,
             string[]? staffRoles = null,
             bool? hasMobileNumber = null) =>
@@ -75,7 +76,8 @@ public partial class TestData
                 RegisteredWithClientId = registeredWithClientId,
                 MergedWithUserId = mergedWithUserId,
                 IsDeleted = mergedWithUserId != null,
-                StaffRoles = userType is UserType.Staff ? staffRoles ?? StaffRoles.All : Array.Empty<string>()
+                StaffRoles = userType is UserType.Staff ? staffRoles ?? StaffRoles.All : Array.Empty<string>(),
+                TrnLookupSupportTicketCreated = trnLookupSupportTicketCreated
             };
 
             dbContext.Users.Add(user);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/CheckAnswersTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/CheckAnswersTests.cs
@@ -171,13 +171,14 @@ public class CheckAnswersTests : TestBase
 
         if (expectZendeskTicketCreated)
         {
-            elementInspectors.Add(e =>
-            {
-                var supportTicketCreatedEvent = Assert.IsType<TrnLookupSupportTicketCreatedEvent>(e);
-                Assert.Equal(ticketIdExpected, supportTicketCreatedEvent.TicketId);
-                Assert.Equal(Clock.UtcNow, supportTicketCreatedEvent.CreatedUtc);
-                Assert.Equal(user?.UserId, supportTicketCreatedEvent.UserId);
-            });
+            elementInspectors.Add(
+                e =>
+                {
+                    var supportTicketCreatedEvent = Assert.IsType<TrnLookupSupportTicketCreatedEvent>(e);
+                    Assert.Equal(ticketIdExpected, supportTicketCreatedEvent.TicketId);
+                    Assert.Equal(Clock.UtcNow, supportTicketCreatedEvent.CreatedUtc);
+                    Assert.Equal(user?.UserId, supportTicketCreatedEvent.UserId);
+                });
         }
 
         EventObserver.AssertEventsSaved(elementInspectors.ToArray());

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/CheckAnswersTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/CheckAnswersTests.cs
@@ -131,7 +131,7 @@ public class CheckAnswersTests : TestBase
         }
 
         TicketCreateRequest? ticketCreateRequestActual = null;
-        long ticketIdExpected = 1234567;
+        long ticketIdExpected = 321;
         if (expectZendeskTicketCreated)
         {
             HostFixture.ZendeskApiWrapper


### PR DESCRIPTION
### Context

When users have gone through ID’s sign up process, if we couldn’t find a TRN then in most cases the user’s TrnLookupStatus is set to Pending. The intention is that these are resolved via the helpdesk manually (following a Zendesk ticket being raised) and ultimately transition to either Failed or Found. However, since NPQ can’t actually handle receiving users without a TRN they are redirecting users at TrnLookupStatus Foundthrough their old journey. Consequently, we haven’t been creating Zendesk tickets and so no one has looked at these records and they’re all stuck inPending. That’s going to be a problem when these users come back to ID and try to access a service that requires a TRN like Access your teaching qualifications.

### Changes proposed in this pull request

Add a TrnLookupSupportTicketCreated property to User, defaulting to false. Modify the CreateUserHelper to populate this field. If a Zendesk ticket is created, set the flag to true, otherwise false.

Add a TrnLookupSupportTicketCreatedEvent and emit this when a Zendesk ticket is created too.

Modify the admin user list page. Add an additional checkbox filters within the Pending TRN lookup status
"With support ticktet". 
This should default to ‘unchecked’.

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
