### PR TITLE
Enable change link for email for trn token sign in journey

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenSignInJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenSignInJourney.cs
@@ -37,9 +37,13 @@ public class TrnTokenSignInJourney : SignInJourney
         return step switch
         {
             Steps.Landing => true,
-            Steps.CheckAnswers => AuthenticationState.MobileNumberVerified,
+            Steps.CheckAnswers => AuthenticationState.ContactDetailsVerified,
             CoreSignInJourney.Steps.Phone => true,
             CoreSignInJourney.Steps.PhoneConfirmation => AuthenticationState is { MobileNumberSet: true, MobileNumberVerified: false },
+            CoreSignInJourney.Steps.ResendPhoneConfirmation => AuthenticationState is { MobileNumberSet: true, MobileNumberVerified: false },
+            CoreSignInJourney.Steps.Email => AuthenticationState.MobileNumberVerified,
+            CoreSignInJourney.Steps.EmailConfirmation => AuthenticationState is { EmailAddressSet: true, EmailAddressVerified: false, MobileNumberVerified: true },
+            CoreSignInJourney.Steps.ResendEmailConfirmation => AuthenticationState is { EmailAddressSet: true, EmailAddressVerified: false },
             _ => false
         };
     }
@@ -48,8 +52,11 @@ public class TrnTokenSignInJourney : SignInJourney
     {
         return (currentStep, AuthenticationState) switch
         {
+            (Steps.Landing, _) => CoreSignInJourney.Steps.Phone,
             (CoreSignInJourney.Steps.Phone, _) => CoreSignInJourney.Steps.PhoneConfirmation,
             (CoreSignInJourney.Steps.PhoneConfirmation, _) => Steps.CheckAnswers,
+            (CoreSignInJourney.Steps.Email, _) => CoreSignInJourney.Steps.EmailConfirmation,
+            (CoreSignInJourney.Steps.EmailConfirmation, _) => Steps.CheckAnswers,
             (CoreSignInJourney.Steps.ResendPhoneConfirmation, _) => CoreSignInJourney.Steps.PhoneConfirmation,
             _ => null
         };
@@ -60,8 +67,14 @@ public class TrnTokenSignInJourney : SignInJourney
         (CoreSignInJourney.Steps.Phone, _) => Steps.Landing,
         (CoreSignInJourney.Steps.PhoneConfirmation, _) => CoreSignInJourney.Steps.Phone,
         (CoreSignInJourney.Steps.ResendPhoneConfirmation, _) => CoreSignInJourney.Steps.PhoneConfirmation,
-        (Steps.CheckAnswers, { MobileNumberVerified: true }) => CoreSignInJourney.Steps.Phone,
+        (CoreSignInJourney.Steps.Email, { ContactDetailsVerified: true }) => Steps.CheckAnswers,
+        (CoreSignInJourney.Steps.Email, { MobileNumberVerified: false }) => CoreSignInJourney.Steps.PhoneConfirmation,
+        (CoreSignInJourney.Steps.Email, { MobileNumberVerified: true }) => CoreSignInJourney.Steps.Email,
+        (CoreSignInJourney.Steps.EmailConfirmation, _) => CoreSignInJourney.Steps.Email,
+        (CoreSignInJourney.Steps.ResendEmailConfirmation, _) => CoreSignInJourney.Steps.EmailConfirmation,
+        (Steps.CheckAnswers, { EmailAddressVerified: false }) => CoreSignInJourney.Steps.EmailConfirmation,
         (Steps.CheckAnswers, { MobileNumberVerified: false }) => CoreSignInJourney.Steps.PhoneConfirmation,
+        (Steps.CheckAnswers, _) => CoreSignInJourney.Steps.Phone,
         _ => null
     };
 
@@ -76,6 +89,9 @@ public class TrnTokenSignInJourney : SignInJourney
         CoreSignInJourney.Steps.Phone => LinkGenerator.RegisterPhone(),
         CoreSignInJourney.Steps.PhoneConfirmation => LinkGenerator.RegisterPhoneConfirmation(),
         CoreSignInJourney.Steps.ResendPhoneConfirmation => LinkGenerator.RegisterResendPhoneConfirmation(),
+        CoreSignInJourney.Steps.Email => LinkGenerator.RegisterEmail(),
+        CoreSignInJourney.Steps.EmailConfirmation => LinkGenerator.RegisterEmailConfirmation(),
+        CoreSignInJourney.Steps.ResendEmailConfirmation => LinkGenerator.RegisterResendEmailConfirmation(),
         _ => throw new ArgumentException($"Unknown step: '{step}'.")
     };
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Email.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Email.cshtml.cs
@@ -7,7 +7,7 @@ using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
 
