### PR TITLE
Check dqt api for trn token

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -18,6 +18,7 @@ public class AuthenticationState
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault
     };
 
+    [JsonConstructor]
     public AuthenticationState(
         Guid journeyId,
         UserRequirements userRequirements,

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -34,6 +34,33 @@ public class AuthenticationState
         OAuthState = oAuthState;
     }
 
+    public AuthenticationState(
+        Guid journeyId,
+        UserRequirements userRequirements,
+        string postSignInUrl,
+        DateTime startedAt,
+        bool firstTimeSignInForEmail,
+        AuthenticationStateInitialisationData? authStateInitData,
+        string? sessionId = null,
+        OAuthAuthorizationState? oAuthState = null) :
+        this(journeyId, userRequirements, postSignInUrl, startedAt, sessionId, oAuthState)
+    {
+        UserId = authStateInitData?.UserId;
+        FirstTimeSignInForEmail = firstTimeSignInForEmail;
+        EmailAddress = authStateInitData?.EmailAddress;
+        EmailAddressVerified = authStateInitData?.EmailAddressVerified == true;
+        FirstName = authStateInitData?.FirstName;
+        MiddleName = authStateInitData?.MiddleName;
+        LastName = authStateInitData?.LastName;
+        DateOfBirth = authStateInitData?.DateOfBirth;
+        Trn = authStateInitData?.Trn;
+        HaveCompletedTrnLookup = authStateInitData?.HaveCompletedTrnLookup is not null;
+        TrnLookup = authStateInitData?.HaveCompletedTrnLookup is not null ? TrnLookupState.Complete : TrnLookupState.None;
+        UserType = authStateInitData?.UserType;
+        StaffRoles = authStateInitData?.StaffRoles;
+        TrnLookupStatus = authStateInitData?.TrnLookupStatus;
+    }
+
     public static TimeSpan AuthCookieLifetime { get; } = TimeSpan.FromMinutes(20);
 
     public Guid JourneyId { get; }
@@ -53,6 +80,8 @@ public class AuthenticationState
     public bool EmailAddressVerified { get; private set; }
     [JsonInclude]
     public string? FirstName { get; private set; }
+    [JsonInclude]
+    public string? MiddleName { get; private set; }
     [JsonInclude]
     public string? LastName { get; private set; }
     [JsonInclude]
@@ -151,35 +180,6 @@ public class AuthenticationState
     public static AuthenticationState Deserialize(string serialized) =>
         JsonSerializer.Deserialize<AuthenticationState>(serialized, _jsonSerializerOptions) ??
             throw new ArgumentException($"Serialized {nameof(AuthenticationState)} is not valid.", nameof(serialized));
-
-    public static AuthenticationState FromUser(
-        Guid journeyId,
-        UserRequirements userRequirements,
-        User? user,
-        string postSignInUrl,
-        DateTime startedAt,
-        string? trn,
-        string? sessionId = null,
-        OAuthAuthorizationState? oAuthState = null,
-        bool? firstTimeSignInForEmail = null)
-    {
-        return new AuthenticationState(journeyId, userRequirements, postSignInUrl, startedAt, sessionId, oAuthState)
-        {
-            UserId = user?.UserId,
-            FirstTimeSignInForEmail = firstTimeSignInForEmail,
-            EmailAddress = user?.EmailAddress,
-            EmailAddressVerified = user is not null,
-            FirstName = user?.FirstName,
-            LastName = user?.LastName,
-            DateOfBirth = user?.DateOfBirth,
-            Trn = trn ?? user?.Trn,
-            HaveCompletedTrnLookup = user?.CompletedTrnLookup is not null,
-            TrnLookup = user?.CompletedTrnLookup is not null ? TrnLookupState.Complete : TrnLookupState.None,
-            UserType = user?.UserType,
-            StaffRoles = user?.StaffRoles,
-            TrnLookupStatus = user?.TrnLookupStatus
-        };
-    }
 
     [MemberNotNull(nameof(OAuthState))]
     public void EnsureOAuthState()

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -41,7 +41,7 @@ public class AuthenticationState
         string postSignInUrl,
         DateTime startedAt,
         bool firstTimeSignInForEmail,
