### PR TITLE
Backfill Created & Updated properties on WebHook

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230614111825_BackfillWebHookCreatedAndUpdated.Designer.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230614111825_BackfillWebHookCreatedAndUpdated.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeacherIdentity.AuthServer.Models;
@@ -12,9 +13,11 @@ using TeacherIdentity.AuthServer.Models;
 namespace TeacherIdentity.AuthServer.Migrations
 {
     [DbContext(typeof(TeacherIdentityServerDbContext))]
-    partial class TeacherIdentityServerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230614111825_BackfillWebHookCreatedAndUpdated")]
+    partial class BackfillWebHookCreatedAndUpdated
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230614111825_BackfillWebHookCreatedAndUpdated.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230614111825_BackfillWebHookCreatedAndUpdated.cs
@@ -1,0 +1,72 @@
+using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeacherIdentity.AuthServer.Migrations
+{
+    /// <inheritdoc />
+    public partial class BackfillWebHookCreatedAndUpdated : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("""
+                update webhooks u
+                set created = e.created
+                from (
+                    select payload ->> 'WebHookId' webhook_id, created from events
+                    where event_name = 'WebHookAddedEvent'
+                ) e;
+
+                update webhooks u
+                set updated = e.created
+                from (
+                    select payload ->> 'WebHookId' webhook_id, max(created) created from events
+                    where event_name in ('WebHookAddedEvent', 'WebHookUpdatedEvent')
+                	group by webhook_id
+                ) e;
+                """);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "updated",
+                table: "webhooks",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "created",
+                table: "webhooks",
+                type: "timestamp with time zone",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified),
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "updated",
+                table: "webhooks",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone");
+
+            migrationBuilder.AlterColumn<DateTime>(
+                name: "created",
+                table: "webhooks",
+                type: "timestamp with time zone",
+                nullable: true,
+                oldClrType: typeof(DateTime),
+                oldType: "timestamp with time zone");
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/Mappings/WebHookMapping.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/Mappings/WebHookMapping.cs
@@ -13,6 +13,8 @@ public class WebHookMapping : IEntityTypeConfiguration<WebHook>
         builder.Property(w => w.Endpoint).IsRequired();
         builder.Property(w => w.Secret).HasMaxLength(64);
         builder.Property(w => w.WebHookMessageTypes).IsRequired().HasDefaultValue(WebHookMessageTypes.None);
+        builder.Property(w => w.Created).IsRequired();
+        builder.Property(w => w.Updated).IsRequired();
         builder.HasKey(w => w.WebHookId);
     }
 }


### PR DESCRIPTION
Also made the `created` and `updated` columns mandatory.