### PR TITLE
Update Trn Token with User ID when User created

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -61,6 +61,7 @@ public class AuthenticationState
         StaffRoles = authStateInitData?.StaffRoles;
         TrnLookupStatus = authStateInitData?.TrnLookupStatus;
         TrnAssociationSource = authStateInitData?.TrnAssociationSource;
+        TrnToken = authStateInitData?.TrnToken;
     }
 
     public static TimeSpan AuthCookieLifetime { get; } = TimeSpan.FromMinutes(20);
@@ -142,6 +143,8 @@ public class AuthenticationState
     public bool? ExistingAccountChosen { get; private set; }
     [JsonInclude]
     public TrnAssociationSource? TrnAssociationSource { get; private set; }
+    [JsonInclude]
+    public string? TrnToken { get; private set; }
 
     /// <summary>
     /// Whether the user has gone back to an earlier page after this journey has been completed.

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -60,7 +60,6 @@ public class AuthenticationState
         UserType = authStateInitData?.UserType;
         StaffRoles = authStateInitData?.StaffRoles;
         TrnLookupStatus = authStateInitData?.TrnLookupStatus;
-        TrnAssociationSource = authStateInitData?.TrnAssociationSource;
         TrnToken = authStateInitData?.TrnToken;
     }
 
@@ -142,8 +141,6 @@ public class AuthenticationState
     [JsonInclude]
     public bool? ExistingAccountChosen { get; private set; }
     [JsonInclude]
-    public TrnAssociationSource? TrnAssociationSource { get; private set; }
-    [JsonInclude]
     public string? TrnToken { get; private set; }
 
     /// <summary>
@@ -176,6 +173,8 @@ public class AuthenticationState
     public bool HasIttProviderSet => HasIttProvider.HasValue;
     [JsonIgnore]
     public bool ContactDetailsVerified => EmailAddressVerified && MobileNumberVerified;
+    [JsonIgnore]
+    public bool HasTrnToken => !string.IsNullOrEmpty(TrnToken);
 
     public static ClaimsPrincipal CreatePrincipal(IEnumerable<Claim> claims)
     {
@@ -218,7 +217,7 @@ public class AuthenticationState
     public bool IsComplete =>
         EmailAddressVerified &&
         (!UserRequirements.HasFlag(UserRequirements.TrnHolder) ||
-        TrnAssociationSource == Models.TrnAssociationSource.TrnToken ||
+        HasTrnToken ||
         TrnLookup == TrnLookupState.Complete) &&
         UserId.HasValue;
 
@@ -457,7 +456,6 @@ public class AuthenticationState
         UserType = user.UserType;
         StaffRoles = user.StaffRoles;
         TrnLookupStatus = user.TrnLookupStatus;
-        TrnAssociationSource = user.TrnAssociationSource;
     }
 
     public void OnEmailChanged(string email)
@@ -623,7 +621,6 @@ public class AuthenticationState
 
         Trn = trn;
         TrnLookupStatus = trnLookupStatus;
-        TrnAssociationSource = trn is null ? null : Models.TrnAssociationSource.Lookup;
     }
 
     public string Serialize() => JsonSerializer.Serialize(this, _jsonSerializerOptions);
@@ -667,7 +664,6 @@ public class AuthenticationState
         UserType = user.UserType;
         StaffRoles = user.StaffRoles;
         TrnLookupStatus = user.TrnLookupStatus;
