### PR TITLE
Add preferred name check answers

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/CheckAnswers.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/CheckAnswers.cshtml
@@ -38,7 +38,7 @@
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Preferred name</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value>@Model.PreferredName</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-value><span fallback-text="Not provided">@Model.PreferredName</span></govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
                         <govuk-summary-list-row-action href="@LinkGenerator.RegisterPreferredName()" visually-hidden-text="name">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/CheckAnswers.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/CheckAnswers.cshtml
@@ -37,6 +37,13 @@
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Preferred name</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.PreferredName</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.RegisterPreferredName()" visually-hidden-text="name">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value>@Model.DateOfBirth?.ToString(Constants.DateFormat)</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/CheckAnswers.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/CheckAnswers.cshtml.cs
@@ -23,6 +23,7 @@ public class CheckAnswers : PageModel
     public string? EmailAddress => _journey.AuthenticationState.EmailAddress;
     public string? MobilePhoneNumber => _journey.AuthenticationState.MobileNumber;
     public string? FullName => _journey.AuthenticationState.GetName();
+    public string? PreferredName => _journey.AuthenticationState.PreferredName;
     public DateOnly? DateOfBirth => _journey.AuthenticationState.DateOfBirth;
     public bool? HasNationalInsuranceNumberSet => _journey.AuthenticationState.HasNationalInsuranceNumberSet;
     public string? NationalInsuranceNumber => _journey.AuthenticationState.NationalInsuranceNumber;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/PreferredNamePage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/PreferredNamePage.cshtml.cs
@@ -45,7 +45,8 @@ public class PreferredNamePage : PageModel
             return this.PageWithErrors();
         }
 
-        HttpContext.GetAuthenticationState().OnPreferredNameSet(PreferredName ?? ExistingName);
+        var preferredName = HasPreferredName == true ? PreferredName : ExistingName;
+        HttpContext.GetAuthenticationState().OnPreferredNameSet(preferredName!);
 
         return await _journey.Advance(CurrentStep);
     }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/CheckAnswers.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/CheckAnswers.cshtml
@@ -43,7 +43,9 @@
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Preferred name</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value>@Model.PreferredName</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-value>
+                        <span fallback-text="Not provided">@Model.PreferredName</span>
+                    </govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
                         <govuk-summary-list-row-action href="@LinkGenerator.RegisterPreferredName()" visually-hidden-text="name">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/CheckAnswers.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/CheckAnswers.cshtml
@@ -42,6 +42,13 @@
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Preferred name</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.PreferredName</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.RegisterPreferredName()" visually-hidden-text="name">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+                <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value>@Model.DateOfBirth?.ToString(Constants.DateFormat)</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/CheckAnswers.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/CheckAnswers.cshtml.cs
@@ -23,6 +23,7 @@ public class CheckAnswers : PageModel
     public string? FirstName => _journey.AuthenticationState.FirstName;
     public string? MiddleName => _journey.AuthenticationState.MiddleName;
     public string? LastName => _journey.AuthenticationState.LastName;
+    public string? PreferredName => _journey.AuthenticationState.PreferredName;
     public DateOnly? DateOfBirth => _journey.AuthenticationState.DateOfBirth;
 
     public void OnGet()

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/TagHelpers/FallbackTextTagHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/TagHelpers/FallbackTextTagHelper.cs
@@ -12,7 +12,7 @@ public class FallbackTextTagHelper : TagHelper
 
     public override async void Process(TagHelperContext context, TagHelperOutput output)
     {
-        if (string.IsNullOrEmpty((await output.GetChildContentAsync()).GetContent()))
+        if ((await output.GetChildContentAsync()).IsEmptyOrWhiteSpace)
         {
             output.Content.SetHtmlContent(FallbackText);
             output.AddClass("gai-summary-row-fallback-text", HtmlEncoder.Default);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/TagHelpers/FallbackTextTagHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/TagHelpers/FallbackTextTagHelper.cs
@@ -1,0 +1,21 @@
+using System.Text.Encodings.Web;
+using Microsoft.AspNetCore.Mvc.TagHelpers;
+using Microsoft.AspNetCore.Razor.TagHelpers;
+
+namespace TeacherIdentity.AuthServer.TagHelpers;
+
+[HtmlTargetElement("span", Attributes = "fallback-text")]
+public class FallbackTextTagHelper : TagHelper
+{
+    [HtmlAttributeName("fallback-text")]
+    public string? FallbackText { get; set; }
+
+    public override async void Process(TagHelperContext context, TagHelperOutput output)
+    {
+        if (string.IsNullOrEmpty((await output.GetChildContentAsync()).GetContent()))
+        {
+            output.Content.SetHtmlContent(FallbackText);
+            output.AddClass("gai-summary-row-fallback-text", HtmlEncoder.Default);
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/wwwroot/Styles/site.scss
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/wwwroot/Styles/site.scss
@@ -176,3 +176,7 @@ $app-button-inverse-hover-background-colour: govuk-tint($app-button-inverse-fore
   padding-left: 5px;
   background-color: #F3F2F1;
 }
+
+.gai-summary-row-fallback-text {
+  color: $govuk-secondary-text-colour;
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/CheckAnswersTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/CheckAnswersTests.cs
@@ -70,6 +70,7 @@ public class CheckAnswersTests : TestBase
         Assert.Equal(authState.EmailAddress, doc.GetSummaryListValueForKey("Email"));
         Assert.Equal(authState.MobileNumber, doc.GetSummaryListValueForKey("Mobile phone"));
         Assert.Equal($"{authState.GetName()}", doc.GetSummaryListValueForKey("Name"));
+        Assert.Equal(authState.PreferredName, doc.GetSummaryListValueForKey("Preferred name"));
         Assert.Equal(authState.DateOfBirth?.ToString(Constants.DateFormat), doc.GetSummaryListValueForKey("Date of birth"));
 
         var hasNiNumberSet = registerJourneyStage > RegisterJourneyPage.HasNiNumber;


### PR DESCRIPTION
### Context

We want a separate, optional preferred name field on a user’s account so that a user can specify an alternative name to be used in correspondence to what’s held in their DQT record.

### Changes proposed in this pull request

Add preferredName to the core sign-in journey check-answers page. Row heading should be Preferred name and should be populated from the preferredName property on Authentication state

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
