### PR TITLE
Show normalized phone number on Check answers page

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/MobileNumber.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/MobileNumber.cs
@@ -259,6 +259,8 @@ public sealed class MobileNumber : IEquatable<MobileNumber>, IParsable<MobileNum
         _normalizedValue = normalizedValue;
     }
 
+    public string ToDisplayString() => _normalizedValue[..2] == "44" ? '0' + _normalizedValue[2..] : '+' + _normalizedValue;
+
     public static MobileNumber Parse(string number)
     {
         if (!TryParseCore(number, out var result, out var error))

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/CheckAnswers.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/CheckAnswers.cshtml.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeacherIdentity.AuthServer.Journeys;
+using TeacherIdentity.AuthServer.Models;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
 
@@ -21,7 +22,7 @@ public class CheckAnswers : PageModel
 
     public bool? RequiresTrnLookup => _journey.AuthenticationState.UserRequirements.RequiresTrnLookup();
     public string? EmailAddress => _journey.AuthenticationState.EmailAddress;
-    public string? MobilePhoneNumber => _journey.AuthenticationState.MobileNumber;
+    public string? MobilePhoneNumber => MobileNumber.Parse(_journey.AuthenticationState.MobileNumber!).ToDisplayString();
     public string? FullName => _journey.AuthenticationState.GetName();
     public string? PreferredName => _journey.AuthenticationState.PreferredName;
     public DateOnly? DateOfBirth => _journey.AuthenticationState.DateOfBirth;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/CheckAnswers.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/CheckAnswers.cshtml.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeacherIdentity.AuthServer.Journeys;
+using TeacherIdentity.AuthServer.Models;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.TrnToken;
 
@@ -19,7 +20,7 @@ public class CheckAnswers : PageModel
 
     public string BackLink => _journey.GetPreviousStepUrl(CurrentStep);
     public string? EmailAddress => _journey.AuthenticationState.EmailAddress;
-    public string? MobilePhoneNumber => _journey.AuthenticationState.MobileNumber;
+    public string? MobilePhoneNumber => MobileNumber.Parse(_journey.AuthenticationState.MobileNumber!).ToDisplayString();
     public string? FirstName => _journey.AuthenticationState.FirstName;
     public string? MiddleName => _journey.AuthenticationState.MiddleName;
     public string? LastName => _journey.AuthenticationState.LastName;

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/CheckAnswersTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/CheckAnswersTests.cs
@@ -1,6 +1,7 @@
 using AngleSharp.Html.Dom;
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Oidc;
 using ZendeskApi.Client.Models;
 using ZendeskApi.Client.Requests;
@@ -68,7 +69,7 @@ public class CheckAnswersTests : TestBase
         // Assert
         var doc = await response.GetDocument();
         Assert.Equal(authState.EmailAddress, doc.GetSummaryListValueForKey("Email"));
-        Assert.Equal(authState.MobileNumber, doc.GetSummaryListValueForKey("Mobile phone"));
+        Assert.Equal(MobileNumber.Parse(authState.MobileNumber!).ToDisplayString(), doc.GetSummaryListValueForKey("Mobile phone"));
         Assert.Equal($"{authState.GetName()}", doc.GetSummaryListValueForKey("Name"));
         Assert.Equal(authState.PreferredName, doc.GetSummaryListValueForKey("Preferred name"));
         Assert.Equal(authState.DateOfBirth?.ToString(Constants.DateFormat), doc.GetSummaryListValueForKey("Date of birth"));


### PR DESCRIPTION
Adds a `ToDisplayString()` method to `MobileNumber` which returns a normalized version of the phone number for display purposes. (The normalized form we actually store isn't great for displaying directly.) We special case the UK country code so we display a leading '0' instead of '+44'.