### PR TITLE
Add Landing page for TRN token sign in journey

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -60,6 +60,7 @@ public class AuthenticationState
         UserType = authStateInitData?.UserType;
         StaffRoles = authStateInitData?.StaffRoles;
         TrnLookupStatus = authStateInitData?.TrnLookupStatus;
+        TrnToken = authStateInitData?.TrnToken;
     }
 
     public static TimeSpan AuthCookieLifetime { get; } = TimeSpan.FromMinutes(20);
@@ -139,6 +140,8 @@ public class AuthenticationState
     public string? ExistingAccountMobileNumber { get; private set; }
     [JsonInclude]
     public bool? ExistingAccountChosen { get; private set; }
+    [JsonInclude]
+    public bool? TrnToken { get; private set; }
 
     /// <summary>
     /// Whether the user has gone back to an earlier page after this journey has been completed.

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -60,7 +60,7 @@ public class AuthenticationState
         UserType = authStateInitData?.UserType;
         StaffRoles = authStateInitData?.StaffRoles;
         TrnLookupStatus = authStateInitData?.TrnLookupStatus;
-        TrnToken = authStateInitData?.TrnToken;
+        TrnToken = authStateInitData?.TrnToken == true;
     }
 
     public static TimeSpan AuthCookieLifetime { get; } = TimeSpan.FromMinutes(20);
@@ -141,7 +141,7 @@ public class AuthenticationState
     [JsonInclude]
     public bool? ExistingAccountChosen { get; private set; }
     [JsonInclude]
-    public bool? TrnToken { get; private set; }
+    public bool TrnToken { get; private set; }
 
     /// <summary>
     /// Whether the user has gone back to an earlier page after this journey has been completed.

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
@@ -506,6 +506,7 @@ public class AuthorizationController : Controller
             DateOfBirth = teacher.DateOfBirth,
             EmailAddress = trnToken.Email,
             Trn = trnToken.Trn,
+            TrnToken = true,
         };
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -84,6 +84,8 @@ public abstract class IdentityLinkGenerator
 
     public string Landing() => Page("/SignIn/Landing");
 