-        AuthenticationStateInitialisationData? authStateInitData,
+        AuthenticationStateInitializationData? authStateInitData,
         string? sessionId = null,
         OAuthAuthorizationState? oAuthState = null) :
         this(journeyId, userRequirements, postSignInUrl, startedAt, sessionId, oAuthState)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
@@ -12,6 +12,7 @@ using OpenIddict.Server.AspNetCore;
 using TeacherIdentity.AuthServer.Journeys;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Oidc;
+using TeacherIdentity.AuthServer.Services.DqtApi;
 using TeacherIdentity.AuthServer.State;
 using static OpenIddict.Abstractions.OpenIddictConstants;
 
@@ -27,6 +28,7 @@ public class AuthorizationController : Controller
     private readonly TeacherIdentityServerDbContext _dbContext;
     private readonly IConfiguration _configuration;
     private readonly IClock _clock;
+    private readonly IDqtApiClient _dqtApiClient;
     public AuthorizationController(
         TeacherIdentityApplicationManager applicationManager,
         IOpenIddictAuthorizationManager authorizationManager,
@@ -34,7 +36,9 @@ public class AuthorizationController : Controller
         SignInJourneyProvider signInJourneyProvider,
         UserClaimHelper userClaimHelper,
         TeacherIdentityServerDbContext dbContext,
-        IConfiguration configuration, IClock clock)
+        IConfiguration configuration,
+        IClock clock,
+        IDqtApiClient dqtApiClient)
     {
         _applicationManager = applicationManager;
         _authorizationManager = authorizationManager;
@@ -44,6 +48,7 @@ public class AuthorizationController : Controller
         _dbContext = dbContext;
         _configuration = configuration;
         _clock = clock;
+        _dqtApiClient = dqtApiClient;
     }
 
     [HttpGet("~/connect/authorize")]
@@ -84,73 +89,49 @@ public class AuthorizationController : Controller
                     }));
             }
 
-            // If the user is signed in with an incompatible UserType then force the user to sign in again
-            var signedInUserId = authenticateResult.Principal?.GetUserId();
-            var user = signedInUserId is not null ? await _dbContext.Users.SingleAsync(u => u.UserId == signedInUserId) : null;
-            if (user?.UserType is UserType userType && !userRequirements.GetPermittedUserTypes().Contains(userType))
-            {
-                user = null;
-            }
-
-            var sessionId = request["session_id"]?.Value as string;
+            var signedInUser = await GetSignedInUser(authenticateResult, userRequirements);
+            var authStateInitData = AuthenticationStateInitialisationData.FromUser(signedInUser);
 
             TrnRequirementType? trnRequirementType = null;
