### PR TITLE
Update identity with dqt name

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -650,7 +650,7 @@ public class AuthenticationState
         return NameHelper.GetFullName(FirstName, includeMiddleName ? MiddleName : null, LastName);
     }
 
-    public void OnTrnLookupCompleted(FindTeachersResponseResult? findTeachersResult, TrnLookupStatus trnLookupStatus)
+    public void OnTrnLookupCompleted(FindTeachersResponseResult? findTeachersResult, TrnLookupStatus trnLookupStatus, bool dqtSynchronizationEnabled = false)
     {
         var trn = findTeachersResult?.Trn;
 
@@ -667,7 +667,7 @@ public class AuthenticationState
         Trn = trn;
         TrnLookupStatus = trnLookupStatus;
 
-        if (findTeachersResult is not null)
+        if (dqtSynchronizationEnabled && findTeachersResult is not null)
         {
             FirstName = findTeachersResult.FirstName;
             MiddleName = findTeachersResult.MiddleName;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Helpers/NameHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Helpers/NameHelper.cs
@@ -9,6 +9,6 @@ public static class NameHelper
             return null;
         }
 
-        return middleName is null ? $"{firstName} {lastName}" : $"{firstName} {middleName} {lastName}";
+        return string.IsNullOrEmpty(middleName) ? $"{firstName} {lastName}" : $"{firstName} {middleName} {lastName}";
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Helpers/NameHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Helpers/NameHelper.cs
@@ -1,0 +1,14 @@
+namespace TeacherIdentity.AuthServer.Helpers;
+
+public static class NameHelper
+{
+    public static string? GetFullName(string? firstName, string? middleName, string? lastName)
+    {
+        if (firstName is null || lastName is null)
+        {
+            return null;
+        }
+
+        return middleName is null ? $"{firstName} {lastName}" : $"{firstName} {middleName} {lastName}";
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourney.cs
@@ -5,8 +5,8 @@ public class CoreSignInJourney : SignInJourney
     public CoreSignInJourney(
         HttpContext httpContext,
         IdentityLinkGenerator linkGenerator,
-        CreateUserHelper createUserHelper)
-        : base(httpContext, linkGenerator, createUserHelper)
+        UserHelper userHelper)
+        : base(httpContext, linkGenerator, userHelper)
     {
     }
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/ServiceCollectionExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/ServiceCollectionExtensions.cs
@@ -19,7 +19,7 @@ public static class ServiceCollectionExtensions
 
         services
             .AddTransient<TrnLookupHelper>()
-            .AddTransient<CreateUserHelper>()
+            .AddTransient<UserHelper>()
             .AddTransient<TrnTokenHelper>();
 
         services.AddTransient<LegacyTrnJourney>(

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/StaffSignInJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/StaffSignInJourney.cs
@@ -5,8 +5,8 @@ namespace TeacherIdentity.AuthServer.Journeys;
 
 public class StaffSignInJourney : SignInJourney
 {
-    public StaffSignInJourney(HttpContext httpContext, IdentityLinkGenerator linkGenerator, CreateUserHelper createUserHelper)
-        : base(httpContext, linkGenerator, createUserHelper)
+    public StaffSignInJourney(HttpContext httpContext, IdentityLinkGenerator linkGenerator, UserHelper userHelper)
+        : base(httpContext, linkGenerator, userHelper)
     {
     }
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnLookupHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnLookupHelper.cs
@@ -22,8 +22,8 @@ public class TrnLookupHelper
         using var cts = new CancellationTokenSource();
         cts.CancelAfter(_trnLookupTimeout);
 
-        string? trn = null;
-        string[] findTeachersResultTrns = Array.Empty<string>();
+        FindTeachersResponseResult? findTeachersResult;
+        FindTeachersResponseResult[] findTeachersResults = Array.Empty<FindTeachersResponseResult>();
 
         try
         {
@@ -42,7 +42,7 @@ public class TrnLookupHelper
                 },
                 cts.Token);
 
-            findTeachersResultTrns = lookupResponse.Results.Select(r => r.Trn).ToArray();
+            findTeachersResults = lookupResponse.Results.ToArray();
         }
         catch (OperationCanceledException ex)
         {
@@ -54,17 +54,19 @@ public class TrnLookupHelper
             // previously-found TRN that may now be invalid.
 
             TrnLookupStatus trnLookupStatus;
-            (trn, trnLookupStatus) = ResolveTrn(findTeachersResultTrns, authenticationState);
-            authenticationState.OnTrnLookupCompleted(trn, trnLookupStatus);
+            (findTeachersResult, trnLookupStatus) = ResolveTrn(findTeachersResults, authenticationState);
+            authenticationState.OnTrnLookupCompleted(findTeachersResult, trnLookupStatus);
         }
 
-        return trn;
+        return findTeachersResult?.Trn;
     }
 
-    public (string? Trn, TrnLookupStatus TrnLookupStatus) ResolveTrn(string[] findTeachersResultTrns, AuthenticationState authenticationState) =>
-        (findTeachersResultTrns, authenticationState) switch
+    public (FindTeachersResponseResult? Trn, TrnLookupStatus TrnLookupStatus) ResolveTrn(
+        FindTeachersResponseResult[] findTeachersResults,
+        AuthenticationState authenticationState) =>
+        (findTeachersResults, authenticationState) switch
         {
-            ({ Length: 1 }, _) => (findTeachersResultTrns.Single(), TrnLookupStatus.Found),
+            ({ Length: 1 }, _) => (findTeachersResults.Single(), TrnLookupStatus.Found),
             ({ Length: > 1 }, _) => (null, TrnLookupStatus.Pending),
             (_, { StatedTrn: not null } or { AwardedQts: true }) => (null, TrnLookupStatus.Pending),
             _ => (null, TrnLookupStatus.None)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnLookupHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnLookupHelper.cs
@@ -8,13 +8,16 @@ public class TrnLookupHelper
 
     private readonly IDqtApiClient _dqtApiClient;
     private readonly ILogger<TrnLookupHelper> _logger;
+    private readonly bool _dqtSynchronizationEnabled;
 
     public TrnLookupHelper(
         IDqtApiClient dqtApiClient,
+        IConfiguration configuration,
         ILogger<TrnLookupHelper> logger)
     {
         _dqtApiClient = dqtApiClient;
         _logger = logger;
+        _dqtSynchronizationEnabled = configuration.GetValue("DqtSynchronizationEnabled", false);
     }
 
     public async Task<string?> LookupTrn(AuthenticationState authenticationState)
@@ -55,7 +58,7 @@ public class TrnLookupHelper
 
             TrnLookupStatus trnLookupStatus;
             (findTeachersResult, trnLookupStatus) = ResolveTrn(findTeachersResults, authenticationState);
-            authenticationState.OnTrnLookupCompleted(findTeachersResult, trnLookupStatus);
+            authenticationState.OnTrnLookupCompleted(findTeachersResult, trnLookupStatus, _dqtSynchronizationEnabled);
         }
 
         return findTeachersResult?.Trn;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenHelper.cs
@@ -136,18 +136,21 @@ public class TrnTokenHelper
 
     private async Task<User> UpdateUserFromToken(User user, string trn)
     {
-        var dqtUser = await _dqtApiClient.GetTeacherByTrn(trn);
         var changes = UserUpdatedEventChanges.None;
 
-        if (dqtUser is not null)
+        if (_configuration.GetValue("DqtSynchronizationEnabled", false))
         {
-            changes |= (user.FirstName != dqtUser.FirstName ? UserUpdatedEventChanges.FirstName : 0) |
-                       (user.MiddleName != dqtUser.MiddleName ? UserUpdatedEventChanges.MiddleName : 0) |
-                       (user.LastName != dqtUser.LastName ? UserUpdatedEventChanges.LastName : 0);
+            var dqtUser = await _dqtApiClient.GetTeacherByTrn(trn);
+            if (dqtUser is not null)
+            {
+                changes |= (user.FirstName != dqtUser.FirstName ? UserUpdatedEventChanges.FirstName : UserUpdatedEventChanges.None) |
+                           (user.MiddleName != dqtUser.MiddleName ? UserUpdatedEventChanges.MiddleName : UserUpdatedEventChanges.None) |
+                           (user.LastName != dqtUser.LastName ? UserUpdatedEventChanges.LastName : UserUpdatedEventChanges.None);
 
-            user.FirstName = dqtUser.FirstName;
-            user.MiddleName = dqtUser.MiddleName;
-            user.LastName = dqtUser.LastName;
+                user.FirstName = dqtUser.FirstName;
+                user.MiddleName = dqtUser.MiddleName;
+                user.LastName = dqtUser.LastName;
+            }
         }
 
         if (user.Trn is null)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenHelper.cs
@@ -90,13 +90,9 @@ public class TrnTokenHelper
         var user = await _dbContext.Users.SingleAsync(u => u.UserId == userId && u.UserType != UserType.Staff);
         var trnToken = await _dbContext.TrnTokens.SingleAsync(t => t.TrnToken == trnTokenValue);
 
-        if (user.Trn is null)
+        if (user.Trn is null || user.Trn == trnToken.Trn)
         {
-            user = await UpdateUserTrn(user, trnToken.Trn);
-        }
-
-        if (user.Trn == trnToken.Trn)
-        {
+            user = await UpdateUserFromToken(user, trnToken.Trn);
             await InvalidateTrnToken(trnToken.TrnToken, user.UserId);
         }
     }
@@ -138,24 +134,47 @@ public class TrnTokenHelper
         };
     }
 