-[CheckJourneyType(typeof(CoreSignInJourney), typeof(CoreSignInJourneyWithTrnLookup))]
+[CheckJourneyType(typeof(CoreSignInJourney), typeof(CoreSignInJourneyWithTrnLookup), typeof(TrnTokenSignInJourney))]
 [CheckCanAccessStep(CurrentStep)]
 public class EmailModel : BaseEmailPageModel
 {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/EmailConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/EmailConfirmation.cshtml.cs
@@ -8,7 +8,7 @@ using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
 
-[CheckJourneyType(typeof(CoreSignInJourney), typeof(CoreSignInJourneyWithTrnLookup))]
+[CheckJourneyType(typeof(CoreSignInJourney), typeof(CoreSignInJourneyWithTrnLookup), typeof(TrnTokenSignInJourney))]
 [CheckCanAccessStep(CurrentStep)]
 public class EmailConfirmationModel : BaseEmailConfirmationPageModel
 {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendEmailConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendEmailConfirmation.cshtml.cs
@@ -7,7 +7,7 @@ using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
 
-[CheckJourneyType(typeof(CoreSignInJourney), typeof(CoreSignInJourneyWithTrnLookup))]
+[CheckJourneyType(typeof(CoreSignInJourney), typeof(CoreSignInJourneyWithTrnLookup), typeof(TrnTokenSignInJourney))]
 [CheckCanAccessStep(CurrentStep)]
 public class ResendEmailConfirmationModel : BaseEmailPageModel
 {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendPhoneConfirmation.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/ResendPhoneConfirmation.cshtml.cs
@@ -6,7 +6,7 @@ using TeacherIdentity.AuthServer.Services.UserVerification;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
 
-[CheckJourneyType(typeof(CoreSignInJourney), typeof(CoreSignInJourneyWithTrnLookup))]
+[CheckJourneyType(typeof(CoreSignInJourney), typeof(CoreSignInJourneyWithTrnLookup), typeof(TrnTokenSignInJourney))]
 [CheckCanAccessStep(CurrentStep)]
 public class ResendPhoneConfirmationModel : BasePhonePageModel
 {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/CheckAnswers.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/CheckAnswers.cshtml
@@ -19,7 +19,7 @@
                     <govuk-summary-list-row-key>Email</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value class="empty-hyphens">@Html.ShyEmail(Model.EmailAddress!)</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="" visually-hidden-text="email">Change</govuk-summary-list-row-action>
+                        <govuk-summary-list-row-action href="@LinkGenerator.RegisterEmail()" visually-hidden-text="email" data-testid="trn-token-email-change-link">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
@@ -88,7 +88,7 @@
                     <govuk-summary-list-row-key>Email</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value class="empty-hyphens">@Html.ShyEmail(Model.EmailAddress!)</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="" visually-hidden-text="sign in email">Change</govuk-summary-list-row-action>
+                        <govuk-summary-list-row-action href="@LinkGenerator.RegisterEmail()" visually-hidden-text="sign in email">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/CheckAnswers.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/CheckAnswers.cshtml
@@ -14,37 +14,6 @@
         <form action="@LinkGenerator.TrnTokenCheckAnswers()" method="post" asp-antiforgery="true">
             <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
 
-            <govuk-summary-list>
-                <govuk-summary-list-row>
-                    <govuk-summary-list-row-key>Email</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value class="empty-hyphens">@Html.ShyEmail(Model.EmailAddress!)</govuk-summary-list-row-value>
-                    <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.RegisterEmail()" visually-hidden-text="email" data-testid="trn-token-email-change-link">Change</govuk-summary-list-row-action>
-                    </govuk-summary-list-row-actions>
-                </govuk-summary-list-row>
-                <govuk-summary-list-row>
-                    <govuk-summary-list-row-key>Mobile phone</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value>@Model.MobilePhoneNumber</govuk-summary-list-row-value>
-                    <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="" visually-hidden-text="mobile phone">Change</govuk-summary-list-row-action>
-                    </govuk-summary-list-row-actions>
-                </govuk-summary-list-row>
-                <govuk-summary-list-row>
-                    <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value>@Model.FullName</govuk-summary-list-row-value>
-                    <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="" visually-hidden-text="name">Change</govuk-summary-list-row-action>
-                    </govuk-summary-list-row-actions>
-                </govuk-summary-list-row>
-                <govuk-summary-list-row>
-                    <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value>@Model.DateOfBirth?.ToString(Constants.DateFormat)</govuk-summary-list-row-value>
-                    <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="" visually-hidden-text="date of birth">Change</govuk-summary-list-row-action>
-                    </govuk-summary-list-row-actions>
-                </govuk-summary-list-row>
-            </govuk-summary-list>
-
             <p>Check the details we have for you from your DfE teacher record.</p>
             <p>You’ll need to provide evidence for some name changes and all date of birth changes.</p>
 
@@ -88,14 +57,14 @@
                     <govuk-summary-list-row-key>Email</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value class="empty-hyphens">@Html.ShyEmail(Model.EmailAddress!)</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.RegisterEmail()" visually-hidden-text="sign in email">Change</govuk-summary-list-row-action>
+                        <govuk-summary-list-row-action href="@LinkGenerator.RegisterEmail()" visually-hidden-text="email" data-testid="trn-token-email-change-link">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Mobile phone</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value>@Model.MobilePhoneNumber</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="" visually-hidden-text="sign in mobile phone">Change</govuk-summary-list-row-action>
+                        <govuk-summary-list-row-action href="" visually-hidden-text="mobile phone">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
             </govuk-summary-list>

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
@@ -350,6 +350,12 @@ public static class PageExtensions
         await page.ClickContinueButton();
     }
 
+    public static async Task ClickChangeLinkTrnTokenCheckAnswersPage(this IPage page, string testId)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/trn-token/check-answers");
+        await page.ClickChangeLinkForElementWithTestId(testId);
+    }
+
     public static async Task SubmitCompletePageForNewUser(this IPage page)
     {
         await page.WaitForUrlPathAsync("/sign-in/complete");


### PR DESCRIPTION
### Context

We have a revised journey for those registering with a magic link. We pre-populate email with the email that we sent the magic link to but a user may wish to change it.

### Changes proposed in this pull request

Amend the Change link for the Email row on the Check Answers page for the TRN token journey to link to /sign-in/register/email. Ensure the Register/Email and Register/EmailConfirmation pages function correctly within this journey and redirect to the Check Answers page once the email is verified. The user should not be able to go ‘back' to the Check Answers page after they change the email before it’s verified.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