-            string? trn = null;
 
             if (userRequirements.HasFlag(UserRequirements.TrnHolder))
             {
-                var requestedTrnRequirement = request["trn_requirement"];
+                trnRequirementType = await TryGetTrnRequirementType(request);
 
-                if (requestedTrnRequirement.HasValue)
+                if (trnRequirementType is null)
                 {
-                    if (!Enum.TryParse<TrnRequirementType>(requestedTrnRequirement?.Value as string, out var parsedTrnRequirementType))
-                    {
-                        return Forbid(
-                            authenticationSchemes: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme,
-                            properties: new AuthenticationProperties(new Dictionary<string, string?>()
-                            {
-                                [OpenIddictServerAspNetCoreConstants.Properties.Error] = Errors.InvalidRequest,
-                                [OpenIddictServerAspNetCoreConstants.Properties.ErrorDescription] =
-                                    "Invalid trn_requirement specified."
-                            }));
-                    }
-
-                    trnRequirementType = parsedTrnRequirementType;
-                }
-                else
-                {
-                    var client = (await _applicationManager.FindByClientIdAsync(request.ClientId!))!;
-                    trnRequirementType = client.TrnRequirementType;
+                    return Forbid(
+                        authenticationSchemes: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme,
+                        properties: new AuthenticationProperties(new Dictionary<string, string?>()
+                        {
+                            [OpenIddictServerAspNetCoreConstants.Properties.Error] = Errors.InvalidRequest,
+                            [OpenIddictServerAspNetCoreConstants.Properties.ErrorDescription] =
+                                "Invalid trn_requirement specified."
+                        }));
                 }
 
                 var requestedTrnToken = request["trn_token"];
 
                 if (_configuration.GetValue("RegisterWithTrnTokenEnabled", false) && requestedTrnToken.HasValue)
                 {
-                    var trnToken = await _dbContext.TrnTokens.SingleOrDefaultAsync(t => t.TrnToken == requestedTrnToken.Value.Value as string && t.ExpiresUtc > _clock.UtcNow);
-                    if (trnToken is not null)
-                    {
-                        if (await _dbContext.Users.FirstOrDefaultAsync(u => u.Trn == trnToken.Trn) is null)
-                        {
-                            trn = trnToken.Trn;
-                        }
-                    }
+                    authStateInitData = await GetTrnTokenInitData(requestedTrnToken.Value.Value as string);
                 }
             }
 
-            authenticationState = AuthenticationState.FromUser(
+            var sessionId = request["session_id"]?.Value as string;
+
+            authenticationState = new AuthenticationState(
                 journeyId,
                 userRequirements,
-                user,
                 GetCallbackUrl(journeyId),
-                startedAt: DateTime.UtcNow,
-                trn,
+                startedAt: _clock.UtcNow,
+                authenticateResult.Succeeded != true,
+                authStateInitData,
                 sessionId,
                 oAuthState: new OAuthAuthorizationState(request.ClientId!, request.Scope!, request.RedirectUri)
                 {
                     TrnRequirementType = trnRequirementType
-                },
-                firstTimeSignInForEmail: authenticateResult.Succeeded != true);
+                });
 
             HttpContext.Features.Set(new AuthenticationStateFeature(authenticationState));
         }
@@ -460,5 +441,70 @@ public class AuthorizationController : Controller
             default:
                 yield break;
         }
+    }
+
+    private async Task<User?> GetSignedInUser(AuthenticateResult authenticateResult, UserRequirements userRequirements)
+    {
+        var signedInUserId = authenticateResult.Principal?.GetUserId();
+
+        if (signedInUserId is null)
+        {
+            return null;
+        }
+
+        var signedInUser = await _dbContext.Users.SingleOrDefaultAsync(u => u.UserId == signedInUserId);
+
+        // If the user is signed in with an incompatible UserType then force the user to sign in again
+        if (signedInUser?.UserType is UserType userType && !userRequirements.GetPermittedUserTypes().Contains(userType))
+        {
+            return null;
+        }
+
+        return signedInUser;
+    }
+
+    private async Task<TrnRequirementType?> TryGetTrnRequirementType(OpenIddictRequest request)
+    {
+        var requestedTrnRequirement = request["trn_requirement"];
+
+        if (requestedTrnRequirement.HasValue)
+        {
+            if (!Enum.TryParse<TrnRequirementType>(requestedTrnRequirement?.Value as string, out var parsedTrnRequirementType))
+            {
+                return null;
+            }
+
+            return parsedTrnRequirementType;
+        }
+
+        var client = (await _applicationManager.FindByClientIdAsync(request.ClientId!))!;
+        return client.TrnRequirementType;
+    }
+
+    private async Task<AuthenticationStateInitialisationData?> GetTrnTokenInitData(string? trnTokenValue)
+    {
+        var trnToken = await _dbContext.TrnTokens.SingleOrDefaultAsync(t => t.TrnToken == trnTokenValue && t.ExpiresUtc > _clock.UtcNow);
+
+        if (trnToken is null || await _dbContext.Users.FirstOrDefaultAsync(u => u.Trn == trnToken.Trn) is not null)
+        {
+            return null;
+        }
+
+        var teacher = await _dqtApiClient.GetTeacherByTrn(trnToken.Trn);
+
+        if (teacher is null)
+        {
+            return null;
+        }
+
+        return new AuthenticationStateInitialisationData()
+        {
+            FirstName = teacher.FirstName,
+            MiddleName = teacher.MiddleName,
+            LastName = teacher.LastName,
+            DateOfBirth = teacher.DateOfBirth,
+            EmailAddress = trnToken.Email,
+            Trn = trnToken.Trn,
+        };
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
@@ -90,13 +90,13 @@ public class AuthorizationController : Controller
             }
 
             var signedInUser = await GetSignedInUser(authenticateResult, userRequirements);
