### PR TITLE
Generate lower case TRN tokens

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Controllers/TrnTokensController.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Controllers/TrnTokensController.cs
@@ -23,11 +23,11 @@ public class TrnTokensController : ControllerBase
     [Authorize(AuthorizationPolicies.ApiTrnTokenWrite)]
     [HttpPost("")]
     [SwaggerOperation(summary: "Generates a TRN token")]
-    [ProducesResponseType(typeof(PostTrnTokenResponse), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(CreateTrnTokenResponse), StatusCodes.Status200OK)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status400BadRequest)]
     [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
     [MapError(10003, statusCode: StatusCodes.Status404NotFound)]
-    public async Task<IActionResult> PostTrnToken([FromBody] PostTrnTokensRequest request)
+    public async Task<IActionResult> CreateTrnToken([FromBody] CreateTrnTokenRequest request)
     {
         var response = await _mediator.Send(request);
         return Ok(response);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Handlers/CreateTrnTokenHandler.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Handlers/CreateTrnTokenHandler.cs
@@ -7,12 +7,12 @@ using TeacherIdentity.AuthServer.Models;
 
 namespace TeacherIdentity.AuthServer.Api.V1.Handlers;
 
-public class PostTrnTokensHandler : IRequestHandler<PostTrnTokensRequest, PostTrnTokenResponse>
+public class CreateTrnTokenHandler : IRequestHandler<CreateTrnTokenRequest, CreateTrnTokenResponse>
 {
     private readonly TeacherIdentityServerDbContext _dbContext;
     private readonly IClock _clock;
 
-    public PostTrnTokensHandler(
+    public CreateTrnTokenHandler(
         TeacherIdentityServerDbContext dbContext,
         IClock clock)
     {
@@ -20,14 +20,14 @@ public class PostTrnTokensHandler : IRequestHandler<PostTrnTokensRequest, PostTr
         _clock = clock;
     }
 
-    public async Task<PostTrnTokenResponse> Handle(PostTrnTokensRequest request, CancellationToken cancellationToken)
+    public async Task<CreateTrnTokenResponse> Handle(CreateTrnTokenRequest request, CancellationToken cancellationToken)
     {
         string trnToken;
         do
         {
             var buffer = new byte[64];
             RandomNumberGenerator.Fill(buffer);
-            trnToken = Convert.ToHexString(buffer);
+            trnToken = Convert.ToHexString(buffer).ToLower();
         } while (await _dbContext.TrnTokens.AnyAsync(t => t.TrnToken == trnToken, cancellationToken));
 
         var created = _clock.UtcNow;
@@ -44,7 +44,7 @@ public class PostTrnTokensHandler : IRequestHandler<PostTrnTokensRequest, PostTr
 
         await _dbContext.SaveChangesAsync(cancellationToken);
 
-        return new PostTrnTokenResponse()
+        return new CreateTrnTokenResponse()
         {
             Trn = request.Trn,
             Email = request.Email,

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Requests/CreateTrnTokenRequest.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Requests/CreateTrnTokenRequest.cs
@@ -3,7 +3,7 @@ using TeacherIdentity.AuthServer.Api.V1.Responses;
 
 namespace TeacherIdentity.AuthServer.Api.V1.Requests;
 
-public record PostTrnTokensRequest : IRequest<PostTrnTokenResponse>
+public record CreateTrnTokenRequest : IRequest<CreateTrnTokenResponse>
 {
     public required string Trn { get; init; }
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Responses/CreateTrnTokenResponse.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Responses/CreateTrnTokenResponse.cs
@@ -1,6 +1,6 @@
 namespace TeacherIdentity.AuthServer.Api.V1.Responses;
 
-public record PostTrnTokenResponse
+public record CreateTrnTokenResponse
 {
     public required string Trn { get; init; }
     public required string Email { get; set; }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Validators/CreateTrnTokenRequestValidator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Validators/CreateTrnTokenRequestValidator.cs
@@ -4,9 +4,9 @@ using TeacherIdentity.AuthServer.Api.Validation;
 
 namespace TeacherIdentity.AuthServer.Api.V1.Validators;
 
-public class PostTrnTokensRequestValidator : AbstractValidator<PostTrnTokensRequest>
+public class CreateTrnTokenRequestValidator : AbstractValidator<CreateTrnTokenRequest>
 {
-    public PostTrnTokensRequestValidator()
+    public CreateTrnTokenRequestValidator()
     {
         RuleFor(r => r.Trn)
             .Must(trn => trn is null || (trn.Length == 7 && trn.All(Char.IsAsciiDigit)))

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/TrnTokens/CreateTrnTokenTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Api/V1/TrnTokens/CreateTrnTokenTests.cs
@@ -3,9 +3,9 @@ using TeacherIdentity.AuthServer.Oidc;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Api.V1.TrnTokens;
 
-public class PostTrnTokenTests : TestBase
+public class CreateTrnTokenTests : TestBase
 {
-    public PostTrnTokenTests(HostFixture hostFixture)
+    public CreateTrnTokenTests(HostFixture hostFixture)
         : base(hostFixture)
     {
     }


### PR DESCRIPTION
Upper case TRN tokens look a bit shouty when appended to a URL so this changes them to be lower case.

I've tweaked the name of the request & response classes to align with the naming we use elsewhere too.