-    private async Task<User> UpdateUserTrn(User user, string trn)
+    private async Task<User> UpdateUserFromToken(User user, string trn)
     {
-        user.Trn = trn;
-        user.TrnLookupStatus = TrnLookupStatus.Found;
-        user.TrnAssociationSource = TrnAssociationSource.TrnToken;
-        user.Updated = _clock.UtcNow;
+        var dqtUser = await _dqtApiClient.GetTeacherByTrn(trn);
+        var changes = UserUpdatedEventChanges.None;
 
-        _dbContext.AddEvent(new UserUpdatedEvent()
+        if (dqtUser is not null)
         {
-            Source = UserUpdatedEventSource.TrnToken,
-            CreatedUtc = _clock.UtcNow,
-            Changes = UserUpdatedEventChanges.Trn | UserUpdatedEventChanges.TrnLookupStatus,
-            User = user,
-            UpdatedByUserId = null,
-            UpdatedByClientId = null
-        });
+            changes |= (user.FirstName != dqtUser.FirstName ? UserUpdatedEventChanges.FirstName : 0) |
+                       (user.MiddleName != dqtUser.MiddleName ? UserUpdatedEventChanges.MiddleName : 0) |
+                       (user.LastName != dqtUser.LastName ? UserUpdatedEventChanges.LastName : 0);
 
-        await _dbContext.SaveChangesAsync();
+            user.FirstName = dqtUser.FirstName;
+            user.MiddleName = dqtUser.MiddleName;
+            user.LastName = dqtUser.LastName;
+        }
+
+        if (user.Trn is null)
+        {
+            user.Trn = trn;
+            user.TrnLookupStatus = TrnLookupStatus.Found;
+            user.TrnAssociationSource = TrnAssociationSource.TrnToken;
+
+            changes |= UserUpdatedEventChanges.Trn | UserUpdatedEventChanges.TrnLookupStatus;
+        }
+
+        if (changes != UserUpdatedEventChanges.None)
+        {
+            user.Updated = _clock.UtcNow;
+
+            _dbContext.AddEvent(new UserUpdatedEvent()
+            {
+                Source = UserUpdatedEventSource.TrnToken,
+                CreatedUtc = _clock.UtcNow,
+                Changes = changes,
+                User = user,
+                UpdatedByUserId = null,
+                UpdatedByClientId = null
+            });
+
+            await _dbContext.SaveChangesAsync();
+        }
 
         return user;
     }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenSignInJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenSignInJourney.cs
