### PR TITLE
Additional zendesk ticket info

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
@@ -1,5 +1,4 @@
 using EntityFramework.Exceptions.Common;
-using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using TeacherIdentity.AuthServer.Oidc;
 using TeacherIdentity.AuthServer.Services.BackgroundJobs;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
@@ -1,4 +1,5 @@
 using EntityFramework.Exceptions.Common;
+using Microsoft.AspNetCore.Components.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using TeacherIdentity.AuthServer.Oidc;
 using TeacherIdentity.AuthServer.Services.BackgroundJobs;
@@ -53,7 +54,9 @@ public class CoreSignInJourneyWithTrnLookup : CoreSignInJourney
                             AuthenticationState.DateOfBirth,
                             AuthenticationState.NationalInsuranceNumber,
                             AuthenticationState.IttProviderName,
-                            AuthenticationState.StatedTrn));
+                            AuthenticationState.StatedTrn,
+                            AuthenticationState.OAuthState.ClientId,
+                            AuthenticationState.OAuthState.TrnRequirementType == Models.TrnRequirementType.Required));
                 }
             }
         }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
@@ -54,7 +54,7 @@ public class CoreSignInJourneyWithTrnLookup : CoreSignInJourney
                             AuthenticationState.NationalInsuranceNumber,
                             AuthenticationState.IttProviderName,
                             AuthenticationState.StatedTrn,
-                            AuthenticationState.OAuthState.ClientId,
+                            client.DisplayName,
                             AuthenticationState.OAuthState.TrnRequirementType == Models.TrnRequirementType.Required));
                 }
             }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CreateUserHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CreateUserHelper.cs
@@ -134,7 +134,7 @@ public class CreateUserHelper
         string? nationalInsuranceNumber,
         string? ittProviderName,
         string? statedTrn,
-        string? clientId,
+        string? serviceName,
         bool requiresTrnLookup)
     {
         var contactUserWithTrn = requiresTrnLookup ? "Yes" : "No";
@@ -147,7 +147,7 @@ public class CreateUserHelper
                 NI number: {nationalInsuranceNumber ?? "Not provided"}
                 ITT provider: {ittProviderName ?? "Not provided"}
                 User-provided TRN: {statedTrn ?? "Not provided"}
-                Service: {clientId ?? "Not provided"}
+                Service: {serviceName ?? "Not provided"}
                 Contact user with TRN: {contactUserWithTrn}
                 """;
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CreateUserHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CreateUserHelper.cs
@@ -133,8 +133,11 @@ public class CreateUserHelper
         DateOnly? dateOfBirth,
         string? nationalInsuranceNumber,
         string? ittProviderName,
-        string? statedTrn)
+        string? statedTrn,
+        string? clientId,
+        bool requiresTrnLookup)
     {
+        var contactUserWithTrn = requiresTrnLookup ? "Yes" : "No";
         var ticketComment = $"""
                 A user has submitted a request to find their TRN. Their information is:
                 Name: {officialName}
@@ -144,6 +147,8 @@ public class CreateUserHelper
                 NI number: {nationalInsuranceNumber ?? "Not provided"}
                 ITT provider: {ittProviderName ?? "Not provided"}
                 User-provided TRN: {statedTrn ?? "Not provided"}
+                Service: {clientId ?? "Not provided"}
+                Contact user with TRN: {contactUserWithTrn}
                 """;
 
         var ticketResponse = await _zendeskApiWrapper.CreateTicketAsync(new()
@@ -166,7 +171,7 @@ public class CreateUserHelper
                     Value = "request_from_identity_auth_service"
                 }
             }
-        }); ;
+        });
 
         var user = await _dbContext.Users.Where(u => u.UserId == userId).SingleAsync();
         user.TrnLookupSupportTicketCreated = true;


### PR DESCRIPTION
### Context

When the helpdesk are manually resolving a TRN they need to know whether the user was prevented from signing in so that they can email them once their TRN has been found. For NPQ, the user would not be emailed since a TRN is not required to sign in to NPQ. For the new Quals UI, the user would be prevented from signing in since the Quals UI requires a TRN to retrieve the user’s data.

### Changes proposed in this pull request

Add an additional two lines to the ticket content:

Service: {service name}
Contact user with TRN: {Yes or No}
Contact user with TRN should be Yes if the current client’s TrnRequirementType is Required, otherwise No.

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
