### PR TITLE
Update check answers fallback text

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Confirm.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Confirm.cshtml
@@ -55,7 +55,7 @@
                             </govuk-summary-list-row>
                             <govuk-summary-list-row>
                                 <govuk-summary-list-row-key>National insurance number</govuk-summary-list-row-key>
-                                <govuk-summary-list-row-value>@(!string.IsNullOrEmpty(Model.DqtNationalInsuranceNumber) ? "Given" : "Not given")</govuk-summary-list-row-value>
+                                <govuk-summary-list-row-value>@(!string.IsNullOrEmpty(Model.DqtNationalInsuranceNumber) ? "Provided" : "Not provided")</govuk-summary-list-row-value>
                             </govuk-summary-list-row>
                             <govuk-summary-list-row>
                                 <govuk-summary-list-row-key>TRN</govuk-summary-list-row-key>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/User.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/User.cshtml
@@ -101,7 +101,7 @@
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>National insurance number</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value>@(!string.IsNullOrEmpty(Model.DqtNationalInsuranceNumber) ? "Given" : "Not given")</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-value>@(!string.IsNullOrEmpty(Model.DqtNationalInsuranceNumber) ? "Provided" : "Not provided")</govuk-summary-list-row-value>
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>TRN</govuk-summary-list-row-key>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/CheckAnswers.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/CheckAnswers.cshtml
@@ -59,7 +59,7 @@
                         <govuk-summary-list-row>
                             <govuk-summary-list-row-key>National Insurance number</govuk-summary-list-row-key>
                             <govuk-summary-list-row-value>
-                                <span fallback-text="Not given">@Model.NationalInsuranceNumber</span>
+                                <span fallback-text="Not provided">@Model.NationalInsuranceNumber</span>
                             </govuk-summary-list-row-value>
                             <govuk-summary-list-row-actions>
                                 <govuk-summary-list-row-action href="@LinkGenerator.RegisterHasNiNumber()" visually-hidden-text="national insurance number">Change</govuk-summary-list-row-action>
@@ -81,7 +81,7 @@
                         <govuk-summary-list-row>
                             <govuk-summary-list-row-key>Where did you get your QTS?</govuk-summary-list-row-key>
                             <govuk-summary-list-row-value>
-                                <span fallback-text="Not given">@Model.IttProviderName</span>
+                                <span fallback-text="Not provided">@Model.IttProviderName</span>
                             </govuk-summary-list-row-value>
                             <govuk-summary-list-row-actions>
                                 <govuk-summary-list-row-action href="@LinkGenerator.RegisterIttProvider()" visually-hidden-text="teacher training provider">Change</govuk-summary-list-row-action>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/CheckAnswers.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/CheckAnswers.cshtml
@@ -39,7 +39,7 @@
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Preferred name</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value>
-                        <span fallback-text="Not provided"></span>
+                        <span fallback-text="Not provided">@Model.PreferredName</span>
                     </govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
                         <govuk-summary-list-row-action href="@LinkGenerator.RegisterPreferredName()" visually-hidden-text="name">Change</govuk-summary-list-row-action>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/CheckAnswers.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/CheckAnswers.cshtml
@@ -38,7 +38,9 @@
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Preferred name</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value><span fallback-text="Not provided">@Model.PreferredName</span></govuk-summary-list-row-value>
+                    <govuk-summary-list-row-value>
+                        <span fallback-text="Not provided"></span>
+                    </govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
                         <govuk-summary-list-row-action href="@LinkGenerator.RegisterPreferredName()" visually-hidden-text="name">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