@@ -10,15 +10,15 @@ public class TrnTokenSignInJourney : SignInJourney
     public TrnTokenSignInJourney(
         HttpContext httpContext,
         IdentityLinkGenerator linkGenerator,
-        CreateUserHelper createUserHelper, TrnTokenHelper trnTokenHelper)
-        : base(httpContext, linkGenerator, createUserHelper)
+        UserHelper userHelper, TrnTokenHelper trnTokenHelper)
+        : base(httpContext, linkGenerator, userHelper)
     {
         _trnTokenHelper = trnTokenHelper;
     }
 
     public override async Task<IActionResult> CreateUser(string currentStep)
     {
-        var user = await CreateUserHelper.CreateUserWithTrnToken(AuthenticationState);
+        var user = await UserHelper.CreateUserWithTrnToken(AuthenticationState);
 
         AuthenticationState.OnUserRegistered(user);
         await AuthenticationState.SignIn(HttpContext);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/UserHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/UserHelper.cs
@@ -260,9 +260,9 @@ public class UserHelper
     {
         var existingUser = await _dbContext.Users.SingleAsync(u => u.UserId == userId);
 
-        var changes = (existingUser.FirstName != dqtUser.FirstName ? Events.UserUpdatedEventChanges.FirstName : 0) |
-                      (existingUser.MiddleName != dqtUser.MiddleName ? Events.UserUpdatedEventChanges.MiddleName : 0) |
-                      (existingUser.LastName != dqtUser.LastName ? Events.UserUpdatedEventChanges.LastName : 0);
+        var changes = (existingUser.FirstName != dqtUser.FirstName ? Events.UserUpdatedEventChanges.FirstName : Events.UserUpdatedEventChanges.None) |
+                      ((existingUser.MiddleName ?? string.Empty) != dqtUser.MiddleName ? Events.UserUpdatedEventChanges.MiddleName : Events.UserUpdatedEventChanges.None) |
+                      (existingUser.LastName != dqtUser.LastName ? Events.UserUpdatedEventChanges.LastName : Events.UserUpdatedEventChanges.None);
 
         existingUser.FirstName = dqtUser.FirstName;
         existingUser.MiddleName = dqtUser.MiddleName;
@@ -270,7 +270,7 @@ public class UserHelper
 
         _dbContext.AddEvent(new Events.UserUpdatedEvent()
         {
-            Source = Events.UserUpdatedEventSource.TrnMatchedToExistingUser,
+            Source = Events.UserUpdatedEventSource.DqtSynchronization,
             CreatedUtc = _clock.UtcNow,
             Changes = changes,
             User = Events.User.FromModel(existingUser),

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/UserHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/UserHelper.cs
@@ -1,32 +1,37 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Helpers;
 using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Services.DqtApi;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 using TeacherIdentity.AuthServer.Services.Zendesk;
 using ZendeskApi.Client.Models;
 
 namespace TeacherIdentity.AuthServer.Journeys;
 
-public class CreateUserHelper
+public class UserHelper
 {
     private readonly TeacherIdentityServerDbContext _dbContext;
     private readonly IUserVerificationService _userVerificationService;
     private readonly IClock _clock;
     private readonly IZendeskApiWrapper _zendeskApiWrapper;
     private readonly TrnTokenHelper _trnTokenHelper;
+    private readonly IDqtApiClient _dqtApiClient;
 
-    public CreateUserHelper(
+    public UserHelper(
         TeacherIdentityServerDbContext dbContext,
         IUserVerificationService userVerificationService,
         IClock clock,
         IZendeskApiWrapper zendeskApiWrapper,
-        TrnTokenHelper trnTokenHelper)
+        TrnTokenHelper trnTokenHelper,
+        IDqtApiClient dqtApiClient)
     {
         _dbContext = dbContext;
         _userVerificationService = userVerificationService;
         _clock = clock;
         _zendeskApiWrapper = zendeskApiWrapper;
         _trnTokenHelper = trnTokenHelper;
+        _dqtApiClient = dqtApiClient;
     }
 
     public async Task<User> CreateUser(AuthenticationState authenticationState)
@@ -233,6 +238,44 @@ public class CreateUserHelper
             TicketComment = ticketComment,
             UserId = user.UserId,
             CreatedUtc = _clock.UtcNow,
+        });
+
+        await _dbContext.SaveChangesAsync();
+    }
+
+    public async Task EnsureDqtUserNameMatch(User user, AuthenticationState authenticationState)
+    {
+        var dqtUser = await _dqtApiClient.GetTeacherByTrn(user.Trn!);
+
+        if (dqtUser is not null &&
+            NameHelper.GetFullName(user.FirstName, user.MiddleName, user.LastName) !=
+            NameHelper.GetFullName(dqtUser.FirstName, dqtUser.MiddleName, dqtUser.LastName))
+        {
+            await AssignDqtUserName(user.UserId, dqtUser);
+            authenticationState.OnNameSet(dqtUser.FirstName, dqtUser.MiddleName, dqtUser.LastName);
+        }
+    }
+
+    private async Task AssignDqtUserName(Guid userId, TeacherInfo dqtUser)
+    {
+        var existingUser = await _dbContext.Users.SingleAsync(u => u.UserId == userId);
+
+        var changes = (existingUser.FirstName != dqtUser.FirstName ? Events.UserUpdatedEventChanges.FirstName : 0) |
+                      (existingUser.MiddleName != dqtUser.MiddleName ? Events.UserUpdatedEventChanges.MiddleName : 0) |
+                      (existingUser.LastName != dqtUser.LastName ? Events.UserUpdatedEventChanges.LastName : 0);
+
+        existingUser.FirstName = dqtUser.FirstName;
+        existingUser.MiddleName = dqtUser.MiddleName;
+        existingUser.LastName = dqtUser.LastName;
+
+        _dbContext.AddEvent(new Events.UserUpdatedEvent()
+        {
+            Source = Events.UserUpdatedEventSource.TrnMatchedToExistingUser,
+            CreatedUtc = _clock.UtcNow,
+            Changes = changes,
+            User = Events.User.FromModel(existingUser),
+            UpdatedByUserId = null,
+            UpdatedByClientId = null
         });
 
         await _dbContext.SaveChangesAsync();

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Confirm.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Confirm.cshtml
@@ -1,4 +1,6 @@
 @page "/admin/users/{userId}/assign-trn/confirm"
+@using TeacherIdentity.AuthServer.Helpers
+@using GovUk.Frontend.AspNetCore.TagHelpers
 @model TeacherIdentity.AuthServer.Pages.Admin.AssignTrn.ConfirmModel
 @{
     ViewBag.Title = Model.Trn is not null ?
@@ -67,7 +69,7 @@
                                 </govuk-summary-list-row>
                                 <govuk-summary-list-row>
                                     <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
-                                    <govuk-summary-list-row-value>@Model.DqtName</govuk-summary-list-row-value>
+                                    <govuk-summary-list-row-value>@NameHelper.GetFullName(Model.DqtFirstName, Model.DqtMiddleName, Model.DqtLastName)</govuk-summary-list-row-value>
                                 </govuk-summary-list-row>
                                 <govuk-summary-list-row>
                                     <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Confirm.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Confirm.cshtml
@@ -84,7 +84,7 @@
                 {
                     <govuk-warning-text icon-fallback-text="Warning" data-testid="EmailOverwriteWarning">
                         The DQT email address will be overwritten with
-                        <span class="empty-hyphens">@Html.ShyEmail(Model.DqtEmailAddress))</span>
+                        <span class="empty-hyphens">@Html.ShyEmail(Model.EmailAddress!))</span>
                         when the TRN is assigned.
                     </govuk-warning-text>
                 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Confirm.cshtml.cs
@@ -102,10 +102,9 @@ public class ConfirmModel : PageModel
 
             if (_dqtSynchronizationEnabled)
             {
-                changes = changes |
-                    (user.FirstName != DqtFirstName ? Events.UserUpdatedEventChanges.FirstName : Events.UserUpdatedEventChanges.None) |
-                    ((user.MiddleName ?? string.Empty) != (DqtMiddleName ?? string.Empty) ? Events.UserUpdatedEventChanges.MiddleName : Events.UserUpdatedEventChanges.None) |
-                    (user.LastName != DqtLastName ? Events.UserUpdatedEventChanges.LastName : Events.UserUpdatedEventChanges.None);
+                changes |= (user.FirstName != DqtFirstName ? Events.UserUpdatedEventChanges.FirstName : Events.UserUpdatedEventChanges.None) |
+                           ((user.MiddleName ?? string.Empty) != (DqtMiddleName ?? string.Empty) ? Events.UserUpdatedEventChanges.MiddleName : Events.UserUpdatedEventChanges.None) |
+                           (user.LastName != DqtLastName ? Events.UserUpdatedEventChanges.LastName : Events.UserUpdatedEventChanges.None);
                 user.FirstName = DqtFirstName!;
                 user.MiddleName = DqtMiddleName;
                 user.LastName = DqtLastName!;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/AccountExists.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/AccountExists.cshtml.cs
@@ -19,7 +19,7 @@ public class AccountExists : BaseExistingEmailPageModel
         SignInJourney journey,
         TeacherIdentityServerDbContext dbContext,
         IUserVerificationService userVerificationService,
-        IClock clock, CreateUserHelper createUserHelper) :
+        IClock clock, UserHelper userHelper) :
         base(userVerificationService, dbContext)
     {
         _journey = journey;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/FindTeachersResponse.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/FindTeachersResponse.cs
@@ -10,6 +10,7 @@ public record FindTeachersResponseResult
     public required string Trn { get; init; }
     public required string[] EmailAddresses { get; init; }
     public required string FirstName { get; init; }
+    public required string? MiddleName { get; init; }
     public required string LastName { get; init; }
     public required DateOnly? DateOfBirth { get; init; }
     public required string? NationalInsuranceNumber { get; init; }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Production.json
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Production.json
@@ -39,5 +39,6 @@
   "WebHooks": {
     "WebHooksCacheDurationSeconds": 120
   },
-  "RegisterWithTrnTokenEnabled": false
+  "RegisterWithTrnTokenEnabled": false,
+  "DqtSynchronizationEnabled":  false
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.json
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.json
@@ -30,6 +30,7 @@
     "RefreshEstablishmentDomainsJobSchedule": "0 2 * * *"
   },
   "RegisterWithTrnTokenEnabled": true,
+  "DqtSynchronizationEnabled": false,
   "BlockEstablishmentEmailDomains": false,
   "SupportEmail": "qts.enquiries@education.gov.uk",
   "TrnTokens": {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/HostFixture.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/HostFixture.cs
@@ -36,6 +36,8 @@ public class HostFixture : IAsyncLifetime
 
     public IServiceProvider AuthServerServices { get; private set; } = null!;
 
+    public IConfiguration Configuration => AuthServerServices.GetRequiredService<IConfiguration>();
+
     public IBrowser Browser { get; private set; } = null!;
 
     public IReadOnlyCollection<string> CapturedAccessTokens => _capturedAccessTokens.AsReadOnly();

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/LegacyTrnJourney.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/LegacyTrnJourney.cs
@@ -157,6 +157,7 @@ public class LegacyTrnJourney : IClassFixture<HostFixture>
         {
             DateOfBirth = dateOfBirth,
             FirstName = officialFirstName,
+            MiddleName = null,
             LastName = officialLastName,
             EmailAddresses = new[] { email },
             HasActiveSanctions = false,
@@ -230,6 +231,7 @@ public class LegacyTrnJourney : IClassFixture<HostFixture>
         {
             DateOfBirth = dateOfBirth,
             FirstName = officialFirstName,
+            MiddleName = null,
             LastName = officialLastName,
             EmailAddresses = new[] { email },
             HasActiveSanctions = false,

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Register.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Register.cs
@@ -184,6 +184,7 @@ public class Register : IClassFixture<HostFixture>
         {
             DateOfBirth = dateOfBirth,
             FirstName = firstName,
+            MiddleName = null,
             LastName = lastName,
             EmailAddresses = new[] { email },
             HasActiveSanctions = false,
@@ -241,6 +242,83 @@ public class Register : IClassFixture<HostFixture>
             });
     }
 
+    [Fact]
+    public async Task NewUser_WithTrnLookup_TrnFoundDifferentName_UpdatesNameAndCanRegister()
+    {
+        var email = Faker.Internet.Email();
+        var mobileNumber = _hostFixture.TestData.GenerateUniqueMobileNumber();
+        var firstName = Faker.Name.First();
+        var lastName = Faker.Name.Last();
+        var dateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
+        var trn = _hostFixture.TestData.GenerateTrn();
+
+        var dqtFirstName = Faker.Name.First();
+        var dqtMiddleName = Faker.Name.Middle();
+        var dqtLastName = Faker.Name.Last();
+
+        ConfigureDqtApiFindTeachersRequest(result: new()
+        {
+            DateOfBirth = dateOfBirth,
+            FirstName = dqtFirstName,
+            MiddleName = dqtMiddleName,
+            LastName = dqtLastName,
+            EmailAddresses = new[] { email },
+            HasActiveSanctions = false,
+            NationalInsuranceNumber = null,
+            Trn = trn,
+            Uid = Guid.NewGuid().ToString()
+        });
+
+        await using var context = await _hostFixture.CreateBrowserContext();
+        var page = await context.NewPageAsync();
+
+        await page.StartOAuthJourney(CustomScopes.DqtRead, TrnRequirementType.Required);
+
+        await page.RegisterFromLandingPage();
+
+        await page.SubmitRegisterEmailPage(email);
+
+        await page.SubmitRegisterEmailConfirmationPage();
+
+        await page.SubmitRegisterPhonePage(mobileNumber);
+
+        await page.SubmitRegisterPhoneConfirmationPage();
+
+        await page.SubmitRegisterNamePage(firstName, lastName);
+
+        await page.SubmitRegisterPreferredNamePage();
+
+        await page.SubmitDateOfBirthPage(dateOfBirth);
+
+        await page.SubmitCheckAnswersPage();
+
+        await page.SubmitCompletePageForNewUser();
+
+        await page.AssertSignedInOnTestClient(email, trn, dqtFirstName, dqtLastName);
+
+        Guid createdUserId = default;
+
+        _hostFixture.EventObserver.AssertEventsSaved(
+            e =>
+            {
+                var userRegisteredEvent = Assert.IsType<UserRegisteredEvent>(e);
+                Assert.Equal(_hostFixture.TestClientId, userRegisteredEvent.ClientId);
+                Assert.Equal(email, userRegisteredEvent.User.EmailAddress);
+                Assert.Equal(mobileNumber, userRegisteredEvent.User.MobileNumber);
+                Assert.Equal(dqtFirstName, userRegisteredEvent.User.FirstName);
+                Assert.Equal(dqtMiddleName, userRegisteredEvent.User.MiddleName);
+                Assert.Equal(dqtLastName, userRegisteredEvent.User.LastName);
+                Assert.Equal(dateOfBirth, userRegisteredEvent.User.DateOfBirth);
+
+                createdUserId = userRegisteredEvent.User.UserId;
+            },
+            e =>
+            {
+                var userSignedInEvent = Assert.IsType<UserSignedInEvent>(e);
+                Assert.Equal(createdUserId, userSignedInEvent.User.UserId);
+            });
+    }
+
     [Theory]
     [InlineData(TrnRequirementType.Optional)]
     [InlineData(TrnRequirementType.Required)]
@@ -260,6 +338,7 @@ public class Register : IClassFixture<HostFixture>
         {
             DateOfBirth = dateOfBirth,
             FirstName = firstName,
+            MiddleName = null,
             LastName = lastName,
             EmailAddresses = new[] { email },
             HasActiveSanctions = false,

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/TrnTokenSignInJourney.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/TrnTokenSignInJourney.cs
@@ -1,4 +1,3 @@
-using Bogus;
 using Microsoft.Playwright;
 using Moq;
 using TeacherIdentity.AuthServer.Events;

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AssignTrn/ConfirmTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AssignTrn/ConfirmTests.cs
@@ -6,6 +6,7 @@ using TeacherIdentity.AuthServer.Services.DqtApi;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Admin.AssignTrn;
 
+[Collection(nameof(DisableParallelization))]
 public class ConfirmTests : TestBase
 {
     public ConfirmTests(HostFixture hostFixture)
@@ -380,6 +381,7 @@ public class ConfirmTests : TestBase
         var dqtEmail = Faker.Internet.Email();
 
         ConfigureDqtApiMock(trn, dqtDateOfBirth, dqtFirstName, dqtMiddleName, dqtLastName, dqtNino, dqtEmail);
+        HostFixture.Configuration["DqtSynchronizationEnabled"] = "true";
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{user.UserId}/assign-trn/confirm?trn={trn}")
         {
@@ -417,6 +419,9 @@ public class ConfirmTests : TestBase
                 Assert.Equal(UserUpdatedEventChanges.Trn | UserUpdatedEventChanges.TrnLookupStatus | UserUpdatedEventChanges.FirstName | UserUpdatedEventChanges.MiddleName | UserUpdatedEventChanges.LastName, userUpdatedEvent.Changes);
                 Assert.Equal(user.UserId, userUpdatedEvent.User.UserId);
             });
+
+        // Reset config
+        HostFixture.Configuration["DqtSynchronizationEnabled"] = "false";
     }
 
     [Fact]

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AssignTrn/ConfirmTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AssignTrn/ConfirmTests.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Events;
 using TeacherIdentity.AuthServer.Models;
@@ -114,12 +113,12 @@ public class ConfirmTests : TestBase
         var doc = await response.GetDocument();
         var idSection = doc.GetElementByTestId("IdSection");
         Assert.Equal(user.EmailAddress, idSection?.GetSummaryListValueForKey("Email address"));
-        Assert.Equal($"{user.FirstName} {user.LastName}", idSection?.GetSummaryListValueForKey("Name"));
+        Assert.Equal($"{user.FirstName} {user.MiddleName} {user.LastName}", idSection?.GetSummaryListValueForKey("Name"));
         Assert.Equal(user.DateOfBirth!.Value.ToString("d MMMM yyyy"), idSection?.GetSummaryListValueForKey("Date of birth"));
         var dqtSection = doc.GetElementByTestId("DqtSection");
         Assert.Equal(trn, dqtSection?.GetSummaryListValueForKey("TRN"));
         Assert.Equal(dqtEmail, dqtSection?.GetSummaryListValueForKey("Email address"));
-        Assert.Equal($"{dqtFirstName} {dqtLastName}", dqtSection?.GetSummaryListValueForKey("Name"));
+        Assert.Equal($"{dqtFirstName} {dqtMiddleName} {dqtLastName}", dqtSection?.GetSummaryListValueForKey("Name"));
         Assert.Equal(dqtDateOfBirth.ToString("d MMMM yyyy"), dqtSection?.GetSummaryListValueForKey("Date of birth"));
     }
 
@@ -367,7 +366,7 @@ public class ConfirmTests : TestBase
     }
 
     [Fact]
-    public async Task Post_WithAddRecordConfirmedWithDifferentDqtName_UpdatesUserNameAndTrnEmitsEventAndRedirects()
+    public async Task Post_WithTrnAndAddRecordConfirmedAndDifferentDqtName_UpdatesUserNameAndTrnAndEmitsEventAndRedirects()
     {
         // Arrange
         var user = await TestData.CreateUser(userType: UserType.Default, hasTrn: false);
@@ -382,11 +381,11 @@ public class ConfirmTests : TestBase
 
         ConfigureDqtApiMock(trn, dqtDateOfBirth, dqtFirstName, dqtMiddleName, dqtLastName, dqtNino, dqtEmail);
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{user.UserId}/assign-trn/{trn}")
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{user.UserId}/assign-trn/confirm?trn={trn}")
         {
             Content = new FormUrlEncodedContentBuilder()
             {
-                { "AddRecord", bool.TrueString }
+                { "AssignTrn", bool.TrueString }
             }
         };
 
@@ -421,7 +420,7 @@ public class ConfirmTests : TestBase
     }
 
     [Fact]
-    public async Task Post_WithTrnAndAddRecordConfirmedAndDqtNameMatch_AssignsTrnToUserEmitsEventAndRedirects()
+    public async Task Post_WithTrnAndAddRecordConfirmedAndDqtNameMatch_AssignsTrnToUserAndEmitsEventAndRedirects()
     {
         // Arrange
         var user = await TestData.CreateUser(userType: UserType.Default, hasTrn: false);
@@ -491,7 +490,7 @@ public class ConfirmTests : TestBase
     }
 
     [Fact]
-    public async Task Post_WithoutTrnAndConfirmed_UpdatesTrnLookupStausEmitsEventAndRedirects()
+    public async Task Post_WithoutTrnAndConfirmed_UpdatesTrnLookupStatusEmitsEventAndRedirects()
     {
         // Arrange
         var user = await TestData.CreateUser(userType: UserType.Default, hasTrn: false);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
@@ -7,6 +7,7 @@ using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn;
 
+[Collection(nameof(DisableParallelization))]
 public class EmailConfirmationTests : TestBase
 {
     public EmailConfirmationTests(HostFixture hostFixture)
@@ -487,6 +488,7 @@ public class EmailConfirmationTests : TestBase
                 PendingNameChange = false
             });
 
+        HostFixture.Configuration["DqtSynchronizationEnabled"] = "true";
         var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(user.EmailAddress), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
@@ -523,5 +525,8 @@ public class EmailConfirmationTests : TestBase
                 Assert.Equal(dqtMiddleName, userUpdatedEvent.User.MiddleName);
                 Assert.Equal(dqtLastName, userUpdatedEvent.User.LastName);
             });
