### PR TITLE
Add trn sign in journey check answers page

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -620,7 +620,7 @@ public class AuthenticationState
 
         Trn = trn;
         TrnLookupStatus = trnLookupStatus;
-        TrnAssociationSource = Models.TrnAssociationSource.Lookup;
+        TrnAssociationSource = trn is null ? null : Models.TrnAssociationSource.Lookup;
     }
 
     public string Serialize() => JsonSerializer.Serialize(this, _jsonSerializerOptions);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
@@ -505,8 +505,10 @@ public class AuthorizationController : Controller
             LastName = teacher.LastName,
             DateOfBirth = teacher.DateOfBirth,
             EmailAddress = trnToken.Email,
+            EmailAddressVerified = true,
             Trn = trnToken.Trn,
-            TrnToken = true,
+            TrnAssociationSource = TrnAssociationSource.TrnToken,
+            TrnLookupStatus = TrnLookupStatus.Found,
         };
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -86,6 +86,8 @@ public abstract class IdentityLinkGenerator
 
     public string TrnTokenLanding() => Page("/SignIn/TrnToken/Landing");
 
+    public string TrnTokenCheckAnswers() => Page("/SignIn/TrnToken/CheckAnswers");
+
     public string Register() => Page("/SignIn/Register/Index");
 
     public string RegisterEmail() => Page("/SignIn/Register/Email");

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
@@ -59,7 +59,6 @@ public class CoreSignInJourneyWithTrnLookup : CoreSignInJourney
         }
         catch (UniqueConstraintException ex) when (ex.IsUniqueIndexViolation(User.TrnUniqueIndexName))
         {
-            // We don't currently handle duplicate TRNs in Core Sign In Journey
             return await CreateUserHelper.GeneratePinForExistingUserAccount(this, currentStep);
         }
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CreateUserHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CreateUserHelper.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Models;
@@ -62,9 +61,8 @@ public class CreateUserHelper
 
     public async Task<User> CreateUserWithTrn(AuthenticationState authenticationState)
     {
-        Debug.Assert(authenticationState.TrnLookupStatus.HasValue);
-
         var userId = Guid.NewGuid();
+
         var user = new User()
         {
             CompletedTrnLookup = _clock.UtcNow,
@@ -78,7 +76,7 @@ public class CreateUserHelper
             UserId = userId,
             UserType = UserType.Default,
             Trn = authenticationState.Trn,
-            TrnAssociationSource = authenticationState.Trn is not null ? TrnAssociationSource.Lookup : null,
+            TrnAssociationSource = authenticationState.TrnAssociationSource,
             LastSignedIn = _clock.UtcNow,
             RegisteredWithClientId = authenticationState.OAuthState?.ClientId,
             TrnLookupStatus = authenticationState.TrnLookupStatus

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/SignInJourneyProvider.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/SignInJourneyProvider.cs
@@ -14,7 +14,7 @@ public class SignInJourneyProvider
                 return ActivatorUtilities.CreateInstance<LegacyTrnJourney>(httpContext.RequestServices, httpContext);
             }
 
-            return authenticationState.TrnToken == true ?
+            return authenticationState.TrnAssociationSource == TrnAssociationSource.TrnToken ?
                 ActivatorUtilities.CreateInstance<TrnTokenSignInJourney>(httpContext.RequestServices, httpContext) :
                 ActivatorUtilities.CreateInstance<CoreSignInJourneyWithTrnLookup>(httpContext.RequestServices, httpContext);
         }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenSignInJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenSignInJourney.cs
@@ -26,6 +26,7 @@ public class TrnTokenSignInJourney : SignInJourney
         catch (UniqueConstraintException ex) when (ex.IsUniqueIndexViolation(User.TrnUniqueIndexName))
         {
             // We currently do not handle trn index violations for the trn token sign in journey
+            throw;
         }
 
         return new RedirectResult(GetNextStepUrl(currentStep));

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenSignInJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenSignInJourney.cs
@@ -1,3 +1,7 @@
+using EntityFramework.Exceptions.Common;
+using Microsoft.AspNetCore.Mvc;
+using TeacherIdentity.AuthServer.Models;
+
 namespace TeacherIdentity.AuthServer.Journeys;
 
 public class TrnTokenSignInJourney : SignInJourney
@@ -10,11 +14,29 @@ public class TrnTokenSignInJourney : SignInJourney
     {
     }
 