@@ -56,7 +58,9 @@
                     {
                         <govuk-summary-list-row>
                             <govuk-summary-list-row-key>National Insurance number</govuk-summary-list-row-key>
-                            <govuk-summary-list-row-value>@(Model.NationalInsuranceNumber ?? "Not given")</govuk-summary-list-row-value>
+                            <govuk-summary-list-row-value>
+                                <span fallback-text="Not given">@Model.NationalInsuranceNumber</span>
+                            </govuk-summary-list-row-value>
                             <govuk-summary-list-row-actions>
                                 <govuk-summary-list-row-action href="@LinkGenerator.RegisterHasNiNumber()" visually-hidden-text="national insurance number">Change</govuk-summary-list-row-action>
                             </govuk-summary-list-row-actions>
@@ -76,7 +80,9 @@
                     {
                         <govuk-summary-list-row>
                             <govuk-summary-list-row-key>Where did you get your QTS?</govuk-summary-list-row-key>
-                            <govuk-summary-list-row-value>@(Model.IttProviderName ?? "Not given")</govuk-summary-list-row-value>
+                            <govuk-summary-list-row-value>
+                                <span fallback-text="Not given">@Model.IttProviderName</span>
+                            </govuk-summary-list-row-value>
                             <govuk-summary-list-row-actions>
                                 <govuk-summary-list-row-action href="@LinkGenerator.RegisterIttProvider()" visually-hidden-text="teacher training provider">Change</govuk-summary-list-row-action>
                             </govuk-summary-list-row-actions>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/CheckAnswers.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/CheckAnswers.cshtml
@@ -57,7 +57,9 @@
                 {
                     <govuk-summary-list-row>
                         <govuk-summary-list-row-key>National Insurance number</govuk-summary-list-row-key>
-                        <govuk-summary-list-row-value>@(Model.NationalInsuranceNumber ?? "Not given")</govuk-summary-list-row-value>
+                        <govuk-summary-list-row-value>
+                            <span fallback-text="Not given">@Model.NationalInsuranceNumber</span>
+                        </govuk-summary-list-row-value>
                         <govuk-summary-list-row-actions>
                             <govuk-summary-list-row-action href="@LinkGenerator.TrnHasNiNumber()" visually-hidden-text="national insurance number">Change</govuk-summary-list-row-action>
                         </govuk-summary-list-row-actions>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/CheckAnswers.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/CheckAnswers.cshtml
@@ -58,7 +58,7 @@
                     <govuk-summary-list-row>
                         <govuk-summary-list-row-key>National Insurance number</govuk-summary-list-row-key>
                         <govuk-summary-list-row-value>
-                            <span fallback-text="Not given">@Model.NationalInsuranceNumber</span>
+                            <span fallback-text="Not provided">@Model.NationalInsuranceNumber</span>
                         </govuk-summary-list-row-value>
                         <govuk-summary-list-row-actions>
                             <govuk-summary-list-row-action href="@LinkGenerator.TrnHasNiNumber()" visually-hidden-text="national insurance number">Change</govuk-summary-list-row-action>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/NoMatch.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Trn/NoMatch.cshtml
@@ -54,7 +54,9 @@
                 {
                     <govuk-summary-list-row>
                         <govuk-summary-list-row-key>National Insurance number</govuk-summary-list-row-key>
-                        <govuk-summary-list-row-value>@(Model.NationalInsuranceNumber ?? "Not given")</govuk-summary-list-row-value>
+                        <govuk-summary-list-row-value>
+                            <span fallback-text="Not provided">@Model.NationalInsuranceNumber</span>
+                        </govuk-summary-list-row-value>
                     </govuk-summary-list-row>
                 }
                 @if (Model.AwardedQts is not null)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AssignTrn/ConfirmTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AssignTrn/ConfirmTests.cs
@@ -171,7 +171,7 @@ public class ConfirmTests : TestBase
         Assert.Equal(user.EmailAddress, doc.GetSummaryListValueForKey("Email address"));
         Assert.Equal($"{dqtFirstName} {dqtLastName}", doc.GetSummaryListValueForKey("DQT name"));
         Assert.Equal(dqtDateOfBirth.ToString("d MMMM yyyy"), doc.GetSummaryListValueForKey("Date of birth"));
-        Assert.Equal("Given", doc.GetSummaryListValueForKey("National insurance number"));
+        Assert.Equal("Provided", doc.GetSummaryListValueForKey("National insurance number"));
         Assert.Equal(trn, doc.GetSummaryListValueForKey("TRN"));
     }
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/UserTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/UserTests.cs
@@ -111,7 +111,7 @@ public class UserTests : TestBase
         Assert.NotNull(doc.GetElementByTestId("DqtSection"));
         Assert.Equal($"{dqtFirstName} {dqtLastName}", doc.GetSummaryListValueForKey("DQT name"));
         Assert.Equal(dqtDateOfBirth.ToString("d MMMM yyyy"), doc.GetSummaryListValueForKey("Date of birth"));
-        Assert.Equal("Given", doc.GetSummaryListValueForKey("National insurance number"));
+        Assert.Equal("Provided", doc.GetSummaryListValueForKey("National insurance number"));
         Assert.Equal(user.Trn, doc.GetSummaryListValueForKey("TRN"));
     }
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/CheckAnswersTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/CheckAnswersTests.cs
@@ -212,7 +212,7 @@ public class CheckAnswersTests : TestBase
         Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
 
         var doc = await response.GetDocument();
-        Assert.Equal(hasNino ? nino : "Not given", doc.GetSummaryListValueForKey("National Insurance number"));
+        Assert.Equal(hasNino ? nino : "Not provided", doc.GetSummaryListValueForKey("National Insurance number"));
     }
 
     [Fact]

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/NoMatchTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/NoMatchTests.cs
@@ -195,7 +195,7 @@ public class NoMatchTests : TestBase
         Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
 
         var doc = await response.GetDocument();
-        Assert.Equal(hasNino ? nino : "Not given", doc.GetSummaryListValueForKey("National Insurance number"));
+        Assert.Equal(hasNino ? nino : "Not provided", doc.GetSummaryListValueForKey("National Insurance number"));
     }
 
     [Theory]


### PR DESCRIPTION
### Changes proposed in this pull request

In the Core Sign-in and TrnToken Check Answers pages, any fallback text should be grey. e.g. When National insurance number does not have a value the fallback text Not given should be grey

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