+
+        // Reset config
+        HostFixture.Configuration["DqtSynchronizationEnabled"] = "false";
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
@@ -477,6 +477,7 @@ public class EmailConfirmationTests : TestBase
             .ReturnsAsync(new AuthServer.Services.DqtApi.TeacherInfo()
             {
                 DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
+                Email = Faker.Internet.Email(),
                 FirstName = dqtFirstName,
                 MiddleName = dqtMiddleName,
                 LastName = dqtLastName,

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
@@ -516,7 +516,7 @@ public class EmailConfirmationTests : TestBase
             {
                 var userUpdatedEvent = Assert.IsType<UserUpdatedEvent>(e);
                 Assert.Equal(Clock.UtcNow, userUpdatedEvent.CreatedUtc);
-                Assert.Equal(UserUpdatedEventSource.TrnMatchedToExistingUser, userUpdatedEvent.Source);
+                Assert.Equal(UserUpdatedEventSource.DqtSynchronization, userUpdatedEvent.Source);
                 Assert.Equal(UserUpdatedEventChanges.FirstName | UserUpdatedEventChanges.MiddleName | UserUpdatedEventChanges.LastName, userUpdatedEvent.Changes);
                 Assert.Equal(user.UserId, userUpdatedEvent.User.UserId);
                 Assert.Equal(dqtFirstName, userUpdatedEvent.User.FirstName);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Options;
+using TeacherIdentity.AuthServer.Events;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Oidc;
 using TeacherIdentity.AuthServer.Services.UserVerification;
@@ -457,5 +458,69 @@ public class EmailConfirmationTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status403Forbidden, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_ValidPinForKnownUserWithTrnAndDifferentDqtName_UpdatesUserSignsInAndRedirects()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(hasTrn: true);
+
+        var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
+        var pinResult = await userVerificationService.GenerateEmailPin(user.EmailAddress);
+
+        var dqtFirstName = Faker.Name.First();
+        var dqtMiddleName = Faker.Name.Middle();
+        var dqtLastName = Faker.Name.Last();
+
+        HostFixture.DqtApiClient.Setup(mock => mock.GetTeacherByTrn(user.Trn!, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new AuthServer.Services.DqtApi.TeacherInfo()
+            {
+                DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
+                FirstName = dqtFirstName,
+                MiddleName = dqtMiddleName,
+                LastName = dqtLastName,
+                NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber(),
+                Trn = user.Trn!,
+                PendingDateOfBirthChange = false,
+                PendingNameChange = false
+            });
+
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(user.EmailAddress), additionalScopes: null);
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Code", pinResult.Pin! }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal(authStateHelper.AuthenticationState.PostSignInUrl, response.Headers.Location?.OriginalString);
+
+        Assert.True(authStateHelper.AuthenticationState.EmailAddressVerified);
+        Assert.NotNull(authStateHelper.AuthenticationState.UserId);
+        Assert.False(authStateHelper.AuthenticationState.FirstTimeSignInForEmail);
+        Assert.Equal(user.Trn, authStateHelper.AuthenticationState.Trn);
+        Assert.Equal(dqtFirstName, authStateHelper.AuthenticationState.FirstName);
+        Assert.Equal(dqtMiddleName, authStateHelper.AuthenticationState.MiddleName);
+        Assert.Equal(dqtLastName, authStateHelper.AuthenticationState.LastName);
+
+        EventObserver.AssertEventsSaved(
+            e =>
+            {
+                var userUpdatedEvent = Assert.IsType<UserUpdatedEvent>(e);
+                Assert.Equal(Clock.UtcNow, userUpdatedEvent.CreatedUtc);
+                Assert.Equal(UserUpdatedEventSource.TrnMatchedToExistingUser, userUpdatedEvent.Source);
+                Assert.Equal(UserUpdatedEventChanges.FirstName | UserUpdatedEventChanges.MiddleName | UserUpdatedEventChanges.LastName, userUpdatedEvent.Changes);
+                Assert.Equal(user.UserId, userUpdatedEvent.User.UserId);
+                Assert.Equal(dqtFirstName, userUpdatedEvent.User.FirstName);
+                Assert.Equal(dqtMiddleName, userUpdatedEvent.User.MiddleName);
+                Assert.Equal(dqtLastName, userUpdatedEvent.User.LastName);
+            });
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/CheckAnswersTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/CheckAnswersTests.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Events;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Oidc;
+using TeacherIdentity.AuthServer.Services.DqtApi;
 using ZendeskApi.Client.Models;
 using ZendeskApi.Client.Requests;
 using ZendeskApi.Client.Responses;
@@ -58,7 +59,7 @@ public class CheckAnswersTests : TestBase
 
         if (requiresTrnLookup)
         {
-            authState.OnTrnLookupCompleted(TestData.GenerateTrn(), TrnLookupStatus.Found);
+            authState.OnTrnLookupCompleted(GetTeachersResponseResult(TestData.GenerateTrn()), TrnLookupStatus.Found);
         }
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/register/check-answers?{authStateHelper.ToQueryParam()}");
@@ -129,7 +130,7 @@ public class CheckAnswersTests : TestBase
         if (requiresTrnLookup)
         {
             var trn = trnLookupStatus == TrnLookupStatus.Found ? TestData.GenerateTrn() : null;
-            authState.OnTrnLookupCompleted(trn, trnLookupStatus);
+            authState.OnTrnLookupCompleted(GetTeachersResponseResult(trn), trnLookupStatus);
         }
 
         TicketCreateRequest? ticketCreateRequestActual = null;
@@ -218,4 +219,20 @@ public class CheckAnswersTests : TestBase
     };
 
     private readonly AuthenticationStateConfigGenerator _currentPageAuthenticationState = RegisterJourneyAuthenticationStateHelper.ConfigureAuthenticationStateForPage(RegisterJourneyPage.CheckAnswers);
+
+    private FindTeachersResponseResult GetTeachersResponseResult(string? trn = null)
+    {
+        return new FindTeachersResponseResult()
+        {
+            Trn = trn!,
+            EmailAddresses = new[] { Faker.Internet.Email() },
+            FirstName = Faker.Name.First(),
+            MiddleName = Faker.Name.Middle(),
+            LastName = Faker.Name.Last(),
+            DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
+            NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber(),
+            Uid = "",
+            HasActiveSanctions = false,
+        };
+    }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TestBase.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TestBase.cs
@@ -64,6 +64,7 @@ public abstract partial class TestBase
                         DateOfBirth = authState.DateOfBirth,
                         EmailAddresses = new[] { authState.EmailAddress! },
                         FirstName = authState.FirstName!,
+                        MiddleName = authState.MiddleName!,
                         LastName = authState.LastName!,
                         HasActiveSanctions = false,
                         NationalInsuranceNumber = authState.NationalInsuranceNumber,

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/CheckAnswersTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/CheckAnswersTests.cs
@@ -1,6 +1,7 @@
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Oidc;
+using TeacherIdentity.AuthServer.Services.DqtApi;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Trn;
 
@@ -90,7 +91,7 @@ public class CheckAnswersTests : TestBase
         var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.DateOfBirthSet(), CustomScopes.Trn, TrnRequirementType.Legacy);
         var authState = authStateHelper.AuthenticationState;
 
-        authState.OnTrnLookupCompleted(trn, TrnLookupStatus.Found);
+        authState.OnTrnLookupCompleted(GetTeachersResponseResult(trn), TrnLookupStatus.Found);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/check-answers?{authStateHelper.ToQueryParam()}");
 
@@ -220,7 +221,7 @@ public class CheckAnswersTests : TestBase
     {
         // Arrange
         var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.DateOfBirthSet(), CustomScopes.Trn, TrnRequirementType.Legacy);
-        authStateHelper.AuthenticationState.OnTrnLookupCompleted(trn: TestData.GenerateTrn(), trnLookupStatus: TrnLookupStatus.Found);
+        authStateHelper.AuthenticationState.OnTrnLookupCompleted(findTeachersResult: GetTeachersResponseResult(TestData.GenerateTrn()), trnLookupStatus: TrnLookupStatus.Found);
         Assert.Null(authStateHelper.AuthenticationState.HasNationalInsuranceNumber);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/check-answers?{authStateHelper.ToQueryParam()}");
@@ -360,7 +361,7 @@ public class CheckAnswersTests : TestBase
         var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.AwardedQtsSet(awardedQts: false), CustomScopes.Trn, TrnRequirementType.Legacy);
         var authState = authStateHelper.AuthenticationState;
 
