### PR TITLE
Trn token phone pages

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenSignInJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenSignInJourney.cs
@@ -15,6 +15,8 @@ public class TrnTokenSignInJourney : SignInJourney
         return step switch
         {
             Steps.Landing => true,
+            CoreSignInJourney.Steps.Phone => true,
+            CoreSignInJourney.Steps.PhoneConfirmation => AuthenticationState is { MobileNumberSet: true, MobileNumberVerified: false },
             _ => false
         };
     }
@@ -23,12 +25,15 @@ public class TrnTokenSignInJourney : SignInJourney
     {
         return (currentStep, AuthenticationState) switch
         {
+            (CoreSignInJourney.Steps.Phone, _) => CoreSignInJourney.Steps.PhoneConfirmation,
             _ => null
         };
     }
 
     protected override string? GetPreviousStep(string currentStep) => (currentStep, AuthenticationState) switch
     {
+        (CoreSignInJourney.Steps.Phone, _) => Steps.Landing,
+        (CoreSignInJourney.Steps.PhoneConfirmation, _) => CoreSignInJourney.Steps.Phone,
         _ => null
     };
 
@@ -39,6 +44,8 @@ public class TrnTokenSignInJourney : SignInJourney
     protected override string GetStepUrl(string step) => step switch
     {
         Steps.Landing => LinkGenerator.TrnTokenLanding(),
+        CoreSignInJourney.Steps.Phone => LinkGenerator.RegisterPhone(),
+        CoreSignInJourney.Steps.PhoneConfirmation => LinkGenerator.RegisterPhoneConfirmation(),
         _ => throw new ArgumentException($"Unknown step: '{step}'.")
     };
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Phone.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Phone.cshtml.cs
@@ -6,7 +6,7 @@ using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
 
-[CheckJourneyType(typeof(CoreSignInJourney), typeof(CoreSignInJourneyWithTrnLookup))]
+[CheckJourneyType(typeof(CoreSignInJourney), typeof(CoreSignInJourneyWithTrnLookup), typeof(TrnTokenSignInJourney))]
 [CheckCanAccessStep(CurrentStep)]
 public class Phone : BasePhonePageModel
 {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/PhoneConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/PhoneConfirmation.cshtml.cs
@@ -8,7 +8,7 @@ using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
 
-[CheckJourneyType(typeof(CoreSignInJourney), typeof(CoreSignInJourneyWithTrnLookup))]
+[CheckJourneyType(typeof(CoreSignInJourney), typeof(CoreSignInJourneyWithTrnLookup), typeof(TrnTokenSignInJourney))]
 [CheckCanAccessStep(CurrentStep)]
 public class PhoneConfirmation : BasePhoneConfirmationPageModel
 {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/Landing.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/Landing.cshtml
@@ -27,7 +27,7 @@
                 </govuk-details-text>
             </govuk-details>
 
-            <govuk-button-link class="app-button--inverse" href="@LinkGenerator.RegisterEmail()">Create an account</govuk-button-link>
+            <govuk-button-link class="app-button--inverse" href="@LinkGenerator.RegisterPhone()">Create an account</govuk-button-link>
 
             <h1 class="govuk-heading-m">Already have an account?</h1>
 


### PR DESCRIPTION
### Context

We have a revised journey for those registering with a magic link. This is the phone number & phone confirmation pages for that journey.

### Changes proposed in this pull request

Amend the /sign-in/register/phone and /sign-in/register/phone-confirmation pages such that they work with the new magic link journey.

Amend the journey so that the ‘Register’ link from the landing page navigates to /sign-in/register/phone.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