+    public string TrnTokenLanding() => Page("/SignIn/TrnToken/Landing");
+
     public string Register() => Page("/SignIn/Register/Index");
 
     public string RegisterEmail() => Page("/SignIn/Register/Email");

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/SignInJourneyProvider.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/SignInJourneyProvider.cs
@@ -9,10 +9,13 @@ public class SignInJourneyProvider
     {
         if (authenticationState.TryGetOAuthState(out var oAuthState) && authenticationState.UserRequirements.RequiresTrnLookup())
         {
-            var useLegacyTrnJourney = oAuthState.TrnRequirementType == TrnRequirementType.Legacy || oAuthState.HasScope(CustomScopes.Trn);
+            if (oAuthState.TrnRequirementType == TrnRequirementType.Legacy || oAuthState.HasScope(CustomScopes.Trn))
+            {
+                return ActivatorUtilities.CreateInstance<LegacyTrnJourney>(httpContext.RequestServices, httpContext);
+            }
 
-            return useLegacyTrnJourney ?
-                ActivatorUtilities.CreateInstance<LegacyTrnJourney>(httpContext.RequestServices, httpContext) :
+            return authenticationState.TrnToken == true ?
+                ActivatorUtilities.CreateInstance<TrnTokenSignInJourney>(httpContext.RequestServices, httpContext) :
                 ActivatorUtilities.CreateInstance<CoreSignInJourneyWithTrnLookup>(httpContext.RequestServices, httpContext);
         }
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenSignInJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenSignInJourney.cs
@@ -1,0 +1,49 @@
+namespace TeacherIdentity.AuthServer.Journeys;
+
+public class TrnTokenSignInJourney : SignInJourney
+{
+    public TrnTokenSignInJourney(
+        HttpContext httpContext,
+        IdentityLinkGenerator linkGenerator,
+        CreateUserHelper createUserHelper)
+        : base(httpContext, linkGenerator, createUserHelper)
+    {
+    }
+
+    public override bool CanAccessStep(string step)
+    {
+        return step switch
+        {
+            Steps.Landing => true,
+            _ => false
+        };
+    }
+
+    protected override string? GetNextStep(string currentStep)
+    {
+        return (currentStep, AuthenticationState) switch
+        {
+            _ => null
+        };
+    }
+
+    protected override string? GetPreviousStep(string currentStep) => (currentStep, AuthenticationState) switch
+    {
+        _ => null
+    };
+
+    protected override string GetStartStep() => Steps.Landing;
+
+    protected override bool IsFinished() => AuthenticationState.IsComplete;
+
+    protected override string GetStepUrl(string step) => step switch
+    {
+        Steps.Landing => LinkGenerator.TrnTokenLanding(),
+        _ => throw new ArgumentException($"Unknown step: '{step}'.")
+    };
+
+    public new static class Steps
+    {
+        public const string Landing = $"{nameof(TrnTokenSignInJourney)}.{nameof(Landing)}";
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/AuthenticationStateInitializationData.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/AuthenticationStateInitializationData.cs
@@ -14,6 +14,7 @@ public record AuthenticationStateInitializationData
     public UserType? UserType;
     public string[]? StaffRoles;
     public TrnLookupStatus? TrnLookupStatus;
+    public bool? TrnToken;
 
     public static AuthenticationStateInitializationData FromUser(User? user)
     {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/Landing.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/Landing.cshtml
@@ -1,0 +1,39 @@
+@page "/sign-in/trn-token"
+@model TeacherIdentity.AuthServer.Pages.SignIn.TrnToken.Landing
+
+@{
+    ViewBag.Title = "Create a DfE Identity account";
+}
+
+<div class="govuk-panel app-panel--interruption" data-testid="landing-panel">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full" data-testid="landing-content">
+            <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
+            <p>It will only take a few minutes and you’ll need your:</p>
+            <ul class="govuk-list govuk-list--bullet">
+                <li>email address (used for contact and account security)</li>
+                <li>mobile phone number (used for account security)</li>
+                <li>name and date of birth</li>
+            </ul>
+
+            <p>Once you've created an account, you can continue to <strong>@Model.ClientDisplayName</strong>.</p>
+
+            <govuk-details>
+                <govuk-details-summary>About DfE Identity accounts</govuk-details-summary>
+                <govuk-details-text>
+                    <p>DfE Identity accounts are new. They let teachers and teaching professionals access different DfE services with one login. You can also update your details with DfE in one place.</p>
+                    <p>If we already have your details in our records, we’ll try to link them with your new DfE Identity account. Some of your details may be different now, but you can change them in your account.</p>
+                    <p>At the moment there are only a few DfE services using DfE Identity accounts. In the future, you’ll be able to use your account details to sign in to most DfE teaching services.</p>
+                </govuk-details-text>
+            </govuk-details>
+
+            <govuk-button-link class="app-button--inverse" href="@LinkGenerator.RegisterEmail()">Create an account</govuk-button-link>
+
+            <h1 class="govuk-heading-m">Already have an account?</h1>
+
+            <p class="govuk-body govuk-!-margin-bottom-6">
+                <a href="@LinkGenerator.Email()">Sign in</a> to use your existing account details
+            </p>
+        </div>
+    </div>
+</div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/Landing.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/Landing.cshtml.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeacherIdentity.AuthServer.Journeys;
+using TeacherIdentity.AuthServer.Oidc;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn.TrnToken;
+
+[CheckCanAccessStep(CurrentStep)]
+public class Landing : PageModel
+{
+    private const string CurrentStep = TrnTokenSignInJourney.Steps.Landing;
+
+    private readonly SignInJourney _journey;
+    private readonly TeacherIdentityApplicationManager _applicationManager;
+
+    public Landing(SignInJourney journey, TeacherIdentityApplicationManager applicationManager)
+    {
+        _journey = journey;
+        _applicationManager = applicationManager;
+    }
+
+    public string? ClientDisplayName;
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        var clientId = _journey.AuthenticationState.OAuthState?.ClientId;
+        var client = await _applicationManager.FindByClientIdAsync(clientId!);
+        ClientDisplayName = await _applicationManager.GetDisplayNameAsync(client!);
+
+        await next();
+    }
+}


### PR DESCRIPTION
### Context

We have a revised journey for those registering with a magic link. This is the initial landing page for that journey.

### Changes proposed in this pull request

Create a new page at /sign-in/trn-token/ following the designs at https://get-an-identity-prototype.herokuapp.com/auth/ga-account . Access your teaching qualifications should be dynamic and use the current client’s display name.

Create a new journey - TrnTokenRegistrationJourney - that is used when a valid trn_token is provided in the authorize endpoint (we may need to add a flag to AuthenticationState so we know that).

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