-        authState.OnTrnLookupCompleted(trn: null, TrnLookupStatus.Pending);
+        authState.OnTrnLookupCompleted(findTeachersResult: null, TrnLookupStatus.Pending);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/check-answers?{authStateHelper.ToQueryParam()}")
         {
@@ -390,7 +391,7 @@ public class CheckAnswersTests : TestBase
         var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.IttProviderSet(), CustomScopes.Trn, TrnRequirementType.Legacy);
         var authState = authStateHelper.AuthenticationState;
 
-        authState.OnTrnLookupCompleted(trn, TrnLookupStatus.Found);
+        authState.OnTrnLookupCompleted(GetTeachersResponseResult(trn), TrnLookupStatus.Found);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/check-answers?{authStateHelper.ToQueryParam()}")
         {
@@ -420,7 +421,7 @@ public class CheckAnswersTests : TestBase
         var authStateHelper = await CreateAuthenticationStateHelper(c => c.Trn.IttProviderSet(), CustomScopes.Trn, TrnRequirementType.Legacy);
         var authState = authStateHelper.AuthenticationState;
 
-        authState.OnTrnLookupCompleted(existingUserWithTrn.Trn, TrnLookupStatus.Found);
+        authState.OnTrnLookupCompleted(GetTeachersResponseResult(existingUserWithTrn.Trn), TrnLookupStatus.Found);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/check-answers?{authStateHelper.ToQueryParam()}")
         {
@@ -481,5 +482,21 @@ public class CheckAnswersTests : TestBase
                 }
             };
         }
