### PR TITLE
Enable date of birth change link for trn token journey

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenSignInJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenSignInJourney.cs
@@ -38,6 +38,7 @@ public class TrnTokenSignInJourney : SignInJourney
         {
             Steps.Landing => true,
             Steps.CheckAnswers => AuthenticationState.ContactDetailsVerified,
+            CoreSignInJourney.Steps.DateOfBirth => AuthenticationState.ContactDetailsVerified,
             CoreSignInJourney.Steps.Phone => true,
             CoreSignInJourney.Steps.PhoneConfirmation => AuthenticationState is { MobileNumberSet: true, MobileNumberVerified: false },
             CoreSignInJourney.Steps.ResendPhoneConfirmation => AuthenticationState is { MobileNumberSet: true, MobileNumberVerified: false },
@@ -57,6 +58,7 @@ public class TrnTokenSignInJourney : SignInJourney
             (CoreSignInJourney.Steps.PhoneConfirmation, _) => Steps.CheckAnswers,
             (CoreSignInJourney.Steps.Email, _) => CoreSignInJourney.Steps.EmailConfirmation,
             (CoreSignInJourney.Steps.EmailConfirmation, _) => Steps.CheckAnswers,
+            (CoreSignInJourney.Steps.DateOfBirth, _) => Steps.CheckAnswers,
             (CoreSignInJourney.Steps.ResendPhoneConfirmation, _) => CoreSignInJourney.Steps.PhoneConfirmation,
             _ => null
         };
@@ -72,6 +74,7 @@ public class TrnTokenSignInJourney : SignInJourney
         (CoreSignInJourney.Steps.Email, { MobileNumberVerified: true }) => CoreSignInJourney.Steps.Email,
         (CoreSignInJourney.Steps.EmailConfirmation, _) => CoreSignInJourney.Steps.Email,
         (CoreSignInJourney.Steps.ResendEmailConfirmation, _) => CoreSignInJourney.Steps.EmailConfirmation,
+        (CoreSignInJourney.Steps.DateOfBirth, _) => Steps.CheckAnswers,
         (Steps.CheckAnswers, { EmailAddressVerified: false }) => CoreSignInJourney.Steps.EmailConfirmation,
         (Steps.CheckAnswers, { MobileNumberVerified: false }) => CoreSignInJourney.Steps.PhoneConfirmation,
         (Steps.CheckAnswers, _) => CoreSignInJourney.Steps.Phone,
@@ -92,6 +95,7 @@ public class TrnTokenSignInJourney : SignInJourney
         CoreSignInJourney.Steps.Email => LinkGenerator.RegisterEmail(),
         CoreSignInJourney.Steps.EmailConfirmation => LinkGenerator.RegisterEmailConfirmation(),
         CoreSignInJourney.Steps.ResendEmailConfirmation => LinkGenerator.RegisterResendEmailConfirmation(),
+        CoreSignInJourney.Steps.DateOfBirth => LinkGenerator.RegisterDateOfBirth(),
         _ => throw new ArgumentException($"Unknown step: '{step}'.")
     };
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/DateOfBirthPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/DateOfBirthPage.cshtml.cs
@@ -6,7 +6,7 @@ using TeacherIdentity.AuthServer.Services.UserSearch;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
 
-[CheckJourneyType(typeof(CoreSignInJourney), typeof(CoreSignInJourneyWithTrnLookup))]
+[CheckJourneyType(typeof(CoreSignInJourney), typeof(CoreSignInJourneyWithTrnLookup), typeof(TrnTokenSignInJourney))]
 [CheckCanAccessStep(CurrentStep)]
 public class DateOfBirthPage : PageModel
 {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/CheckAnswers.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/CheckAnswers.cshtml
@@ -45,7 +45,7 @@
                     <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value>@Model.DateOfBirth?.ToString(Constants.DateFormat)</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="" visually-hidden-text="date of birth">Change</govuk-summary-list-row-action>
+                        <govuk-summary-list-row-action href="@LinkGenerator.RegisterDateOfBirth()" visually-hidden-text="date of birth">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
             </govuk-summary-list>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/CheckAnswers.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/CheckAnswers.cshtml.cs
@@ -20,7 +20,6 @@ public class CheckAnswers : PageModel
     public string BackLink => _journey.GetPreviousStepUrl(CurrentStep);
     public string? EmailAddress => _journey.AuthenticationState.EmailAddress;
     public string? MobilePhoneNumber => _journey.AuthenticationState.MobileNumber;
-    public string? FullName => _journey.AuthenticationState.GetPreferredName();
     public string? FirstName => _journey.AuthenticationState.FirstName;
     public string? MiddleName => _journey.AuthenticationState.MiddleName;
     public string? LastName => _journey.AuthenticationState.LastName;


### PR DESCRIPTION
### Context

We have a revised journey for those registering with a magic link. We pre-populate date of birth with the date of birth of the DQT record for the TRN that the magic link was for but a user may wish to change it if it’s not correct.

### Changes proposed in this pull request

Amend the Change link for the Date of birth row on the Check Answers page for the TRN token journey to link to /sign-in/register/date-of-birth. Ensure the Register/DateOfBirth page functions correctly within this journey and redirects to the Check Answers page once a valid date of birth has been submitted.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
