### PR TITLE
Add feature to change middle name from account page

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/ClaimsPrincipalExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/ClaimsPrincipalExtensions.cs
@@ -12,6 +12,9 @@ public static class ClaimsPrincipalExtensions
 
     public static string GetFirstName(this ClaimsPrincipal principal) => GetClaim(principal, Claims.GivenName);
 
+    public static string? GetMiddleName(this ClaimsPrincipal principal) =>
+        TryGetClaim(principal, Claims.MiddleName, out var middleName) ? middleName : null;
+
     public static string GetLastName(this ClaimsPrincipal principal) => GetClaim(principal, Claims.FamilyName);
 
     public static string[] GetStaffRoles(this ClaimsPrincipal principal) =>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -175,9 +175,10 @@ public abstract class IdentityLinkGenerator
         Page("/Account/Name/Index", authenticationJourneyRequired: false)
             .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo);
 
-    public string AccountNameConfirm(string firstName, string lastName, ClientRedirectInfo? clientRedirectInfo) =>
+    public string AccountNameConfirm(string firstName, string? middleName, string lastName, ClientRedirectInfo? clientRedirectInfo) =>
         Page("/Account/Name/Confirm", authenticationJourneyRequired: false)
             .SetQueryParam("firstName", firstName)
+            .SetQueryParam("middleName", middleName)
             .SetQueryParam("lastName", lastName)
             .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo)
             .AppendQueryStringSignature(QueryStringSignatureHelper);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml.cs
@@ -46,6 +46,7 @@ public class IndexModel : PageModel
             .Select(u => new
             {
                 u.FirstName,
+                u.MiddleName,
                 u.LastName,
                 u.DateOfBirth,
                 u.EmailAddress,
@@ -54,7 +55,7 @@ public class IndexModel : PageModel
             })
             .SingleAsync();
 
-        Name = $"{user.FirstName} {user.LastName}";
+        Name = string.IsNullOrEmpty(user.MiddleName) ? $"{user.FirstName} {user.LastName}" : $"{user.FirstName} {user.MiddleName} {user.LastName}";
         DateOfBirth = user.DateOfBirth;
         Email = user.EmailAddress;
         MobileNumber = user.MobileNumber;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Confirm.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Confirm.cshtml
@@ -2,6 +2,10 @@
 @model TeacherIdentity.AuthServer.Pages.Account.Name.Confirm
 @{
     ViewBag.Title = "Confirm change";
+
+    var fullName = string.IsNullOrEmpty(Model.MiddleName) ?
+        $"{Model.FirstName} {Model.LastName}" :
+        $"{Model.FirstName} {Model.MiddleName} {Model.LastName}";
 }
 
 @section BeforeContent
@@ -11,13 +15,13 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.AccountNameConfirm(Model.FirstName!, Model.LastName!, Model.ClientRedirectInfo)" method="post" asp-antiforgery="true">
+        <form action="@LinkGenerator.AccountNameConfirm(Model.FirstName!, Model.MiddleName, Model.LastName!, Model.ClientRedirectInfo)" method="post" asp-antiforgery="true">
             <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
 
             <govuk-summary-list>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value>@Model.FirstName @Model.LastName</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-value>@fullName</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
                         <govuk-summary-list-row-action href="@LinkGenerator.AccountName(Model.ClientRedirectInfo)" visually-hidden-text="name">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Confirm.cshtml.cs
@@ -30,6 +30,9 @@ public class Confirm : PageModel
     [FromQuery(Name = "firstName")]
     public string? FirstName { get; set; }
 
+    [FromQuery(Name = "middleName")]
+    public string? MiddleName { get; set; }
+
     [FromQuery(Name = "lastName")]
     public string? LastName { get; set; }
 
@@ -54,6 +57,11 @@ public class Confirm : PageModel
             changes |= UserUpdatedEventChanges.FirstName;
         }
 