+    }
+
+    private FindTeachersResponseResult GetTeachersResponseResult(string? trn = null)
+    {
+        return new FindTeachersResponseResult()
+        {
+            Trn = trn ?? TestData.GenerateTrn(),
+            EmailAddresses = new[] { Faker.Internet.Email() },
+            FirstName = Faker.Name.First(),
+            MiddleName = Faker.Name.Middle(),
+            LastName = Faker.Name.Last(),
+            DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
+            NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber(),
+            Uid = "",
+            HasActiveSanctions = false,
+        };
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/NoMatchTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Trn/NoMatchTests.cs
@@ -68,7 +68,7 @@ public class NoMatchTests : TestBase
         var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.Trn, TrnRequirementType.Legacy);
         var authState = authStateHelper.AuthenticationState;
 
-        authState.OnTrnLookupCompleted(trn: null, TrnLookupStatus.Pending);
+        authState.OnTrnLookupCompleted(findTeachersResult: null, TrnLookupStatus.Pending);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/no-match?{authStateHelper.ToQueryParam()}");
 
@@ -94,7 +94,7 @@ public class NoMatchTests : TestBase
         var authStateHelper = await CreateAuthenticationStateHelper(
             c => c.Trn.IttProviderSet(previousOfficialFirstName: previousFirstName, previousOfficialLastName: previousLastName),
             CustomScopes.Trn, TrnRequirementType.Legacy);
-        authStateHelper.AuthenticationState.OnTrnLookupCompleted(trn: null, TrnLookupStatus.Pending);
+        authStateHelper.AuthenticationState.OnTrnLookupCompleted(findTeachersResult: null, TrnLookupStatus.Pending);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/no-match?{authStateHelper.ToQueryParam()}");
 
@@ -115,7 +115,7 @@ public class NoMatchTests : TestBase
         var authStateHelper = await CreateAuthenticationStateHelper(
             c => c.Trn.IttProviderSet(previousOfficialFirstName: null, previousOfficialLastName: null),
             CustomScopes.Trn, TrnRequirementType.Legacy);
-        authStateHelper.AuthenticationState.OnTrnLookupCompleted(trn: null, TrnLookupStatus.Pending);
+        authStateHelper.AuthenticationState.OnTrnLookupCompleted(findTeachersResult: null, TrnLookupStatus.Pending);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/no-match?{authStateHelper.ToQueryParam()}");
 
@@ -139,7 +139,7 @@ public class NoMatchTests : TestBase
         var authStateHelper = await CreateAuthenticationStateHelper(
             c => c.Trn.IttProviderSet(preferredFirstName: preferredFirstName, preferredLastName: preferredLastName),
             CustomScopes.Trn, TrnRequirementType.Legacy);
-        authStateHelper.AuthenticationState.OnTrnLookupCompleted(trn: null, TrnLookupStatus.Pending);
+        authStateHelper.AuthenticationState.OnTrnLookupCompleted(findTeachersResult: null, TrnLookupStatus.Pending);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/no-match?{authStateHelper.ToQueryParam()}");
 
@@ -160,7 +160,7 @@ public class NoMatchTests : TestBase
         var authStateHelper = await CreateAuthenticationStateHelper(
             c => c.Trn.IttProviderSet(preferredFirstName: null, preferredLastName: null),
             CustomScopes.Trn, TrnRequirementType.Legacy);
-        authStateHelper.AuthenticationState.OnTrnLookupCompleted(trn: null, TrnLookupStatus.Pending);
+        authStateHelper.AuthenticationState.OnTrnLookupCompleted(findTeachersResult: null, TrnLookupStatus.Pending);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/no-match?{authStateHelper.ToQueryParam()}");
 
@@ -184,7 +184,7 @@ public class NoMatchTests : TestBase
         var authStateHelper = await CreateAuthenticationStateHelper(
             c => c.Trn.IttProviderSet(nationalInsuranceNumber: nino),
             CustomScopes.Trn, TrnRequirementType.Legacy);
-        authStateHelper.AuthenticationState.OnTrnLookupCompleted(trn: null, TrnLookupStatus.Pending);
+        authStateHelper.AuthenticationState.OnTrnLookupCompleted(findTeachersResult: null, TrnLookupStatus.Pending);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/no-match?{authStateHelper.ToQueryParam()}");
 
@@ -207,7 +207,7 @@ public class NoMatchTests : TestBase
         var authStateHelper = await CreateAuthenticationStateHelper(
             c => haveQts ? c.Trn.IttProviderSet() : c.Trn.AwardedQtsSet(awardedQts: false),
             CustomScopes.Trn, TrnRequirementType.Legacy);
-        authStateHelper.AuthenticationState.OnTrnLookupCompleted(trn: null, trnLookupStatus: TrnLookupStatus.Pending);
+        authStateHelper.AuthenticationState.OnTrnLookupCompleted(findTeachersResult: null, trnLookupStatus: TrnLookupStatus.Pending);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/no-match?{authStateHelper.ToQueryParam()}");
 
