### PR TITLE
Add a preferred name page to the regiter journey

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/DataAnnotationsExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/DataAnnotationsExtensions.cs
@@ -168,3 +168,23 @@ public class NationalInsuranceNumber : ValidationAttribute
         return value is string str && NationalInsuranceNumberHelper.IsValid(str);
     }
 }
+
+[AttributeUsage(AttributeTargets.Property | AttributeTargets.Field | AttributeTargets.Parameter)]
+public class StringLengthIfTrueAttribute : StringLengthAttribute
+{
+    private string PropertyName { get; }
+
+    public StringLengthIfTrueAttribute(string propertyName, int maximumLength) : base(maximumLength)
+    {
+        PropertyName = propertyName;
+    }
+
+    protected override ValidationResult IsValid(object? value, ValidationContext context)
+    {
+        object instance = context.ObjectInstance;
+        Type type = instance.GetType();
+
+        bool.TryParse(type.GetProperty(PropertyName)?.GetValue(instance)?.ToString(), out bool isRequired);
+        return isRequired && !base.IsValid(value) ? new ValidationResult(ErrorMessage) : ValidationResult.Success!;
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -108,6 +108,8 @@ public abstract class IdentityLinkGenerator
 
     public string RegisterName() => Page("/SignIn/Register/Name");
 
+    public string RegisterPreferredName() => Page("/SignIn/Register/PreferredNamePage");
+
     public string RegisterDateOfBirth() => Page("/SignIn/Register/DateOfBirthPage");
 
     public string RegisterAccountExists() => Page("/SignIn/Register/AccountExists");

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourney.cs
@@ -43,6 +43,7 @@ public class CoreSignInJourney : SignInJourney
             Steps.ResendPhoneConfirmation => AuthenticationState is { MobileNumberSet: true, MobileNumberVerified: false },
             Steps.PhoneExists => AuthenticationState.IsComplete,
             Steps.Name => AuthenticationState.ContactDetailsVerified,
+            Steps.PreferredName => AuthenticationState is { NameSet: true, ContactDetailsVerified: true },
             Steps.DateOfBirth => AuthenticationState is { PreferredNameSet: true, ContactDetailsVerified: true },
             Steps.AccountExists => AuthenticationState.ExistingAccountFound,
             Steps.ExistingAccountEmailConfirmation => AuthenticationState is { ExistingAccountFound: true, ExistingAccountChosen: true },
@@ -89,7 +90,9 @@ public class CoreSignInJourney : SignInJourney
             (Steps.PhoneConfirmation, { IsComplete: false }) => shouldCheckAnswers ? Steps.CheckAnswers : Steps.Name,
             (Steps.ResendPhoneConfirmation, _) => Steps.PhoneConfirmation,
             (Steps.Name, { ExistingAccountFound: true }) => Steps.AccountExists,
-            (Steps.Name, { ExistingAccountFound: false }) => shouldCheckAnswers ? Steps.CheckAnswers : Steps.DateOfBirth,
+            (Steps.Name, { ExistingAccountFound: false }) => shouldCheckAnswers ? Steps.CheckAnswers : Steps.PreferredName,
+            (Steps.PreferredName, { ExistingAccountFound: true }) => Steps.AccountExists,
+            (Steps.PreferredName, { ExistingAccountFound: false }) => shouldCheckAnswers ? Steps.CheckAnswers : Steps.DateOfBirth,
             (Steps.DateOfBirth, { ExistingAccountFound: true }) => Steps.AccountExists,
             (Steps.DateOfBirth, { ExistingAccountFound: false }) => Steps.CheckAnswers,
             (Steps.AccountExists, { ExistingAccountChosen: true }) => Steps.ExistingAccountEmailConfirmation,
@@ -122,7 +125,8 @@ public class CoreSignInJourney : SignInJourney
         (Steps.PhoneExists, { MobileNumberVerified: false }) => Steps.PhoneConfirmation,
         (Steps.Name, { MobileNumberVerified: true }) => Steps.Phone,
         (Steps.Name, { MobileNumberVerified: false }) => Steps.PhoneConfirmation,
-        (Steps.DateOfBirth, _) => Steps.Name,
+        (Steps.PreferredName, _) => Steps.Name,
+        (Steps.DateOfBirth, _) => Steps.PreferredName,
         (Steps.AccountExists, _) => Steps.DateOfBirth,
         (Steps.ExistingAccountEmailConfirmation, _) => Steps.AccountExists,
         (Steps.ResendExistingAccountEmail, _) => Steps.ExistingAccountEmailConfirmation,
@@ -152,6 +156,7 @@ public class CoreSignInJourney : SignInJourney
         Steps.ResendPhoneConfirmation => LinkGenerator.RegisterResendPhoneConfirmation(),
         Steps.PhoneExists => LinkGenerator.RegisterPhoneExists(),
         Steps.Name => LinkGenerator.RegisterName(),
+        Steps.PreferredName => LinkGenerator.RegisterPreferredName(),
         Steps.DateOfBirth => LinkGenerator.RegisterDateOfBirth(),
         Steps.AccountExists => LinkGenerator.RegisterAccountExists(),
         Steps.ExistingAccountEmailConfirmation => LinkGenerator.RegisterExistingAccountEmailConfirmation(),
@@ -173,8 +178,9 @@ public class CoreSignInJourney : SignInJourney
             HasValidEmail: true,
             MobileNumberSet: true,
             MobileNumberVerified: true,
+            NameSet: true,
             PreferredNameSet: true,
-            DateOfBirthSet: true
+            DateOfBirthSet: true,
         };
 
     public new static class Steps
@@ -190,6 +196,7 @@ public class CoreSignInJourney : SignInJourney
         public const string ResendPhoneConfirmation = $"{nameof(CoreSignInJourney)}.{nameof(ResendPhoneConfirmation)}";
         public const string PhoneExists = $"{nameof(CoreSignInJourney)}.{nameof(PhoneExists)}";
         public const string Name = $"{nameof(CoreSignInJourney)}.{nameof(Name)}";
+        public const string PreferredName = $"{nameof(CoreSignInJourney)}.{nameof(PreferredName)}";
         public const string DateOfBirth = $"{nameof(CoreSignInJourney)}.{nameof(DateOfBirth)}";
         public const string AccountExists = $"{nameof(CoreSignInJourney)}.{nameof(AccountExists)}";
         public const string ExistingAccountEmailConfirmation = $"{nameof(CoreSignInJourney)}.{nameof(ExistingAccountEmailConfirmation)}";

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
@@ -47,7 +47,7 @@ public class CoreSignInJourneyWithTrnLookup : CoreSignInJourney
                         u => u.CreateTrnResolutionZendeskTicket(
                             user.UserId,
                             AuthenticationState.GetOfficialName(),
-                            AuthenticationState.GetPreferredName(),
+                            AuthenticationState.GetName(),
                             AuthenticationState.EmailAddress,
                             AuthenticationState.GetPreviousOfficialName(),
                             AuthenticationState.DateOfBirth,
@@ -196,7 +196,7 @@ public class CoreSignInJourneyWithTrnLookup : CoreSignInJourney
         AuthenticationState.EmailAddressVerified &&
         AuthenticationState.MobileNumberSet &&
         AuthenticationState.MobileNumberVerified &&
-        AuthenticationState.PreferredNameSet &&
+        AuthenticationState.NameSet &&
         AuthenticationState.DateOfBirthSet &&
         AuthenticationState.HasNationalInsuranceNumberSet &&
         (AuthenticationState.NationalInsuranceNumberSet || AuthenticationState.HasNationalInsuranceNumber == false) &&

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CreateUserHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CreateUserHelper.cs
@@ -42,6 +42,7 @@ public class CreateUserHelper
             FirstName = authenticationState.FirstName!,
             MiddleName = authenticationState.MiddleName,
             LastName = authenticationState.LastName!,
+            PreferredName = authenticationState.PreferredName,
             Updated = _clock.UtcNow,
             UserId = userId,
             UserType = UserType.Default,
@@ -63,7 +64,7 @@ public class CreateUserHelper
         return user;
     }
 
-    public async Task<User> CreateUserWithTrnLookup(AuthenticationState authenticationState, bool populatePreferredName = false)
+    public async Task<User> CreateUserWithTrnLookup(AuthenticationState authenticationState)
     {
         var userId = Guid.NewGuid();
 
@@ -77,6 +78,7 @@ public class CreateUserHelper
             FirstName = authenticationState.FirstName ?? authenticationState.OfficialFirstName!,
             MiddleName = authenticationState.MiddleName,
             LastName = authenticationState.LastName ?? authenticationState.OfficialLastName!,
+            PreferredName = authenticationState.PreferredName ?? authenticationState.GetOfficialName(),
             Updated = _clock.UtcNow,
             UserId = userId,
             UserType = UserType.Default,
@@ -86,11 +88,6 @@ public class CreateUserHelper
             RegisteredWithClientId = authenticationState.OAuthState?.ClientId,
             TrnLookupStatus = authenticationState.TrnLookupStatus
         };
-
-        if (populatePreferredName)
-        {
-            user.PreferredName = authenticationState.GetPreferredName();
-        }
 
         _dbContext.Users.Add(user);
 
@@ -124,6 +121,7 @@ public class CreateUserHelper
             MobileNumber = authenticationState.MobileNumber,
             FirstName = authenticationState.FirstName ?? authenticationState.OfficialFirstName!,
             LastName = authenticationState.LastName ?? authenticationState.OfficialLastName!,
+            PreferredName = authenticationState.PreferredName,
             Updated = _clock.UtcNow,
             UserId = userId,
             UserType = UserType.Default,

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/LegacyTrnJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/LegacyTrnJourney.cs
@@ -26,7 +26,7 @@ public class LegacyTrnJourney : SignInJourney
     {
         try
         {
-            var user = await CreateUserHelper.CreateUserWithTrnLookup(AuthenticationState, useOfficialNameDefault: true);
+            var user = await CreateUserHelper.CreateUserWithTrnLookup(AuthenticationState);
 
             AuthenticationState.OnTrnLookupCompletedAndUserRegistered(user);
             await AuthenticationState.SignIn(HttpContext);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/LegacyTrnJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/LegacyTrnJourney.cs
@@ -26,7 +26,7 @@ public class LegacyTrnJourney : SignInJourney
     {
         try
         {
-            var user = await CreateUserHelper.CreateUserWithTrnLookup(AuthenticationState, populatePreferredName: true);
+            var user = await CreateUserHelper.CreateUserWithTrnLookup(AuthenticationState, useOfficialNameDefault: true);
 
             AuthenticationState.OnTrnLookupCompletedAndUserRegistered(user);
             await AuthenticationState.SignIn(HttpContext);
@@ -152,7 +152,7 @@ public class LegacyTrnJourney : SignInJourney
                 Steps.HasTrn => AuthenticationState.EmailAddressVerified,
                 Steps.OfficialName => AuthenticationState.HasTrnSet,
                 Steps.PreferredName => AuthenticationState.OfficialNameSet,
-                Steps.DateOfBirth => AuthenticationState.PreferredNameSet,
+                Steps.DateOfBirth => AuthenticationState.NameSet,
                 Steps.HasNationalInsuranceNumber => AuthenticationState.DateOfBirthSet,
                 Steps.NationalInsuranceNumber =>
                     AuthenticationState.HasNationalInsuranceNumberSet && AuthenticationState.HasNationalInsuranceNumber == true,
@@ -204,7 +204,7 @@ public class LegacyTrnJourney : SignInJourney
             AuthenticationState.EmailAddressVerified &&
             AuthenticationState.HasTrnSet &&
             AuthenticationState.OfficialNameSet &&
-            AuthenticationState.PreferredNameSet &&
+            AuthenticationState.NameSet &&
             AuthenticationState.DateOfBirthSet &&
             AuthenticationState.HasNationalInsuranceNumberSet &&
             (AuthenticationState.NationalInsuranceNumberSet || AuthenticationState.HasNationalInsuranceNumber == false) &&

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/CheckAnswers.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/CheckAnswers.cshtml.cs
@@ -22,7 +22,7 @@ public class CheckAnswers : PageModel
     public bool? RequiresTrnLookup => _journey.AuthenticationState.UserRequirements.RequiresTrnLookup();
     public string? EmailAddress => _journey.AuthenticationState.EmailAddress;
     public string? MobilePhoneNumber => _journey.AuthenticationState.MobileNumber;
-    public string? FullName => _journey.AuthenticationState.GetPreferredName();
+    public string? FullName => _journey.AuthenticationState.GetName();
     public DateOnly? DateOfBirth => _journey.AuthenticationState.DateOfBirth;
     public bool? HasNationalInsuranceNumberSet => _journey.AuthenticationState.HasNationalInsuranceNumberSet;
     public string? NationalInsuranceNumber => _journey.AuthenticationState.NationalInsuranceNumber;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/PreferredNamePage.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/PreferredNamePage.cshtml
@@ -1,0 +1,37 @@
+@page "/sign-in/register/preferred-name"
+@model TeacherIdentity.AuthServer.Pages.SignIn.Register.PreferredNamePage
+@{
+    ViewBag.Title = "What is your preferred name?";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@Model.BackLink" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.RegisterPreferredName()" method="post" asp-antiforgery="true">
+            <h1 class="govuk-heading-xl">@ViewBag.Title</h1>
+
+            <p>For example, Mike Smith instead of Michael Smith.</p>
+            <p>We’ll use your preferred name in correspondence. We use official names on teaching certificates.</p>
+
+            <govuk-radios asp-for="HasPreferredName">
+                <govuk-radios-fieldset>
+                    <govuk-radios-item value="@false">Use <strong>@Html.ShyEmail(Model.ExistingName)</strong></govuk-radios-item>
+                    <govuk-radios-item value="@true">Other
+                        <govuk-radios-item-conditional>
+                            <govuk-input asp-for="PreferredName" spellcheck="false">
+                                <govuk-input-label class="govuk-label--s"/>
+                            </govuk-input>
+                        </govuk-radios-item-conditional>
+                    </govuk-radios-item>
+
+                </govuk-radios-fieldset>
+            </govuk-radios>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>
+

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/PreferredNamePage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/PreferredNamePage.cshtml.cs
@@ -1,0 +1,63 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeacherIdentity.AuthServer.Journeys;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
+
+[CheckJourneyType(typeof(CoreSignInJourney), typeof(CoreSignInJourneyWithTrnLookup), typeof(TrnTokenSignInJourney))]
+[CheckCanAccessStep(CurrentStep)]
+public class PreferredNamePage : PageModel
+{
+    private const string CurrentStep = CoreSignInJourney.Steps.PreferredName;
+
+    private SignInJourney _journey;
+
+    public PreferredNamePage(SignInJourney journey)
+    {
+        _journey = journey;
+    }
+
+    public string BackLink => _journey.GetPreviousStepUrl(CurrentStep);
+
+    public string ExistingName => _journey.AuthenticationState.GetName()!;
+
+    [BindProperty]
+    [Display(Name = "Use preferred name?")]
+    [Required(ErrorMessage = "Select which name to use")]
+    public bool? HasPreferredName { get; set; }
+
+    [BindProperty]
+    [Display(Name = "Your preferred name")]
+    [RequiredIfTrue(nameof(HasPreferredName), ErrorMessage = "Enter your preferred name")]
+    [StringLengthIfTrue(nameof(HasPreferredName), 200, ErrorMessage = "Preferred name must be 200 characters or less")]
+    public string? PreferredName { get; set; }
+
+    public void OnGet()
+    {
+        SetDefaultInputValues();
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        HttpContext.GetAuthenticationState().OnPreferredNameSet(PreferredName ?? ExistingName);
+
+        return await _journey.Advance(CurrentStep);
+    }
+
+    private void SetDefaultInputValues()
+    {
+        var authState = _journey.AuthenticationState;
+
+        if (!string.IsNullOrEmpty(authState.PreferredName) && authState.PreferredName != authState.GetName())
+        {
+            HasPreferredName = true;
+            PreferredName = authState.PreferredName;
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/CheckAnswers.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/CheckAnswers.cshtml.cs
@@ -21,7 +21,7 @@ public class CheckAnswers : PageModel
     public string? EmailAddress => _journey.AuthenticationState.EmailAddress;
     public string? OfficialName => _journey.AuthenticationState.GetOfficialName();
     public string? PreviousOfficialName => _journey.AuthenticationState.GetPreviousOfficialName();
-    public string? PreferredName => _journey.AuthenticationState.GetPreferredName();
+    public string? PreferredName => _journey.AuthenticationState.GetName();
     public DateOnly? DateOfBirth => _journey.AuthenticationState.DateOfBirth;
     public bool? HaveNationalInsuranceNumber => _journey.AuthenticationState.HasNationalInsuranceNumber;
     public string? NationalInsuranceNumber => _journey.AuthenticationState.NationalInsuranceNumber;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/NoMatch.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/NoMatch.cshtml.cs
@@ -24,7 +24,7 @@ public class NoMatch : PageModel
     public string? EmailAddress => _journey.AuthenticationState.EmailAddress;
     public string? OfficialName => _journey.AuthenticationState.GetOfficialName();
     public string? PreviousOfficialName => _journey.AuthenticationState.GetPreviousOfficialName();
-    public string? PreferredName => _journey.AuthenticationState.GetPreferredName();
+    public string? PreferredName => _journey.AuthenticationState.GetName();
     public DateOnly? DateOfBirth => _journey.AuthenticationState.DateOfBirth;
     public bool? HaveNationalInsuranceNumber => _journey.AuthenticationState.HasNationalInsuranceNumber;
     public string? NationalInsuranceNumber => _journey.AuthenticationState.NationalInsuranceNumber;

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
@@ -353,6 +353,24 @@ public static class PageExtensions
         await page.ClickContinueButton();
     }
 
+    public static async Task SubmitRegisterPreferredNamePage(this IPage page, string? preferredName = null)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/register/preferred-name");
+
+        if (string.IsNullOrEmpty(preferredName))
+        {
+            await page.ClickAsync("label:text-is('Use')"); // Use existing name
+        }
+        else
+        {
+            await page.ClickAsync("label:text-is('Other')"); // Use other name
+            await page.FillAsync("label:text-is('Your preferred name')", preferredName);
+        }
+
+        await page.FocusAsync("button:text-is('Continue')");
+        await page.ClickContinueButton();
+    }
+
     public static async Task SubmitDateOfBirthPage(this IPage page, DateOnly dateOfBirth)
     {
         await page.WaitForUrlPathAsync("/sign-in/register/date-of-birth");

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Register.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Register.cs
@@ -42,6 +42,8 @@ public class Register : IClassFixture<HostFixture>
 
         await page.SubmitRegisterNamePage(firstName, lastName);
 
+        await page.SubmitRegisterPreferredNamePage();
+
         await page.SubmitDateOfBirthPage(dateOfBirth);
 
         await page.SubmitCheckAnswersPage();
@@ -121,6 +123,8 @@ public class Register : IClassFixture<HostFixture>
         await page.SubmitRegisterPhoneConfirmationPage();
 
         await page.SubmitRegisterNamePage(firstName, lastName);
+
+        await page.SubmitRegisterPreferredNamePage();
 
         await page.SubmitDateOfBirthPage(dateOfBirth);
 
@@ -205,6 +209,8 @@ public class Register : IClassFixture<HostFixture>
 
         await page.SubmitRegisterNamePage(firstName, lastName);
 
+        await page.SubmitRegisterPreferredNamePage();
+
         await page.SubmitDateOfBirthPage(dateOfBirth);
 
         await page.SubmitCheckAnswersPage();
@@ -278,6 +284,8 @@ public class Register : IClassFixture<HostFixture>
         await page.SubmitRegisterPhoneConfirmationPage();
 
         await page.SubmitRegisterNamePage(firstName, lastName);
+
+        await page.SubmitRegisterPreferredNamePage();
 
         await page.SubmitDateOfBirthPage(dateOfBirth);
 
@@ -388,6 +396,8 @@ public class Register : IClassFixture<HostFixture>
 
         await page.SubmitRegisterNamePage(existingUser.FirstName, existingUser.LastName);
 
+        await page.SubmitRegisterPreferredNamePage();
+
         await page.SubmitDateOfBirthPage(existingUser.DateOfBirth!.Value);
 
         await page.SubmitAccountExistsPage(isUsersAccount: true);
@@ -431,6 +441,8 @@ public class Register : IClassFixture<HostFixture>
         await page.SubmitRegisterPhoneConfirmationPage();
 
         await page.SubmitRegisterNamePage(existingUser.FirstName, existingUser.LastName);
+
+        await page.SubmitRegisterPreferredNamePage();
 
         await page.SubmitDateOfBirthPage(existingUser.DateOfBirth!.Value);
 
@@ -494,6 +506,8 @@ public class Register : IClassFixture<HostFixture>
         await page.SubmitRegisterPhoneConfirmationPage();
 
         await page.SubmitRegisterNamePage(firstName, lastName);
+
+        await page.SubmitRegisterPreferredNamePage();
 
         await page.SubmitDateOfBirthPage(dateOfBirth);
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/TrnTokenSignInJourney.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/TrnTokenSignInJourney.cs
@@ -25,6 +25,7 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
         var firstName = Faker.Name.First();
         var middleName = Faker.Name.Middle();
         var lastName = Faker.Name.Last();
+        var preferredName = Faker.Name.FullName();
         var dateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
         var trn = _hostFixture.TestData.GenerateTrn();
 
@@ -53,6 +54,8 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
         await page.SubmitRegisterPhonePage(mobileNumber);
 
         await page.SubmitRegisterPhoneConfirmationPage();
+
+        await page.SubmitRegisterPreferredNamePage();
 
         await page.SubmitTrnTokenCheckAnswersPage();
 
@@ -99,6 +102,8 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
         await page.SubmitRegisterPhonePage(mobileNumber);
 
         await page.SubmitRegisterPhoneConfirmationPage();
+
+        await page.SubmitRegisterPreferredNamePage();
 
         await page.ClickChangeLinkTrnTokenCheckAnswersPage("trn-token-email-change-link");
 
@@ -216,6 +221,8 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
         await page.SubmitRegisterPhonePage(differentMobileNumber);
 
         await page.SubmitRegisterPhoneConfirmationPage();
+
+        await page.SubmitRegisterPreferredNamePage();
 
         await page.SubmitTrnTokenCheckAnswersPage();
 
@@ -499,6 +506,8 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
 
         await page.SubmitRegisterPhoneConfirmationPage();
 
+        await page.SubmitRegisterPreferredNamePage();
+
         await page.SubmitTrnTokenCheckAnswersPage();
 
         await page.SubmitCompletePageForNewUser();
@@ -653,6 +662,8 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
 
         await page.SubmitRegisterPhoneConfirmationPage();
 
+        await page.SubmitRegisterPreferredNamePage();
+
         await page.ClickChangeLinkTrnTokenCheckAnswersPage("trn-token-email-change-link");
 
         await page.SubmitRegisterEmailPage(newInstitutionEmail);
@@ -732,6 +743,8 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
         await page.SubmitRegisterPhoneConfirmationPage();
 
         await page.SubmitRegisterNamePage(firstName, lastName);
+
+        await page.SubmitRegisterPreferredNamePage();
 
         await page.SubmitDateOfBirthPage(dateOfBirth);
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/AuthenticationStateHelper.cs
@@ -160,8 +160,8 @@ public sealed class AuthenticationStateHelper
                 s.OnNameSet(firstName ?? Faker.Name.First(), middleName ?? Faker.Name.Last(), lastName ?? Faker.Name.Last());
             };
 
-        public Func<AuthenticationState, Task> RegisterDateOfBirthSet(
-            DateOnly? dateOfBirth = null,
+        public Func<AuthenticationState, Task> RegisterPreferredNameSet(
+            string? preferredName = null,
             string? firstName = null,
             string? middleName = null,
             string? lastName = null,
@@ -170,12 +170,31 @@ public sealed class AuthenticationStateHelper
             User? user = null) =>
             async s =>
             {
+                firstName ??= Faker.Name.First();
+                lastName ??= Faker.Name.Last();
+
                 await RegisterNameSet(firstName, middleName, lastName, mobileNumber, email, user)(s);
+                s.OnPreferredNameSet(preferredName ?? $"{firstName} {lastName}");
+            };
+
+        public Func<AuthenticationState, Task> RegisterDateOfBirthSet(
+            DateOnly? dateOfBirth = null,
+            string? preferredName = null,
+            string? firstName = null,
+            string? middleName = null,
+            string? lastName = null,
+            string? mobileNumber = null,
+            string? email = null,
+            User? user = null) =>
+            async s =>
+            {
+                await RegisterPreferredNameSet(preferredName, firstName, middleName, lastName, mobileNumber, email, user)(s);
                 s.OnDateOfBirthSet(dateOfBirth ?? DateOnly.FromDateTime(Faker.Identification.DateOfBirth()));
             };
 
         public Func<AuthenticationState, Task> RegisterHasNiNumberSet(
             DateOnly? dateOfBirth = null,
+            string? preferredName = null,
             string? firstName = null,
             string? middleName = null,
             string? lastName = null,
@@ -184,12 +203,13 @@ public sealed class AuthenticationStateHelper
             User? user = null) =>
             async s =>
             {
-                await RegisterDateOfBirthSet(dateOfBirth, firstName, middleName, lastName, mobileNumber, email, user)(s);
+                await RegisterDateOfBirthSet(dateOfBirth, preferredName, firstName, middleName, lastName, mobileNumber, email, user)(s);
                 s.OnHasNationalInsuranceNumberSet(true);
             };
 
         public Func<AuthenticationState, Task> RegisterNiNumberSet(
             DateOnly? dateOfBirth = null,
+            string? preferredName = null,
             string? firstName = null,
             string? middleName = null,
             string? lastName = null,
@@ -198,12 +218,13 @@ public sealed class AuthenticationStateHelper
             User? user = null) =>
             async s =>
             {
-                await RegisterHasNiNumberSet(dateOfBirth, firstName, middleName, lastName, mobileNumber, email, user)(s);
+                await RegisterHasNiNumberSet(dateOfBirth, preferredName, firstName, middleName, lastName, mobileNumber, email, user)(s);
                 s.OnNationalInsuranceNumberSet(Faker.Identification.UkNationalInsuranceNumber());
             };
 
         public Func<AuthenticationState, Task> RegisterHasTrnSet(
             DateOnly? dateOfBirth = null,
+            string? preferredName = null,
             string? firstName = null,
             string? middleName = null,
             string? lastName = null,
@@ -212,12 +233,13 @@ public sealed class AuthenticationStateHelper
             User? user = null) =>
             async s =>
             {
-                await RegisterNiNumberSet(dateOfBirth, firstName, middleName, lastName, mobileNumber, email, user)(s);
+                await RegisterNiNumberSet(dateOfBirth, preferredName, firstName, middleName, lastName, mobileNumber, email, user)(s);
                 s.OnHasTrnSet(true);
             };
 
         public Func<AuthenticationState, Task> RegisterTrnSet(
             DateOnly? dateOfBirth = null,
+            string? preferredName = null,
             string? firstName = null,
             string? middleName = null,
             string? lastName = null,
@@ -226,12 +248,13 @@ public sealed class AuthenticationStateHelper
             User? user = null) =>
             async s =>
             {
-                await RegisterHasTrnSet(dateOfBirth, firstName, middleName, lastName, mobileNumber, email, user)(s);
+                await RegisterHasTrnSet(dateOfBirth, preferredName, firstName, middleName, lastName, mobileNumber, email, user)(s);
                 s.OnTrnSet(TestData.GenerateTrn());
             };
 
         public Func<AuthenticationState, Task> RegisterHasQtsSet(
             DateOnly? dateOfBirth = null,
+            string? preferredName = null,
             string? firstName = null,
             string? middleName = null,
             string? lastName = null,
@@ -241,12 +264,13 @@ public sealed class AuthenticationStateHelper
             bool? awardedQts = null) =>
             async s =>
             {
-                await RegisterTrnSet(dateOfBirth, firstName, middleName, lastName, mobileNumber, email, user)(s);
+                await RegisterTrnSet(dateOfBirth, preferredName, firstName, middleName, lastName, mobileNumber, email, user)(s);
                 s.OnAwardedQtsSet(awardedQts == true);
             };
 
         public Func<AuthenticationState, Task> RegisterIttProviderSet(
             DateOnly? dateOfBirth = null,
+            string? preferredName = null,
             string? firstName = null,
             string? middleName = null,
             string? lastName = null,
@@ -257,13 +281,14 @@ public sealed class AuthenticationStateHelper
             string? ittProviderName = "provider") =>
             async s =>
             {
-                await RegisterHasQtsSet(dateOfBirth, firstName, middleName, lastName, mobileNumber, email, user, awardedQts)(s);
+                await RegisterHasQtsSet(dateOfBirth, preferredName, firstName, middleName, lastName, mobileNumber, email, user, awardedQts)(s);
                 s.OnHasIttProviderSet(hasIttProvider: ittProviderName is not null, ittProviderName);
             };
 
         public Func<AuthenticationState, Task> RegisterExistingUserAccountMatch(
             User? existingUserAccount = null,
             DateOnly? dateOfBirth = null,
+            string? preferredName = null,
             string? firstName = null,
             string? middleName = null,
             string? lastName = null,
@@ -271,13 +296,14 @@ public sealed class AuthenticationStateHelper
             string? email = null) =>
             async s =>
             {
-                await RegisterDateOfBirthSet(dateOfBirth, firstName, middleName, lastName, mobileNumber, email)(s);
+                await RegisterDateOfBirthSet(dateOfBirth, preferredName, firstName, middleName, lastName, mobileNumber, email)(s);
                 s.OnExistingAccountSearch(existingUserAccount ?? await TestData.CreateUser());
             };
 
         public Func<AuthenticationState, Task> RegisterExistingUserAccountChosen(
             User? existingUserAccount = null,
             DateOnly? dateOfBirth = null,
+            string? preferredName = null,
             string? firstName = null,
             string? middleName = null,
             string? lastName = null,
@@ -285,7 +311,7 @@ public sealed class AuthenticationStateHelper
             string? email = null) =>
             async s =>
             {
-                await RegisterExistingUserAccountMatch(existingUserAccount, dateOfBirth, firstName, middleName, lastName, mobileNumber, email)(s);
+                await RegisterExistingUserAccountMatch(existingUserAccount, dateOfBirth, preferredName, firstName, middleName, lastName, mobileNumber, email)(s);
                 s.OnExistingAccountChosen(true);
             };
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/CheckAnswersTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/CheckAnswersTests.cs
@@ -69,7 +69,7 @@ public class CheckAnswersTests : TestBase
         var doc = await response.GetDocument();
         Assert.Equal(authState.EmailAddress, doc.GetSummaryListValueForKey("Email"));
         Assert.Equal(authState.MobileNumber, doc.GetSummaryListValueForKey("Mobile phone"));
-        Assert.Equal($"{authState.FirstName} {authState.LastName}", doc.GetSummaryListValueForKey("Name"));
+        Assert.Equal($"{authState.GetName()}", doc.GetSummaryListValueForKey("Name"));
         Assert.Equal(authState.DateOfBirth?.ToString(Constants.DateFormat), doc.GetSummaryListValueForKey("Date of birth"));
 
         var hasNiNumberSet = registerJourneyStage > RegisterJourneyPage.HasNiNumber;

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/DateOfBirthPageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/DateOfBirthPageTests.cs
@@ -35,9 +35,9 @@ public class DateOfBirthPageTests : TestBase
     }
 
     [Fact]
-    public async Task Get_NameNotSet_RedirectsToNamePage()
+    public async Task Get_NameNotSet_RedirectsToPreferredNamePage()
     {
-        await GivenAuthenticationState_RedirectsTo(_previousPageAuthenticationState(), additionalScopes: null, trnRequirementType: null, HttpMethod.Get, "/sign-in/register/date-of-birth", "/sign-in/register/name");
+        await GivenAuthenticationState_RedirectsTo(_previousPageAuthenticationState(), additionalScopes: null, trnRequirementType: null, HttpMethod.Get, "/sign-in/register/date-of-birth", "/sign-in/register/preferred-name");
     }
 
     [Fact]
@@ -71,9 +71,9 @@ public class DateOfBirthPageTests : TestBase
     }
 
     [Fact]
-    public async Task Post_NameNotSet_RedirectsToNamePage()
+    public async Task Post_NameNotSet_RedirectsToPreferredNamePage()
     {
-        await GivenAuthenticationState_RedirectsTo(_previousPageAuthenticationState(), additionalScopes: null, trnRequirementType: null, HttpMethod.Post, "/sign-in/register/date-of-birth", "/sign-in/register/name");
+        await GivenAuthenticationState_RedirectsTo(_previousPageAuthenticationState(), additionalScopes: null, trnRequirementType: null, HttpMethod.Post, "/sign-in/register/date-of-birth", "/sign-in/register/preferred-name");
     }
 
     [Fact]
@@ -158,7 +158,7 @@ public class DateOfBirthPageTests : TestBase
         var user = await TestData.CreateUser();
         var dateOfBirth = user.DateOfBirth;
 
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.RegisterNameSet(user.FirstName, null, user.LastName), additionalScopes: null);
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.RegisterPreferredNameSet(firstName: user.FirstName, lastName: user.LastName), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/date-of-birth?{authStateHelper.ToQueryParam()}")
         {
             Content = new FormUrlEncodedContentBuilder()
@@ -239,6 +239,6 @@ public class DateOfBirthPageTests : TestBase
     }
 
     private readonly AuthenticationStateConfigGenerator _currentPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.DateOfBirth);
-    private readonly AuthenticationStateConfigGenerator _previousPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.Name);
+    private readonly AuthenticationStateConfigGenerator _previousPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.PreferredName);
     private readonly AuthenticationStateConfigGenerator _allQuestionsAnsweredAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.CheckAnswers);
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/NameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/NameTests.cs
@@ -206,7 +206,7 @@ public class NameTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith("/sign-in/register/date-of-birth", response.Headers.Location?.OriginalString);
+        Assert.StartsWith("/sign-in/register/preferred-name", response.Headers.Location?.OriginalString);
 
         Assert.Equal(firstName, authStateHelper.AuthenticationState.FirstName);
         Assert.Equal(lastName, authStateHelper.AuthenticationState.LastName);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/PreferredNamePageTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/PreferredNamePageTests.cs
@@ -1,0 +1,173 @@
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
+
+public class PreferredNamePageTests : TestBase
+{
+    public PreferredNamePageTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register/preferred-name");
+    }
+
+    [Fact]
+    public async Task Get_MissingAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Get, "/sign-in/register/preferred-name");
+    }
+
+    [Fact]
+    public async Task Get_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, trnRequirementType: null, HttpMethod.Get, "/sign-in/register/preferred-name");
+    }
+
+    [Fact]
+    public async Task Get_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(_currentPageAuthenticationState(), additionalScopes: null, trnRequirementType: null, HttpMethod.Get, "/sign-in/register/preferred-name");
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_RendersContent()
+    {
+        await ValidRequest_RendersContent(_currentPageAuthenticationState(), additionalScopes: null, trnRequirementType: null, url: "/sign-in/register/preferred-name");
+    }
+
+    [Fact]
+    public async Task Post_InvalidAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await InvalidAuthenticationState_ReturnsBadRequest(HttpMethod.Post, "/sign-in/register/preferred-name");
+    }
+
+    [Fact]
+    public async Task Post_NoAuthenticationStateProvided_ReturnsBadRequest()
+    {
+        await MissingAuthenticationState_ReturnsBadRequest(HttpMethod.Post, "/sign-in/register/preferred-name");
+    }
+
+    [Fact]
+    public async Task Post_JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl()
+    {
+        await JourneyIsAlreadyCompleted_RedirectsToPostSignInUrl(additionalScopes: null, trnRequirementType: null, HttpMethod.Post, "/sign-in/register/preferred-name");
+    }
+
+    [Fact]
+    public async Task Post_JourneyHasExpired_RendersErrorPage()
+    {
+        await JourneyHasExpired_RendersErrorPage(_currentPageAuthenticationState(), additionalScopes: null, trnRequirementType: null, HttpMethod.Post, "/sign-in/register/preferred-name");
+    }
+
+    [Fact]
+    public async Task Post_EmptyHasPreferredName_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/preferred-name?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "HasPreferredName", "Select which name to use");
+    }
+
+    [Fact]
+    public async Task Post_HasPreferredNameFalse_SetsPreferredNameOnAuthenticationStateAndRedirects()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/preferred-name?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "HasPreferredName", false },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/register/date-of-birth", response.Headers.Location?.OriginalString);
+
+        Assert.Equal(authStateHelper.AuthenticationState.GetName(), authStateHelper.AuthenticationState.PreferredName);
+    }
+
+    [Fact]
+    public async Task Post_EmptyPreferredName_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/preferred-name?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "HasPreferredName", true },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "PreferredName", "Enter your preferred name");
+    }
+
+    [Fact]
+    public async Task Post_PreferredNameTooLong_ReturnsError()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/preferred-name?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "HasPreferredName", true },
+                { "PreferredName", new string('a', 201) },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "PreferredName", "Preferred name must be 200 characters or less");
+    }
+
+    [Fact]
+    public async Task Post_ValidPreferredName_SetsPreferredNameAndRedirects()
+    {
+        // Arrange
+        var authStateHelper = await CreateAuthenticationStateHelper(_currentPageAuthenticationState(), additionalScopes: null);
+        var preferredName = Faker.Name.FullName();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/register/preferred-name?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "HasPreferredName", true },
+                { "PreferredName", preferredName },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/sign-in/register/date-of-birth", response.Headers.Location?.OriginalString);
+
+        Assert.Equal(preferredName, authStateHelper.AuthenticationState.PreferredName);
+    }
+
+    private readonly AuthenticationStateConfigGenerator _currentPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.PreferredName);
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/RegisterJourneyAuthenticationStateHelper.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/RegisterJourneyAuthenticationStateHelper.cs
@@ -36,8 +36,11 @@ public static class RegisterJourneyAuthenticationStateHelper
                 case RegisterJourneyPage.Name:
                     return c => c.MobileVerified();
 
-                case RegisterJourneyPage.DateOfBirth:
+                case RegisterJourneyPage.PreferredName:
                     return c => c.RegisterNameSet();
+
+                case RegisterJourneyPage.DateOfBirth:
+                    return c => c.RegisterPreferredNameSet();
 
                 case RegisterJourneyPage.HasNiNumber:
                     return c => c.RegisterDateOfBirthSet();
@@ -95,6 +98,7 @@ public enum RegisterJourneyPage
     PhoneExists,
     ResendPhone,
     Name,
+    PreferredName,
     DateOfBirth,
     AccountExists,
     ExistingAccountEmailConfirmation,


### PR DESCRIPTION
### Context

We want a separate, optional preferred name field on a user’s account so that a user can specify an alternative name to be used in correspondence to what’s held in their DQT record.

### Changes proposed in this pull request

Amend both the core registration and TRN token journey to add in a new page at /sign-in/register/preferred-name following the designs at https://dfe-identity-account-prototype.herokuapp.com/auth/preferred-name . The page should be shown after the Name page (for the Core registration journey) and after Phone (for the TRN token journey).

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