-            var authStateInitData = AuthenticationStateInitialisationData.FromUser(signedInUser);
+            var authStateInitData = AuthenticationStateInitializationData.FromUser(signedInUser);
 
             TrnRequirementType? trnRequirementType = null;
 
             if (userRequirements.HasFlag(UserRequirements.TrnHolder))
             {
-                trnRequirementType = await TryGetTrnRequirementType(request);
+                trnRequirementType = await GetTrnRequirementType(request);
 
                 if (trnRequirementType is null)
                 {
@@ -114,6 +114,7 @@ public class AuthorizationController : Controller
 
                 if (_configuration.GetValue("RegisterWithTrnTokenEnabled", false) && requestedTrnToken.HasValue)
                 {
+                    // TODO: merge trn token init data with signed in user init data
                     authStateInitData = await GetTrnTokenInitData(requestedTrnToken.Value.Value as string);
                 }
             }
@@ -463,7 +464,7 @@ public class AuthorizationController : Controller
         return signedInUser;
     }
 
-    private async Task<TrnRequirementType?> TryGetTrnRequirementType(OpenIddictRequest request)
+    private async Task<TrnRequirementType?> GetTrnRequirementType(OpenIddictRequest request)
     {
         var requestedTrnRequirement = request["trn_requirement"];
 
@@ -481,7 +482,7 @@ public class AuthorizationController : Controller
         return client.TrnRequirementType;
     }
 
-    private async Task<AuthenticationStateInitialisationData?> GetTrnTokenInitData(string? trnTokenValue)
+    private async Task<AuthenticationStateInitializationData?> GetTrnTokenInitData(string? trnTokenValue)
     {
         var trnToken = await _dbContext.TrnTokens.SingleOrDefaultAsync(t => t.TrnToken == trnTokenValue && t.ExpiresUtc > _clock.UtcNow);
 
@@ -497,7 +498,7 @@ public class AuthorizationController : Controller
             return null;
         }
 
-        return new AuthenticationStateInitialisationData()
+        return new AuthenticationStateInitializationData()
         {
             FirstName = teacher.FirstName,
             MiddleName = teacher.MiddleName,

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/AuthenticationStateInitialisationData.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/AuthenticationStateInitialisationData.cs
@@ -17,19 +17,24 @@ public record AuthenticationStateInitialisationData
 
     public static AuthenticationStateInitialisationData FromUser(User? user)
     {
-        return new AuthenticationStateInitialisationData()
+        if (user is null)
         {
-            UserId = user?.UserId,
-            EmailAddress = user?.EmailAddress,
-            EmailAddressVerified = user is not null,
-            FirstName = user?.FirstName,
-            LastName = user?.LastName,
-            DateOfBirth = user?.DateOfBirth,
-            Trn = user?.Trn,
-            HaveCompletedTrnLookup = user?.CompletedTrnLookup is not null,
-            UserType = user?.UserType,
-            StaffRoles = user?.StaffRoles,
-            TrnLookupStatus = user?.TrnLookupStatus
+            return new AuthenticationStateInitialisationData();
+        }
+
+        return new AuthenticationStateInitialisationData
+        {
+            UserId = user.UserId,
+            EmailAddress = user.EmailAddress,
+            EmailAddressVerified = true,
+            FirstName = user.FirstName,
+            LastName = user.LastName,
+            DateOfBirth = user.DateOfBirth,
+            Trn = user.Trn,
+            HaveCompletedTrnLookup = user.CompletedTrnLookup != null,
+            UserType = user.UserType,
+            StaffRoles = user.StaffRoles,
+            TrnLookupStatus = user.TrnLookupStatus
         };
     }
 };

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/AuthenticationStateInitialisationData.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/AuthenticationStateInitialisationData.cs
@@ -11,7 +11,6 @@ public record AuthenticationStateInitialisationData
     public DateOnly? DateOfBirth;
     public string? Trn;
     public bool? HaveCompletedTrnLookup;
