### PR TITLE
Allow cross-origin requests to OIDC metadata endpoint

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
@@ -297,7 +297,6 @@ public class Program
                     model.Filters.Add(new NoCachePageFilter());
                 });
 
-
             options.Conventions.AddFolderApplicationModelConvention(
                 "/SignIn/Trn",
                 model =>
@@ -522,6 +521,15 @@ public class Program
 
         app.UseSerilogRequestLogging();
         app.UseMiddleware<Infrastructure.Middleware.RequestLogContextMiddleware>();
+
+        app.UseWhen(
+            context => context.Request.Path == new PathString("/.well-known/openid-configuration") && context.Request.Method == HttpMethods.Get,
+            a => a.UseCors(options =>
+            {
+                options.AllowAnyHeader();
+                options.AllowAnyMethod();
+                options.AllowAnyOrigin();
+            }));
 
         app.UseWhen(
             context => !context.Request.Path.StartsWithSegments("/api") && !context.Request.Path.StartsWithSegments("/connect"),


### PR DESCRIPTION
This is primarily to allow javascript-based OIDC clients to read the metadata.