@@ -230,7 +230,7 @@ public class NoMatchTests : TestBase
         var authStateHelper = await CreateAuthenticationStateHelper(
             c => c.Trn.IttProviderSet(ittProviderName: ittProviderName),
             CustomScopes.Trn, TrnRequirementType.Legacy);
-        authStateHelper.AuthenticationState.OnTrnLookupCompleted(trn: null, TrnLookupStatus.Pending);
+        authStateHelper.AuthenticationState.OnTrnLookupCompleted(findTeachersResult: null, TrnLookupStatus.Pending);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/no-match?{authStateHelper.ToQueryParam()}");
 
@@ -251,7 +251,7 @@ public class NoMatchTests : TestBase
         var authStateHelper = await CreateAuthenticationStateHelper(
             c => c.Trn.IttProviderSet(ittProviderName: null),
             CustomScopes.Trn, TrnRequirementType.Legacy);
-        authStateHelper.AuthenticationState.OnTrnLookupCompleted(trn: null, TrnLookupStatus.Pending);
+        authStateHelper.AuthenticationState.OnTrnLookupCompleted(findTeachersResult: null, TrnLookupStatus.Pending);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/no-match?{authStateHelper.ToQueryParam()}");
 
@@ -272,7 +272,7 @@ public class NoMatchTests : TestBase
         var authStateHelper = await CreateAuthenticationStateHelper(
             c => c.Trn.AwardedQtsSet(awardedQts: false),
             CustomScopes.Trn, TrnRequirementType.Legacy);
-        authStateHelper.AuthenticationState.OnTrnLookupCompleted(trn: null, TrnLookupStatus.Pending);
+        authStateHelper.AuthenticationState.OnTrnLookupCompleted(findTeachersResult: null, TrnLookupStatus.Pending);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/no-match?{authStateHelper.ToQueryParam()}");
 
@@ -342,7 +342,7 @@ public class NoMatchTests : TestBase
         var authStateHelper = await CreateAuthenticationStateHelper(ConfigureValidAuthenticationState, CustomScopes.Trn, TrnRequirementType.Legacy);
         var authState = authStateHelper.AuthenticationState;
 
