### PR TITLE
Fix No Account page when no previous step is available

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/NoAccount.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/NoAccount.cshtml
@@ -4,9 +4,12 @@
     ViewBag.Title = "We could not find an account";
 }
 
-@section BeforeContent
+@if (Model.BackLink is not null)
 {
-    <govuk-back-link href="@Model.BackLink" />
+    @section BeforeContent
+    {
+        <govuk-back-link href="@Model.BackLink" />
+    }
 }
 
 <div class="govuk-panel app-panel--interruption" data-testid="landing-panel">

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/NoAccount.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/NoAccount.cshtml.cs
@@ -21,7 +21,7 @@ public class NoAccount : PageModel
         _applicationManager = applicationManager;
     }
 
-    public string BackLink => _journey.GetPreviousStepUrl(CurrentStep);
+    public string? BackLink => _journey.TryGetPreviousStepUrl(CurrentStep, out var backLink) ? backLink : null;
 
     public string? EmailAddress => _journey.AuthenticationState.EmailAddress;
 


### PR DESCRIPTION
We've got an error in Sentry caused by `GetPreviousStepUrl` throwing. This changes to `TryGetPreviousStepUrl` to conditionally render the back link only if we can go back.