-    public AuthenticationState.TrnLookupState? TrnLookup;
     public UserType? UserType;
     public string[]? StaffRoles;
     public TrnLookupStatus? TrnLookupStatus;
@@ -28,9 +27,6 @@ public record AuthenticationStateInitialisationData
             DateOfBirth = user?.DateOfBirth,
             Trn = user?.Trn,
             HaveCompletedTrnLookup = user?.CompletedTrnLookup is not null,
-            TrnLookup = user?.CompletedTrnLookup is not null
-                ? AuthenticationState.TrnLookupState.Complete
-                : AuthenticationState.TrnLookupState.None,
             UserType = user?.UserType,
             StaffRoles = user?.StaffRoles,
             TrnLookupStatus = user?.TrnLookupStatus

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/AuthenticationStateInitialisationData.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/AuthenticationStateInitialisationData.cs
@@ -1,0 +1,39 @@
+namespace TeacherIdentity.AuthServer.Models;
+
+public record AuthenticationStateInitialisationData
+{
+    public Guid? UserId;
+    public string? EmailAddress;
+    public bool EmailAddressVerified;
+    public string? FirstName;
+    public string? MiddleName;
+    public string? LastName;
+    public DateOnly? DateOfBirth;
+    public string? Trn;
+    public bool? HaveCompletedTrnLookup;
+    public AuthenticationState.TrnLookupState? TrnLookup;
+    public UserType? UserType;
+    public string[]? StaffRoles;
+    public TrnLookupStatus? TrnLookupStatus;
+
+    public static AuthenticationStateInitialisationData FromUser(User? user)
+    {
+        return new AuthenticationStateInitialisationData()
+        {
+            UserId = user?.UserId,
+            EmailAddress = user?.EmailAddress,
+            EmailAddressVerified = user is not null,
+            FirstName = user?.FirstName,
+            LastName = user?.LastName,
+            DateOfBirth = user?.DateOfBirth,
+            Trn = user?.Trn,
+            HaveCompletedTrnLookup = user?.CompletedTrnLookup is not null,
+            TrnLookup = user?.CompletedTrnLookup is not null
+                ? AuthenticationState.TrnLookupState.Complete
+                : AuthenticationState.TrnLookupState.None,
+            UserType = user?.UserType,
+            StaffRoles = user?.StaffRoles,
+            TrnLookupStatus = user?.TrnLookupStatus
+        };
+    }
+};

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/AuthenticationStateInitializationData.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/AuthenticationStateInitializationData.cs
@@ -1,6 +1,6 @@
 namespace TeacherIdentity.AuthServer.Models;
 