+    public override async Task<IActionResult> CreateUser(string currentStep)
+    {
+        try
+        {
+            var user = await CreateUserHelper.CreateUserWithTrn(AuthenticationState);
+
+            AuthenticationState.OnUserRegistered(user);
+            await AuthenticationState.SignIn(HttpContext);
+        }
+        catch (UniqueConstraintException ex) when (ex.IsUniqueIndexViolation(User.TrnUniqueIndexName))
+        {
+            // We currently do not handle trn index violations for the trn token sign in journey
+        }
+
+        return new RedirectResult(GetNextStepUrl(currentStep));
+    }
+
     public override bool CanAccessStep(string step)
     {
         return step switch
         {
             Steps.Landing => true,
+            Steps.CheckAnswers => AuthenticationState.MobileNumberVerified,
             CoreSignInJourney.Steps.Phone => true,
             CoreSignInJourney.Steps.PhoneConfirmation => AuthenticationState is { MobileNumberSet: true, MobileNumberVerified: false },
             _ => false
@@ -26,6 +48,8 @@ public class TrnTokenSignInJourney : SignInJourney
         return (currentStep, AuthenticationState) switch
         {
             (CoreSignInJourney.Steps.Phone, _) => CoreSignInJourney.Steps.PhoneConfirmation,
+            (CoreSignInJourney.Steps.PhoneConfirmation, _) => Steps.CheckAnswers,
+            (CoreSignInJourney.Steps.ResendPhoneConfirmation, _) => CoreSignInJourney.Steps.PhoneConfirmation,
             _ => null
         };
     }
@@ -34,6 +58,9 @@ public class TrnTokenSignInJourney : SignInJourney
     {
         (CoreSignInJourney.Steps.Phone, _) => Steps.Landing,
         (CoreSignInJourney.Steps.PhoneConfirmation, _) => CoreSignInJourney.Steps.Phone,
+        (CoreSignInJourney.Steps.ResendPhoneConfirmation, _) => CoreSignInJourney.Steps.PhoneConfirmation,
+        (Steps.CheckAnswers, { MobileNumberVerified: true }) => CoreSignInJourney.Steps.Phone,
+        (Steps.CheckAnswers, { MobileNumberVerified: false }) => CoreSignInJourney.Steps.PhoneConfirmation,
         _ => null
     };
 
@@ -44,13 +71,16 @@ public class TrnTokenSignInJourney : SignInJourney
     protected override string GetStepUrl(string step) => step switch
     {
         Steps.Landing => LinkGenerator.TrnTokenLanding(),
+        Steps.CheckAnswers => LinkGenerator.TrnTokenCheckAnswers(),
         CoreSignInJourney.Steps.Phone => LinkGenerator.RegisterPhone(),
         CoreSignInJourney.Steps.PhoneConfirmation => LinkGenerator.RegisterPhoneConfirmation(),
+        CoreSignInJourney.Steps.ResendPhoneConfirmation => LinkGenerator.RegisterResendPhoneConfirmation(),
         _ => throw new ArgumentException($"Unknown step: '{step}'.")
     };
 
     public new static class Steps
     {
         public const string Landing = $"{nameof(TrnTokenSignInJourney)}.{nameof(Landing)}";
+        public const string CheckAnswers = $"{nameof(TrnTokenSignInJourney)}.{nameof(CheckAnswers)}";
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/AuthenticationStateInitializationData.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/AuthenticationStateInitializationData.cs
@@ -14,7 +14,7 @@ public record AuthenticationStateInitializationData
     public UserType? UserType;
     public string[]? StaffRoles;
     public TrnLookupStatus? TrnLookupStatus;
-    public bool? TrnToken;
+    public TrnAssociationSource? TrnAssociationSource;
 
     public static AuthenticationStateInitializationData FromUser(User? user)
     {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/TrnAssociationSource.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/TrnAssociationSource.cs
@@ -5,5 +5,6 @@ public enum TrnAssociationSource
     Lookup = 0,
     Api = 1,
     SupportUi = 2,
-    UserImport = 3
+    UserImport = 3,
+    TrnToken = 4,
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/NoAccount.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/NoAccount.cshtml
@@ -25,7 +25,7 @@
                  <li>name and date of birth</li>
                 </ul>
 
-                <p>Once you've created an account, you can continue to <strong>@Model.ClientDisplayName</strong>.</p>
+                <p>Once you’ve created an account, you can continue to <strong>@Model.ClientDisplayName</strong>.</p>
 
                 <govuk-button type="submit" class="app-button--inverse govuk-!-margin-bottom-0">Create an account</govuk-button>
             </form>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/CheckAnswers.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/CheckAnswers.cshtml
@@ -55,28 +55,28 @@
                     <govuk-summary-list-row-key>First names</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value class="empty-hyphens">@Model.FirstName</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="" visually-hidden-text="DQT first name">Change</govuk-summary-list-row-action>
+                        <govuk-summary-list-row-action href="" visually-hidden-text="first names">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Middle names</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value>@Model.MiddleName</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="" visually-hidden-text="DQT middle name">Change</govuk-summary-list-row-action>
+                        <govuk-summary-list-row-action href="" visually-hidden-text="middle names">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Last names</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value>@Model.LastName</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="" visually-hidden-text="DQT last name">Change</govuk-summary-list-row-action>
+                        <govuk-summary-list-row-action href="" visually-hidden-text="last names">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value>@Model.DateOfBirth?.ToString(Constants.DateFormat)</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="" visually-hidden-text="DQT date of birth">Change</govuk-summary-list-row-action>
+                        <govuk-summary-list-row-action href="" visually-hidden-text="date of birth">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
             </govuk-summary-list>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/CheckAnswers.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/CheckAnswers.cshtml
@@ -1,0 +1,107 @@
+@page "/sign-in/trn-token/check-answers"
+@model TeacherIdentity.AuthServer.Pages.SignIn.TrnToken.CheckAnswers
+@{
+    ViewBag.Title = "Check your answers";
+}
+
+@section BeforeContent
+{
+    <govuk-back-link href="@Model.BackLink" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.TrnTokenCheckAnswers()" method="post" asp-antiforgery="true">
+            <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
+
+            <govuk-summary-list>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Email</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value class="empty-hyphens">@Html.ShyEmail(Model.EmailAddress!)</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="" visually-hidden-text="email">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Mobile phone</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.MobilePhoneNumber</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="" visually-hidden-text="mobile phone">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.FullName</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="" visually-hidden-text="name">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.DateOfBirth?.ToString(Constants.DateFormat)</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="" visually-hidden-text="date of birth">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+            </govuk-summary-list>
+
+            <p>Check the details we have for you from your DfE teacher record.</p>
+            <p>You’ll need to provide evidence for some name changes and all date of birth changes.</p>
+
+            <h2 class="govuk-heading-m">Personal details</h2>
+
+            <govuk-summary-list>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>First names</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value class="empty-hyphens">@Model.FirstName</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="" visually-hidden-text="DQT first name">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Middle names</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.MiddleName</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="" visually-hidden-text="DQT middle name">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Last names</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.LastName</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="" visually-hidden-text="DQT last name">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.DateOfBirth?.ToString(Constants.DateFormat)</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="" visually-hidden-text="DQT date of birth">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+            </govuk-summary-list>
+
+            <h2 class="govuk-heading-m">Sign in details</h2>
+
+            <govuk-summary-list>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Email</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value class="empty-hyphens">@Html.ShyEmail(Model.EmailAddress!)</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="" visually-hidden-text="sign in email">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Mobile phone</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.MobilePhoneNumber</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="" visually-hidden-text="sign in mobile phone">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+            </govuk-summary-list>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>
+

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/CheckAnswers.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/CheckAnswers.cshtml.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeacherIdentity.AuthServer.Journeys;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn.TrnToken;
+
+[CheckJourneyType(typeof(TrnTokenSignInJourney))]
+[CheckCanAccessStep(CurrentStep)]
+public class CheckAnswers : PageModel
+{
+    private const string CurrentStep = TrnTokenSignInJourney.Steps.CheckAnswers;
+
+    private readonly SignInJourney _journey;
+
+    public CheckAnswers(SignInJourney journey)
+    {
+        _journey = journey;
+    }
+
+    public string BackLink => _journey.GetPreviousStepUrl(CurrentStep);
+    public string? EmailAddress => _journey.AuthenticationState.EmailAddress;
+    public string? MobilePhoneNumber => _journey.AuthenticationState.MobileNumber;
+    public string? FullName => _journey.AuthenticationState.GetPreferredName();
+    public string? FirstName => _journey.AuthenticationState.FirstName;
+    public string? MiddleName => _journey.AuthenticationState.MiddleName;
+    public string? LastName => _journey.AuthenticationState.LastName;
+    public DateOnly? DateOfBirth => _journey.AuthenticationState.DateOfBirth;
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        return await _journey.CreateUser(CurrentStep);
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/Landing.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/Landing.cshtml
@@ -16,7 +16,7 @@
                 <li>name and date of birth</li>
             </ul>
 
-            <p>Once you've created an account, you can continue to <strong>@Model.ClientDisplayName</strong>.</p>
+            <p>Once you’ve created an account, you can continue to <strong>@Model.ClientDisplayName</strong>.</p>
 
             <govuk-details>
                 <govuk-details-summary>About DfE Identity accounts</govuk-details-summary>

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
@@ -34,7 +34,11 @@ public static class PageExtensions
         await page.FillAsync("label:text-is('Year')", date.Year.ToString());
     }
 
-    public static async Task StartOAuthJourney(this IPage page, string? additionalScope = null, TrnRequirementType? trnRequirement = null)
+    public static async Task StartOAuthJourney(
+        this IPage page,
+        string? additionalScope = null,
+        TrnRequirementType? trnRequirement = null,
+        string? trnToken = null)
     {
         var allScopes = new List<string>()
         {
@@ -54,6 +58,11 @@ public static class PageExtensions
         if (trnRequirement is not null)
         {
             url.SetQueryParam("trn_requirement", trnRequirement);
+        }
+
+        if (trnToken is not null)
+        {
+            url.SetQueryParam("trn_token", trnToken);
         }
 
         await page.GotoAsync(url);
@@ -280,6 +289,12 @@ public static class PageExtensions
         await page.ClickAsync("a:text-is('Create an account')");
     }
 
+    public static async Task RegisterFromTrnTokenLandingPage(this IPage page)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/trn-token");
+        await page.ClickAsync("a:text-is('Create an account')");
+    }
+
     public static async Task SubmitRegisterEmailPage(this IPage page, string email)
     {
         await page.WaitForUrlPathAsync("/sign-in/register/email");
@@ -326,6 +341,12 @@ public static class PageExtensions
     public static async Task SubmitCheckAnswersPage(this IPage page)
     {
         await page.WaitForUrlPathAsync("/sign-in/register/check-answers");
+        await page.ClickContinueButton();
+    }
+
+    public static async Task SubmitTrnTokenCheckAnswersPage(this IPage page)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/trn-token/check-answers");
         await page.ClickContinueButton();
     }
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/TrnTokenSignInJourney.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/TrnTokenSignInJourney.cs
@@ -1,0 +1,59 @@
+using Moq;
+using TeacherIdentity.AuthServer.Oidc;
+using TeacherIdentity.AuthServer.Services.DqtApi;
+
+namespace TeacherIdentity.AuthServer.EndToEndTests;
+
+public class TrnTokenSignInJourney : IClassFixture<HostFixture>
+{
+    private readonly HostFixture _hostFixture;
+
+    public TrnTokenSignInJourney(HostFixture hostFixture)
+    {
+        _hostFixture = hostFixture;
+        _hostFixture.OnTestStarting();
+    }
+
+    [Fact]
+    public async Task NewTeacherUser_WithTrnToken_CreatesUserAndCompletesFlow()
+    {
+        var mobileNumber = _hostFixture.TestData.GenerateUniqueMobileNumber();
+        var firstName = Faker.Name.First();
+        var middleName = Faker.Name.Middle();
+        var lastName = Faker.Name.Last();
+        var dateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
+        var trn = _hostFixture.TestData.GenerateTrn();
+
+        var trnToken = await _hostFixture.TestData.GenerateTrnToken(trn);
+
+        _hostFixture.DqtApiClient.Setup(mock => mock.GetTeacherByTrn(trn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TeacherInfo()
+            {
+                DateOfBirth = dateOfBirth,
+                FirstName = firstName,
+                MiddleName = middleName,
+                LastName = lastName,
+                Trn = trn,
+                NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber(),
+                PendingDateOfBirthChange = false,
+                PendingNameChange = false
+            });
+
+        await using var context = await _hostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.StartOAuthJourney(CustomScopes.DqtRead, trnToken: trnToken.TrnToken);
+
+        await page.RegisterFromTrnTokenLandingPage();
+
+        await page.SubmitRegisterPhonePage(mobileNumber);
+
+        await page.SubmitRegisterPhoneConfirmationPage();
+
+        await page.SubmitTrnTokenCheckAnswersPage();
+
+        await page.SubmitCompletePageForNewUser();
+
+        await page.AssertSignedInOnTestClient(trnToken.Email, trn, firstName, lastName);
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TestData.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TestData.cs
@@ -95,6 +95,28 @@ public partial class TestData
         }
     }
 
+    public async Task<TrnTokenModel> GenerateTrnToken(string trn, DateTime? expires = null)
+    {
+        expires ??= _clock.UtcNow.AddYears(1);
+
+        var trnToken = new TrnTokenModel()
+        {
+            TrnToken = GenerateUniqueTrnTokenValue(),
+            Trn = trn,
+            Email = GenerateUniqueEmail(),
+            CreatedUtc = _clock.UtcNow,
+            ExpiresUtc = expires.Value
+        };
+
+        await WithDbContext(async dbContext =>
+        {
+            dbContext.TrnTokens.Add(trnToken);
+            await dbContext.SaveChangesAsync();
+        });
+
+        return trnToken;
+    }
+
     public string GenerateUniqueTrnTokenValue()
     {
         string trnToken;

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Oidc/AuthorizeTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Oidc/AuthorizeTests.cs
@@ -270,7 +270,7 @@ public class AuthorizeTests : TestBase
     {
         // Arrange
         var trn = TestData.GenerateTrn();
-        var trnToken = await GenerateTrnToken(trn, expires: Clock.UtcNow.AddDays(1));
+        var trnToken = await TestData.GenerateTrnToken(trn, expires: Clock.UtcNow.AddDays(1));
 
         var firstName = Faker.Name.First();
         var lastName = Faker.Name.Last();
@@ -316,7 +316,7 @@ public class AuthorizeTests : TestBase
     {
         // Arrange
         var trn = TestData.GenerateTrn();
-        var trnToken = await GenerateTrnToken(trn, expires: Clock.UtcNow.AddDays(-1));
+        var trnToken = await TestData.GenerateTrnToken(trn, expires: Clock.UtcNow.AddDays(-1));
 
         MockDqtApiResponse(trn);
 
@@ -336,7 +336,7 @@ public class AuthorizeTests : TestBase
     {
         // Arrange
         var user = await TestData.CreateUser(hasTrn: true);
-        var trnToken = await GenerateTrnToken(user.Trn!, expires: Clock.UtcNow.AddDays(1));
+        var trnToken = await TestData.GenerateTrnToken(user.Trn!, expires: Clock.UtcNow.AddDays(1));
 
         MockDqtApiResponse(user.Trn);
 
@@ -356,7 +356,7 @@ public class AuthorizeTests : TestBase
     {
         // Arrange
         var trn = TestData.GenerateTrn();
-        var trnToken = await GenerateTrnToken(trn, expires: Clock.UtcNow.AddDays(1));
+        var trnToken = await TestData.GenerateTrnToken(trn, expires: Clock.UtcNow.AddDays(1));
 
         MockDqtApiResponse(trn);
 
@@ -377,7 +377,7 @@ public class AuthorizeTests : TestBase
     {
         // Arrange
         var trn = TestData.GenerateTrn();
-        var trnToken = await GenerateTrnToken(trn, expires: Clock.UtcNow.AddDays(1));
+        var trnToken = await TestData.GenerateTrnToken(trn, expires: Clock.UtcNow.AddDays(1));
 
         HostFixture.DqtApiClient
             .Setup(mock => mock.GetTeacherByTrn(trn, It.IsAny<CancellationToken>()))
@@ -447,32 +447,12 @@ public class AuthorizeTests : TestBase
         return Guid.Parse(asid);
     }
 
-    private async Task<TrnTokenModel> GenerateTrnToken(string trn, DateTime expires)
-    {
-        var trnToken = new TrnTokenModel()
-        {
-            TrnToken = TestData.GenerateUniqueTrnTokenValue(),
-            Trn = trn,
-            Email = TestData.GenerateUniqueEmail(),
-            CreatedUtc = Clock.UtcNow,
-            ExpiresUtc = expires
-        };
-
-        await TestData.WithDbContext(async dbContext =>
-        {
-            dbContext.TrnTokens.Add(trnToken);
-            await dbContext.SaveChangesAsync();
-        });
-
-        return trnToken;
-    }
-
     private void MockDqtApiResponse(string? trn = null, string? firstName = null, string? lastName = null, DateOnly? dateOfBirth = null)
     {
         trn ??= TestData.GenerateTrn();
 
         HostFixture.DqtApiClient.Setup(mock => mock.GetTeacherByTrn(trn, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new AuthServer.Services.DqtApi.TeacherInfo()
+            .ReturnsAsync(new TeacherInfo()
             {
                 DateOfBirth = dateOfBirth ?? DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
                 FirstName = firstName ?? Faker.Name.First(),


### PR DESCRIPTION
### Context

We have a revised journey for those registering with a magic link. This is the check answers and create user page.

### Changes proposed in this pull request

Create a new page at /sign-in/trn-token/check-answers following the designs at https://dfe-identity-account-prototype.herokuapp.com/auth/check-answers . Amend the journey to redirect here after the user’s phone number has been confirmed.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