+        if (user.MiddleName != MiddleName)
+        {
+            changes |= UserUpdatedEventChanges.MiddleName;
+        }
+
         if (user.LastName != LastName)
         {
             changes |= UserUpdatedEventChanges.LastName;
@@ -63,6 +71,7 @@ public class Confirm : PageModel
         {
             user.FirstName = FirstName!;
             user.LastName = LastName!;
+            user.MiddleName = MiddleName;
             user.Updated = _clock.UtcNow;
 
             _dbContext.AddEvent(new UserUpdatedEvent()

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Index.cshtml
@@ -17,6 +17,10 @@
                 <govuk-input-label class="govuk-label--s" />
             </govuk-input>
 
+            <govuk-input asp-for="MiddleName" spellcheck="false" autocomplete="additional-name">
+                <govuk-input-label class="govuk-label--s" />
+            </govuk-input>
+
             <govuk-input asp-for="LastName" spellcheck="false" autocomplete="family-name">
                 <govuk-input-label class="govuk-label--s"/>
             </govuk-input>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Index.cshtml.cs
@@ -23,6 +23,10 @@ public class Name : PageModel
     [StringLength(200, ErrorMessage = "First name must be 200 characters or less")]
     public string? FirstName { get; set; }
 
+    [Display(Name = "Middle name")]
+    [StringLength(200, ErrorMessage = "Middle name must be 200 characters or less")]
+    public string? MiddleName { get; set; }
+
     [Display(Name = "Last name", Description = "Or family names")]
     [Required(ErrorMessage = "Enter your last name")]
     [StringLength(200, ErrorMessage = "Last name must be 200 characters or less")]
@@ -31,6 +35,7 @@ public class Name : PageModel
     public void OnGet()
     {
         FirstName = User.GetFirstName();
+        MiddleName = User.GetMiddleName();
         LastName = User.GetLastName();
     }
 
@@ -41,6 +46,6 @@ public class Name : PageModel
             return this.PageWithErrors();
         }
 
-        return Redirect(_linkGenerator.AccountNameConfirm(FirstName!, LastName!, ClientRedirectInfo));
+        return Redirect(_linkGenerator.AccountNameConfirm(FirstName!, MiddleName, LastName!, ClientRedirectInfo));
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Name.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Name.cshtml
@@ -17,7 +17,7 @@
                 <govuk-input-label class="govuk-label--s" />
             </govuk-input>
 
-            <govuk-input asp-for="MiddleName" spellcheck="false" autocomplete="given-name">
+            <govuk-input asp-for="MiddleName" spellcheck="false" autocomplete="additional-name">
                 <govuk-input-label class="govuk-label--s" />
             </govuk-input>
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/IndexTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/IndexTests.cs
@@ -89,7 +89,7 @@ public class IndexTests : TestBase
         // Assert
         var doc = await response.GetDocument();
 
-        Assert.Equal($"{user.FirstName} {user.LastName}", doc.GetSummaryListValueForKey("Name"));
+        Assert.Equal($"{user.FirstName} {user.MiddleName} {user.LastName}", doc.GetSummaryListValueForKey("Name"));
         Assert.Equal($"{user.DateOfBirth?.ToString(Constants.DateFormat)}", doc.GetSummaryListValueForKey("Date of birth"));
         Assert.Equal(user.EmailAddress, doc.GetSummaryListValueForKey("Email"));
         Assert.Equal(user.MobileNumber, doc.GetSummaryListValueForKey("Mobile number"));

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Name/NameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Name/NameTests.cs
@@ -66,6 +66,27 @@ public class NameTests : TestBase
     }
 
     [Fact]
+    public async Task Post_TooLongMiddleName_ReturnsError()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/name")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "FirstName", Faker.Name.First() },
+                { "MiddleName", new string('a', 201) },
+                { "LastName", Faker.Name.Last() },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "MiddleName", "Middle name must be 200 characters or less");
+    }
+
+    [Fact]
     public async Task Post_TooLongLastName_ReturnsError()
     {
         // Arrange
@@ -94,6 +115,7 @@ public class NameTests : TestBase
             Content = new FormUrlEncodedContentBuilder()
             {
                 { "FirstName", Faker.Name.First() },
+                { "MiddleName", Faker.Name.Middle() },
                 { "LastName", Faker.Name.Last() },
             }
         };
@@ -130,7 +152,7 @@ public class NameTests : TestBase
     }
 
     [Fact]
-    public async Task Get_Prepopulates_FirstandLastName()
+    public async Task Get_Prepopulates_FirstMiddleAndLastName()
     {
         // Arrange
         var request = new HttpRequestMessage(HttpMethod.Get, $"/account/name");
@@ -142,6 +164,7 @@ public class NameTests : TestBase
         var doc = await response.GetDocument();
 
         Assert.True(doc.GetElementById("FirstName")?.GetAttribute("value")?.Length > 0);
+        Assert.True(doc.GetElementById("MiddleName")?.GetAttribute("value")?.Length > 0);
         Assert.True(doc.GetElementById("LastName")?.GetAttribute("value")?.Length > 0);
     }
 }


### PR DESCRIPTION
### Context

We’ve added the MiddleName field to User, now we need a way for existing users to change it.

### Changes proposed in this pull request

Add an optional MiddleName field to /account/name with label ‘Enter your middle name’. If the middle name is over 200 characters, show an error ‘Middle name must be 200 characters or less’.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