-public record AuthenticationStateInitialisationData
+public record AuthenticationStateInitializationData
 {
     public Guid? UserId;
     public string? EmailAddress;
@@ -15,14 +15,14 @@ public record AuthenticationStateInitialisationData
     public string[]? StaffRoles;
     public TrnLookupStatus? TrnLookupStatus;
 
-    public static AuthenticationStateInitialisationData FromUser(User? user)
+    public static AuthenticationStateInitializationData FromUser(User? user)
     {
         if (user is null)
         {
-            return new AuthenticationStateInitialisationData();
+            return new AuthenticationStateInitializationData();
         }
 
-        return new AuthenticationStateInitialisationData
+        return new AuthenticationStateInitializationData
         {
             UserId = user.UserId,
             EmailAddress = user.EmailAddress,

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateTests.cs
@@ -8,7 +8,7 @@ namespace TeacherIdentity.AuthServer.Tests;
 public partial class AuthenticationStateTests
 {
     [Fact]
-    public void FromUser_DefaultUser_MapsDataOnCorrectly()
+    public void FromUser_DefaultUser_MapsDataToAuthStateCorrectly()
     {
         // Arrange
         var user = new User()
@@ -26,6 +26,7 @@ public partial class AuthenticationStateTests
             UserId = Guid.NewGuid(),
             UserType = UserType.Default
         };
+        var authStateInitData = AuthenticationStateInitialisationData.FromUser(user);
 
         var firstTimeSignInForEmail = true;
 
@@ -33,15 +34,14 @@ public partial class AuthenticationStateTests
         var userRequirements = UserRequirements.DefaultUserType | UserRequirements.TrnHolder;
 
         // Act
-        var authenticationState = AuthenticationState.FromUser(
+        var authenticationState = new AuthenticationState(
             journeyId,
             userRequirements,
-            user,
             postSignInUrl: "/",
             startedAt: DateTime.UtcNow,
-            trn: null,
-            oAuthState: null,
-            firstTimeSignInForEmail: firstTimeSignInForEmail);
+            firstTimeSignInForEmail: firstTimeSignInForEmail,
+            authStateInitData,
+            oAuthState: null);
 
         // Assert
         Assert.Equal(user.DateOfBirth, authenticationState.DateOfBirth);
@@ -74,6 +74,7 @@ public partial class AuthenticationStateTests
             UserId = Guid.NewGuid(),
             UserType = UserType.Default
         };
+        var authStateInitData = AuthenticationStateInitialisationData.FromUser(user);
 
         var firstTimeSignInForEmail = true;
 
@@ -81,15 +82,14 @@ public partial class AuthenticationStateTests
         var userRequirements = UserRequirements.DefaultUserType | UserRequirements.TrnHolder;
 
         // Act
-        var authenticationState = AuthenticationState.FromUser(
+        var authenticationState = new AuthenticationState(
             journeyId,
             userRequirements,
-            user,
             postSignInUrl: "/",
             startedAt: DateTime.UtcNow,
-            trn: null,
-            oAuthState: null,
-            firstTimeSignInForEmail: firstTimeSignInForEmail);
+            firstTimeSignInForEmail: firstTimeSignInForEmail,
+            authStateInitData,
+            oAuthState: null);
 
         // Assert
         Assert.Equal(user.DateOfBirth, authenticationState.DateOfBirth);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateTests.cs
@@ -26,7 +26,7 @@ public partial class AuthenticationStateTests
             UserId = Guid.NewGuid(),
             UserType = UserType.Default
         };
-        var authStateInitData = AuthenticationStateInitialisationData.FromUser(user);
+        var authStateInitData = AuthenticationStateInitializationData.FromUser(user);
 
         var firstTimeSignInForEmail = true;
 
@@ -74,7 +74,7 @@ public partial class AuthenticationStateTests
             UserId = Guid.NewGuid(),
             UserType = UserType.Default
         };
-        var authStateInitData = AuthenticationStateInitialisationData.FromUser(user);
+        var authStateInitData = AuthenticationStateInitializationData.FromUser(user);
 
         var firstTimeSignInForEmail = true;
 


### PR DESCRIPTION
### Context

We’re adding magic link support to the authorize endpoint so that we can send users whose TRN we know a link to a registration journey that won’t require them to enter information that we already know.

### Changes proposed in this pull request

Add to the authorize endpoint’s trn_token check by calling the DQT API  (IDqtApiClient.GetTeacherByTrn) with the token’s TRN. If the null is returned, ignore the TRN token. Otherwise, populate the FirstName, MiddleName , LastName, EmailAddress and DateOfBirth in AuthenticationState.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