-        TrnAssociationSource = user.TrnAssociationSource;
 
         if (HaveCompletedTrnLookup || Trn is not null)
         {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
@@ -509,7 +509,6 @@ public class AuthorizationController : Controller
             EmailAddress = trnToken.Email,
             EmailAddressVerified = true,
             Trn = trnToken.Trn,
-            TrnAssociationSource = TrnAssociationSource.TrnToken,
             TrnLookupStatus = TrnLookupStatus.Found,
             TrnToken = trnToken.TrnToken,
         };

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
@@ -486,7 +486,9 @@ public class AuthorizationController : Controller
     {
         var trnToken = await _dbContext.TrnTokens.SingleOrDefaultAsync(t => t.TrnToken == trnTokenValue && t.ExpiresUtc > _clock.UtcNow);
 
-        if (trnToken is null || await _dbContext.Users.FirstOrDefaultAsync(u => u.Trn == trnToken.Trn) is not null)
+        if (trnToken is null ||
+            trnToken.UserId is not null ||
+            await _dbContext.Users.FirstOrDefaultAsync(u => u.Trn == trnToken.Trn) is not null)
         {
             return null;
         }
@@ -509,6 +511,7 @@ public class AuthorizationController : Controller
             Trn = trnToken.Trn,
             TrnAssociationSource = TrnAssociationSource.TrnToken,
             TrnLookupStatus = TrnLookupStatus.Found,
+            TrnToken = trnToken.TrnToken,
         };
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CreateUserHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CreateUserHelper.cs
@@ -88,7 +88,7 @@ public class CreateUserHelper
 
         if (authenticationState.HasTrnToken)
         {
-            _dbContext.Database.ExecuteSqlInterpolatedAsync(
+            await _dbContext.Database.ExecuteSqlInterpolatedAsync(
                 $"update trn_tokens set user_id = {userId} where trn_token = {authenticationState.TrnToken};");
         }
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CreateUserHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CreateUserHelper.cs
@@ -84,6 +84,12 @@ public class CreateUserHelper
 
         _dbContext.Users.Add(user);
 
+        if (authenticationState.TrnToken is not null && authenticationState.TrnAssociationSource == TrnAssociationSource.TrnToken)
+        {
+            _dbContext.Database.ExecuteSqlInterpolatedAsync(
+                $"update trn_tokens set user_id = {userId} where trn_token = {authenticationState.TrnToken};");
+        }
+
         _dbContext.AddEvent(new Events.UserRegisteredEvent()
         {
             ClientId = authenticationState.OAuthState?.ClientId,

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/SignInJourneyProvider.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/SignInJourneyProvider.cs
@@ -14,7 +14,7 @@ public class SignInJourneyProvider
                 return ActivatorUtilities.CreateInstance<LegacyTrnJourney>(httpContext.RequestServices, httpContext);
             }
 
-            return authenticationState.TrnAssociationSource == TrnAssociationSource.TrnToken ?
+            return authenticationState.HasTrnToken ?
                 ActivatorUtilities.CreateInstance<TrnTokenSignInJourney>(httpContext.RequestServices, httpContext) :
                 ActivatorUtilities.CreateInstance<CoreSignInJourneyWithTrnLookup>(httpContext.RequestServices, httpContext);
         }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230519103755_TrnTokenUserId.Designer.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230519103755_TrnTokenUserId.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeacherIdentity.AuthServer.Models;
@@ -12,9 +13,11 @@ using TeacherIdentity.AuthServer.Models;
 namespace TeacherIdentity.AuthServer.Migrations
 {
     [DbContext(typeof(TeacherIdentityServerDbContext))]
-    partial class TeacherIdentityServerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230519103755_TrnTokenUserId")]
+    partial class TrnTokenUserId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230519103755_TrnTokenUserId.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230519103755_TrnTokenUserId.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeacherIdentity.AuthServer.Migrations
+{
+    /// <inheritdoc />
+    public partial class TrnTokenUserId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "user_id",
+                table: "trn_tokens",
+                type: "uuid",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "user_id",
+                table: "trn_tokens");
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/AuthenticationStateInitializationData.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/AuthenticationStateInitializationData.cs
@@ -15,6 +15,7 @@ public record AuthenticationStateInitializationData
     public string[]? StaffRoles;
     public TrnLookupStatus? TrnLookupStatus;
     public TrnAssociationSource? TrnAssociationSource;
+    public string? TrnToken;
 
     public static AuthenticationStateInitializationData FromUser(User? user)
     {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/AuthenticationStateInitializationData.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/AuthenticationStateInitializationData.cs
@@ -14,7 +14,6 @@ public record AuthenticationStateInitializationData
     public UserType? UserType;
     public string[]? StaffRoles;
     public TrnLookupStatus? TrnLookupStatus;
-    public TrnAssociationSource? TrnAssociationSource;
     public string? TrnToken;
 
     public static AuthenticationStateInitializationData FromUser(User? user)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/TrnTokenModel.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/TrnTokenModel.cs
@@ -10,4 +10,5 @@ public class TrnTokenModel
     public required string Email { get; set; }
     public required DateTime CreatedUtc { get; set; }
     public required DateTime ExpiresUtc { get; set; }
+    public Guid? UserId { get; set; }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/TrnTokenSignInJourney.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/TrnTokenSignInJourney.cs
@@ -1,3 +1,4 @@
+using System.Data.Entity;
 using Moq;
 using TeacherIdentity.AuthServer.Oidc;
 using TeacherIdentity.AuthServer.Services.DqtApi;
@@ -55,6 +56,9 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
         await page.SubmitCompletePageForNewUser();
 
         await page.AssertSignedInOnTestClient(trnToken.Email, trn, firstName, lastName);
+
+        var trnTokenModel = await _hostFixture.TestData.GetTrnToken(trnToken.TrnToken);
+        Assert.NotNull(trnTokenModel?.UserId);
     }
 
     [Fact]

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/TrnTokenSignInJourney.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/TrnTokenSignInJourney.cs
@@ -1,4 +1,3 @@
-using System.Data.Entity;
 using Moq;
 using TeacherIdentity.AuthServer.Oidc;
 using TeacherIdentity.AuthServer.Services.DqtApi;

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TestData.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/TestData.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Security.Cryptography;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
 using TeacherIdentity.AuthServer.Models;
 
@@ -93,6 +94,14 @@ public partial class TestData
             _mobileNumbers.Add(mobileNumber);
             return mobileNumber;
         }
+    }
+
+    public async Task<TrnTokenModel?> GetTrnToken(string trnToken)
+    {
+        return await WithDbContext(async dbContext =>
+        {
+            return await dbContext.TrnTokens.SingleOrDefaultAsync(t => t.TrnToken == trnToken);
+        });
     }
 
     public async Task<TrnTokenModel> GenerateTrnToken(string trn, DateTime? expires = null)


### PR DESCRIPTION
### Context

Once a TRN token has been used to create a new account it should not be usable again.

### Changes proposed in this pull request

Add a UserId property to TrnTokenModel. When an account is created from a TRN token, set this property to the ID of the created account.

Amend the authorize endpoint to validate that a TRN token’s UserId is null before proceeding with it.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
