### PR TITLE
Add an explicit check that a user has gone through TRN lookup

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
@@ -179,6 +179,18 @@ public class CoreSignInJourneyWithTrnLookup : CoreSignInJourney
             _ => base.GetLastAccessibleStepUrl(requestedStep)
         };
 
+    public override Task<IActionResult> OnEmailVerified(User? user, string currentStep)
+    {
+        if (user is not null && user.UserType == Models.UserType.Default && user.TrnLookupStatus is null)
+        {
+            // User was created in a journey that didn't perform a TRN lookup;
+            // we don't have an 'upgrade' story for that scenario yet but we cannot allow the user to sign in.
+            throw new NotImplementedException("Cannot lookup a TRN for an existing user.");
+        }
+
+        return base.OnEmailVerified(user, currentStep);
+    }
+
     protected override bool AreAllQuestionsAnswered() =>
         AuthenticationState.EmailAddressSet &&
         AuthenticationState.EmailAddressVerified &&

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/LegacyTrnJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/LegacyTrnJourney.cs
@@ -187,6 +187,18 @@ public class LegacyTrnJourney : SignInJourney
             _ => base.GetLastAccessibleStepUrl(requestedStep)
         };
 
+    public override Task<IActionResult> OnEmailVerified(User? user, string currentStep)
+    {
+        if (user is not null && user.UserType == Models.UserType.Default && user.TrnLookupStatus is null)
+        {
+            // User was created in a journey that didn't perform a TRN lookup;
+            // we don't have an 'upgrade' story for that scenario yet but we cannot allow the user to sign in.
+            throw new NotImplementedException("Cannot lookup a TRN for an existing user.");
+        }
+
+        return base.OnEmailVerified(user, currentStep);
+    }
+
     private bool AreAllQuestionsAnswered() =>
         AuthenticationState.EmailAddressSet &&
             AuthenticationState.EmailAddressVerified &&

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/UserClaimHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/UserClaimHelper.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Security.Claims;
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Models;
@@ -79,6 +80,7 @@ public class UserClaimHelper
 
         if (UserRequirementsExtensions.GetUserRequirementsForScopes(hasScope).RequiresTrnLookup())
         {
+            Debug.Assert(user.TrnLookupStatus.HasValue);
             claims.Add(new Claim(CustomClaims.TrnLookupStatus, user.TrnLookupStatus!.Value.ToString()));
 
             if (user.Trn is not null)


### PR DESCRIPTION
We've an error in our logs from internal testing where a user has signed up using the Core journey (without TRN lookup) then attempted to sign in using a scope that requires a TRN lookup. We don't yet support 'upgrading' an account by asking TRN lookup questions for existing users but the error thrown was an `InvalidOperationException` - `Nullable object must have a value.` from the depths of `UserClaimHelper`.

This change puts an explicit check into the TRN lookup-requiring journeys and throws a more specific exception. It's also a useful placeholder so we know where to change when we're building out support for this scenario.