-        authState.OnTrnLookupCompleted(trn: null, TrnLookupStatus.Pending);
+        authState.OnTrnLookupCompleted(findTeachersResult: null, TrnLookupStatus.Pending);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/no-match?{authStateHelper.ToQueryParam()}")
         {
@@ -364,7 +364,7 @@ public class NoMatchTests : TestBase
         var authState = authStateHelper.AuthenticationState;
 
         authState.OnAwardedQtsSet(false);
-        authState.OnTrnLookupCompleted(trn: null, TrnLookupStatus.Pending);
+        authState.OnTrnLookupCompleted(findTeachersResult: null, TrnLookupStatus.Pending);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/no-match?{authStateHelper.ToQueryParam()}")
         {
@@ -398,7 +398,7 @@ public class NoMatchTests : TestBase
         var authState = authStateHelper.AuthenticationState;
 
         authState.OnAwardedQtsSet(false);
-        authState.OnTrnLookupCompleted(trn: null, trnLookupStatus);
+        authState.OnTrnLookupCompleted(findTeachersResult: null, trnLookupStatus);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/no-match?{authStateHelper.ToQueryParam()}")
         {
@@ -426,7 +426,7 @@ public class NoMatchTests : TestBase
     private Func<AuthenticationState, Task> ConfigureValidAuthenticationState(Configure configure) => async s =>
     {
         await configure.Trn.IttProviderSet()(s);
-        s.OnTrnLookupCompleted(trn: null, trnLookupStatus: TrnLookupStatus.Pending);
+        s.OnTrnLookupCompleted(findTeachersResult: null, trnLookupStatus: TrnLookupStatus.Pending);
     };
 
     public static TheoryData<AuthenticationStateConfiguration, string> MissingAnswersData

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/JourneyTests/TrnLookupHelperTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/JourneyTests/TrnLookupHelperTests.cs
@@ -1,11 +1,19 @@
 using Microsoft.Extensions.Logging.Abstractions;
 using TeacherIdentity.AuthServer.Journeys;
 using TeacherIdentity.AuthServer.Services.DqtApi;
+using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
 namespace TeacherIdentity.AuthServer.Tests.JourneyTests;
 
 public class TrnLookupHelperTests
 {
+    private readonly IConfiguration _configuration;
+
+    public TrnLookupHelperTests(TestConfiguration testConfiguration)
+    {
+        _configuration = testConfiguration.Configuration;
+    }
+
     [Fact]
     public async Task LookupTrn_IsCancelled_ReturnsNullAndSetsNullResultOnAuthenticationState()
     {
@@ -22,7 +30,7 @@ public class TrnLookupHelperTests
 
         var logger = new NullLogger<TrnLookupHelper>();
 
-        var helper = new TrnLookupHelper(dqtApiClientMock.Object, logger);
+        var helper = new TrnLookupHelper(dqtApiClientMock.Object, _configuration, logger);
 
         // Act
         var result = await helper.LookupTrn(authenticationState);
@@ -53,7 +61,7 @@ public class TrnLookupHelperTests
 
         var logger = new NullLogger<TrnLookupHelper>();
 
-        var helper = new TrnLookupHelper(dqtApiClientMock.Object, logger);
+        var helper = new TrnLookupHelper(dqtApiClientMock.Object, _configuration, logger);
 
         // Act
         var result = await helper.LookupTrn(authenticationState);
@@ -110,7 +118,7 @@ public class TrnLookupHelperTests
 
         var logger = new NullLogger<TrnLookupHelper>();
 
-        var helper = new TrnLookupHelper(dqtApiClientMock.Object, logger);
+        var helper = new TrnLookupHelper(dqtApiClientMock.Object, _configuration, logger);
 
         // Act
         var result = await helper.LookupTrn(authenticationState);
@@ -152,9 +160,10 @@ public class TrnLookupHelperTests
                 }
             });
 
+
         var logger = new NullLogger<TrnLookupHelper>();
 
-        var helper = new TrnLookupHelper(dqtApiClientMock.Object, logger);
+        var helper = new TrnLookupHelper(dqtApiClientMock.Object, _configuration, logger);
 
         // Act
         var result = await helper.LookupTrn(authenticationState);
@@ -182,7 +191,7 @@ public class TrnLookupHelperTests
 
         var logger = new NullLogger<TrnLookupHelper>();
 
-        var helper = new TrnLookupHelper(dqtApiClientMock.Object, logger);
+        var helper = new TrnLookupHelper(dqtApiClientMock.Object, _configuration, logger);
 
         // Act
         await helper.LookupTrn(authenticationState);
@@ -209,7 +218,7 @@ public class TrnLookupHelperTests
 
         var logger = new NullLogger<TrnLookupHelper>();
 
-        var helper = new TrnLookupHelper(dqtApiClientMock.Object, logger);
+        var helper = new TrnLookupHelper(dqtApiClientMock.Object, _configuration, logger);
 
         // Act
         await helper.LookupTrn(authenticationState);
@@ -235,7 +244,7 @@ public class TrnLookupHelperTests
         var dqtApiClientMock = new Mock<IDqtApiClient>();
         var logger = new NullLogger<TrnLookupHelper>();
 
-        var helper = new TrnLookupHelper(dqtApiClientMock.Object, logger);
+        var helper = new TrnLookupHelper(dqtApiClientMock.Object, _configuration, logger);
 
         // Act
         var (trn, trnLookupStatus) = helper.ResolveTrn(trnLookupResults, authenticationState);
@@ -259,7 +268,7 @@ public class TrnLookupHelperTests
         var dqtApiClientMock = new Mock<IDqtApiClient>();
         var logger = new NullLogger<TrnLookupHelper>();
 
-        var helper = new TrnLookupHelper(dqtApiClientMock.Object, logger);
+        var helper = new TrnLookupHelper(dqtApiClientMock.Object, _configuration, logger);
 
         // Act
         var (trn, trnLookupStatus) = helper.ResolveTrn(trnLookupResults, authenticationState);
@@ -281,7 +290,7 @@ public class TrnLookupHelperTests
         var dqtApiClientMock = new Mock<IDqtApiClient>();
         var logger = new NullLogger<TrnLookupHelper>();
 
-        var helper = new TrnLookupHelper(dqtApiClientMock.Object, logger);
+        var helper = new TrnLookupHelper(dqtApiClientMock.Object, _configuration, logger);
 
         // Act
         var (trn, trnLookupStatus) = helper.ResolveTrn(trnLookupResults, authenticationState);
@@ -303,7 +312,7 @@ public class TrnLookupHelperTests
         var dqtApiClientMock = new Mock<IDqtApiClient>();
         var logger = new NullLogger<TrnLookupHelper>();
 
-        var helper = new TrnLookupHelper(dqtApiClientMock.Object, logger);
+        var helper = new TrnLookupHelper(dqtApiClientMock.Object, _configuration, logger);
 
         // Act
         var (trn, trnLookupStatus) = helper.ResolveTrn(trnLookupResults, authenticationState);
@@ -323,7 +332,7 @@ public class TrnLookupHelperTests
         var dqtApiClientMock = new Mock<IDqtApiClient>();
         var logger = new NullLogger<TrnLookupHelper>();
 
-        var helper = new TrnLookupHelper(dqtApiClientMock.Object, logger);
+        var helper = new TrnLookupHelper(dqtApiClientMock.Object, _configuration, logger);
 
         // Act
         var (trn, trnLookupStatus) = helper.ResolveTrn(trnLookupResults, authenticationState);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/JourneyTests/TrnLookupHelperTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/JourneyTests/TrnLookupHelperTests.cs
@@ -13,7 +13,7 @@ public class TrnLookupHelperTests
         var authenticationState = CreateAuthenticationState();
 
         // Set an existing result on AuthenticationState so we can be sure it's being cleared out
-        authenticationState.OnTrnLookupCompleted(trn: "1234567", TrnLookupStatus.Found);
+        authenticationState.OnTrnLookupCompleted(findTeachersResult: GetTeachersResponseResult("1234567"), TrnLookupStatus.Found);
 
         var dqtApiClientMock = new Mock<IDqtApiClient>();
         dqtApiClientMock
@@ -41,7 +41,7 @@ public class TrnLookupHelperTests
         var authenticationState = CreateAuthenticationState();
 
         // Set an existing result on AuthenticationState so we can be sure it's being cleared out
-        authenticationState.OnTrnLookupCompleted(trn: "1234567", TrnLookupStatus.Found);
+        authenticationState.OnTrnLookupCompleted(findTeachersResult: GetTeachersResponseResult("1234567"), TrnLookupStatus.Found);
 
         var dqtApiClientMock = new Mock<IDqtApiClient>();
         dqtApiClientMock
@@ -72,7 +72,7 @@ public class TrnLookupHelperTests
         var authenticationState = CreateAuthenticationState();
 
         // Set an existing result on AuthenticationState so we can be sure it's being cleared out
-        authenticationState.OnTrnLookupCompleted(trn: "1234567", TrnLookupStatus.Found);
+        authenticationState.OnTrnLookupCompleted(findTeachersResult: GetTeachersResponseResult("1234567"), TrnLookupStatus.Found);
 
         var dqtApiClientMock = new Mock<IDqtApiClient>();
         dqtApiClientMock
@@ -86,6 +86,7 @@ public class TrnLookupHelperTests
                         DateOfBirth = authenticationState.DateOfBirth,
                         EmailAddresses = new[] { authenticationState.EmailAddress! },
                         FirstName = authenticationState.FirstName!,
+                        MiddleName = authenticationState.MiddleName!,
                         LastName = authenticationState.LastName!,
                         HasActiveSanctions = false,
                         NationalInsuranceNumber = authenticationState.NationalInsuranceNumber,
@@ -97,6 +98,7 @@ public class TrnLookupHelperTests
                         DateOfBirth = authenticationState.DateOfBirth,
                         EmailAddresses = new[] { authenticationState.EmailAddress! },
                         FirstName = authenticationState.FirstName!,
+                        MiddleName = authenticationState.MiddleName!,
                         LastName = authenticationState.LastName!,
                         HasActiveSanctions = false,
                         NationalInsuranceNumber = authenticationState.NationalInsuranceNumber,
@@ -140,6 +142,7 @@ public class TrnLookupHelperTests
                         DateOfBirth = authenticationState.DateOfBirth,
                         EmailAddresses = new[] { authenticationState.EmailAddress! },
                         FirstName = authenticationState.FirstName!,
+                        MiddleName = authenticationState.MiddleName!,
                         LastName = authenticationState.LastName!,
                         HasActiveSanctions = false,
                         NationalInsuranceNumber = authenticationState.NationalInsuranceNumber,
@@ -227,7 +230,7 @@ public class TrnLookupHelperTests
     {
         // Arrange
         var authenticationState = CreateAuthenticationState(statedTrn, awardedQts);
-        var trnLookupResults = new[] { "2345678" };
+        var trnLookupResults = new[] { GetTeachersResponseResult("2345678") };
 
         var dqtApiClientMock = new Mock<IDqtApiClient>();
         var logger = new NullLogger<TrnLookupHelper>();
@@ -251,7 +254,7 @@ public class TrnLookupHelperTests
     {
         // Arrange
         var authenticationState = CreateAuthenticationState(statedTrn, awardedQts);
-        var trnLookupResults = new[] { "2345678", "3456789" };
+        var trnLookupResults = new[] { GetTeachersResponseResult("2345678"), GetTeachersResponseResult("3456789") };
 
         var dqtApiClientMock = new Mock<IDqtApiClient>();
         var logger = new NullLogger<TrnLookupHelper>();
@@ -273,7 +276,7 @@ public class TrnLookupHelperTests
     {
         // Arrange
         var authenticationState = CreateAuthenticationState(statedTrn: "1234567", awardedQts);
-        var trnLookupResults = Array.Empty<string>();
+        var trnLookupResults = Array.Empty<FindTeachersResponseResult>();
 
         var dqtApiClientMock = new Mock<IDqtApiClient>();
         var logger = new NullLogger<TrnLookupHelper>();
@@ -295,7 +298,7 @@ public class TrnLookupHelperTests
     {
         // Arrange
         var authenticationState = CreateAuthenticationState(statedTrn, awardedQts: true);
-        var trnLookupResults = Array.Empty<string>();
+        var trnLookupResults = Array.Empty<FindTeachersResponseResult>();
 
         var dqtApiClientMock = new Mock<IDqtApiClient>();
         var logger = new NullLogger<TrnLookupHelper>();
@@ -315,7 +318,7 @@ public class TrnLookupHelperTests
     {
         // Arrange
         var authenticationState = CreateAuthenticationState(statedTrn: null, awardedQts: false);
-        var trnLookupResults = Array.Empty<string>();
+        var trnLookupResults = Array.Empty<FindTeachersResponseResult>();
 
         var dqtApiClientMock = new Mock<IDqtApiClient>();
         var logger = new NullLogger<TrnLookupHelper>();
@@ -351,5 +354,25 @@ public class TrnLookupHelperTests
         authState.OnAwardedQtsSet(awardedQts);
 
         return authState;
+    }
+
+    private FindTeachersResponseResult GetTeachersResponseResult(
+        string trn,
+        string? firstName = null,
+        string? middleName = null,
+        string? lastName = null)
+    {
+        return new FindTeachersResponseResult()
+        {
+            Trn = trn,
+            EmailAddresses = new[] { Faker.Internet.Email() },
+            FirstName = firstName ?? Faker.Name.First(),
+            MiddleName = middleName ?? Faker.Name.Middle(),
+            LastName = lastName ?? Faker.Name.Last(),
+            DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
+            NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber(),
+            Uid = "",
+            HasActiveSanctions = false,
+        };
     }
 }


### PR DESCRIPTION
### Context

For ID accounts that are linked to a TRN, we want to make the ID name match the DQT name.

### Changes proposed in this pull request

Amend the Core + TRN token journeys to use the first, middle and last name from the matched DQT record for the corresponding ID fields.

Amend the /admin/assign-trn journey to set the first, middle and last names on the ID account to match those from the assigned TRN.

Amend the sign in process for an existing user across all journeys to call the DQT API if the user has a TRN and update the first, middle and last name fields if they are different (+ issue an event).

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
