### PR TITLE
Add admin UI for unlinking a TRN

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230623095958_RemoveTrnLookupStatusCheckConstraint.Designer.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230623095958_RemoveTrnLookupStatusCheckConstraint.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeacherIdentity.AuthServer.Models;
@@ -12,9 +13,11 @@ using TeacherIdentity.AuthServer.Models;
 namespace TeacherIdentity.AuthServer.Migrations
 {
     [DbContext(typeof(TeacherIdentityServerDbContext))]
-    partial class TeacherIdentityServerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230623095958_RemoveTrnLookupStatusCheckConstraint")]
+    partial class RemoveTrnLookupStatusCheckConstraint
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230623095958_RemoveTrnLookupStatusCheckConstraint.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230623095958_RemoveTrnLookupStatusCheckConstraint.cs
@@ -1,0 +1,27 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeacherIdentity.AuthServer.Migrations
+{
+    /// <inheritdoc />
+    public partial class RemoveTrnLookupStatusCheckConstraint : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropCheckConstraint(
+                name: "ck_trn_lookup_status",
+                table: "users");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddCheckConstraint(
+                name: "ck_trn_lookup_status",
+                table: "users",
+                sql: "(completed_trn_lookup is null and trn is null) or trn_lookup_status is not null");
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/Mappings/UserMapping.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/Mappings/UserMapping.cs
@@ -7,9 +7,7 @@ public class UserMapping : IEntityTypeConfiguration<User>
 {
     public void Configure(EntityTypeBuilder<User> builder)
     {
-        builder.ToTable(
-            "users",
-            t => t.HasCheckConstraint("ck_trn_lookup_status", "(completed_trn_lookup is null and trn is null) or trn_lookup_status is not null"));
+        builder.ToTable("users");
         builder.HasKey(u => u.UserId);
         builder.Property(u => u.EmailAddress).HasMaxLength(EmailAddress.EmailAddressMaxLength).IsRequired().UseCollation("case_insensitive");
         builder.HasIndex(u => u.EmailAddress).IsUnique().HasDatabaseName(User.EmailAddressUniqueIndexName).HasFilter("is_deleted = false");

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Remove.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Remove.cshtml
@@ -1,0 +1,53 @@
+@page "/admin/users/{userId}/remove-trn"
+@model TeacherIdentity.AuthServer.Pages.Admin.AssignTrn.RemoveModel
+@{
+    ViewBag.Title = "Remove TRN";
+}
+
+@section BeforeContent {
+    <govuk-back-link asp-page="/Admin/User" asp-route-userId="@Model.UserId" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+        <form asp-page="Remove" asp-route-userId="@Model.UserId">
+            <h1 class="govuk-heading-l">Remove TRN</h1>
+
+            <govuk-warning-text icon-fallback-text="Warning">
+                Some services may not automatically handle a user’s accounts having its TRN removed.
+                Be sure to communicate this change to relevant parties.
+            </govuk-warning-text>
+
+            <section class="x-govuk-summary-card govuk-!-margin-bottom-6">
+                <header class="x-govuk-summary-card__header">
+                    <h2 class="x-govuk-summary-card__title">
+                        Account details
+                    </h2>
+                </header>
+
+                <div class="x-govuk-summary-card__body">
+                    <govuk-summary-list>
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>Email address</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value class="empty-hyphens">@Html.ShyEmail(Model.Email!)</govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value>@Model.Name</govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                        <govuk-summary-list-row>
+                            <govuk-summary-list-row-key>TRN</govuk-summary-list-row-key>
+                            <govuk-summary-list-row-value>@Model.Trn</govuk-summary-list-row-value>
+                        </govuk-summary-list-row>
+                    </govuk-summary-list>
+                </div>
+            </section>
+
+            <govuk-checkboxes asp-for="ConfirmRemoveTrn">
+                <govuk-checkboxes-item value="@true">Remove TRN from this account</govuk-checkboxes-item>
+            </govuk-checkboxes>
+
+            <govuk-button type="submit" class="govuk-button--warning">Confirm</govuk-button>
+        </form>
+    </div>
+</div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Remove.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Remove.cshtml.cs
@@ -1,0 +1,90 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Infrastructure.Security;
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.Pages.Admin.AssignTrn;
+
+[Authorize(AuthorizationPolicies.GetAnIdentitySupport)]
+public class RemoveModel : PageModel
+{
+    private readonly TeacherIdentityServerDbContext _dbContext;
+    private readonly IClock _clock;
+    private Models.User? _user;
+
+    public RemoveModel(
+        TeacherIdentityServerDbContext dbContext,
+        IClock clock)
+    {
+        _dbContext = dbContext;
+        _clock = clock;
+    }
+
+    [FromRoute(Name = "userId")]
+    public Guid UserId { get; set; }
+
+    public string? Email => _user?.EmailAddress;
+
+    public string? Name => $"{_user?.FirstName} {_user?.LastName}";
+
+    public string? Trn => _user?.Trn;
+
+    [BindProperty]
+    public bool ConfirmRemoveTrn { get; set; }
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (!ConfirmRemoveTrn)
+        {
+            ModelState.AddModelError(nameof(ConfirmRemoveTrn), "Confirm you want to remove the TRN");
+            return this.PageWithErrors();
+        }
+
+        _user!.Trn = null;
+        _user.TrnAssociationSource = null;
+        _user.TrnLookupStatus = null;
+        _user.Updated = _clock.UtcNow;
+
+        _dbContext.AddEvent(new UserUpdatedEvent()
+        {
+            Changes = UserUpdatedEventChanges.Trn | UserUpdatedEventChanges.TrnLookupStatus,
+            CreatedUtc = _clock.UtcNow,
+            Source = UserUpdatedEventSource.SupportUi,
+            UpdatedByClientId = null,
+            UpdatedByUserId = User.GetUserId(),
+            User = _user
+        });
+
+        await _dbContext.SaveChangesAsync();
+
+        TempData.SetFlashSuccess("TRN removed");
+        return RedirectToPage("/Admin/User", new { UserId });
+    }
+
+    public override async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        _user = await _dbContext.Users.SingleOrDefaultAsync(u => u.UserId == UserId);
+
+        if (_user is null || _user.UserType != UserType.Default)
+        {
+            context.Result = NotFound();
+            return;
+        }
+
+        if (_user.Trn is null)
+        {
+            context.Result = BadRequest();
+            return;
+        }
+
+        await next();
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AssignTrn/RemoveTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AssignTrn/RemoveTests.cs
@@ -1,0 +1,189 @@
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Events;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Admin.AssignTrn;
+
+public class RemoveTests : TestBase
+{
+    public RemoveTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_UnauthenticatedUser_RedirectsToSignIn()
+    {
+        var user = await TestData.CreateUser(userType: Models.UserType.Default, hasTrn: true);
+
+        await UnauthenticatedUser_RedirectsToSignIn(HttpMethod.Get, $"/admin/users/{user.UserId}/remove-trn");
+    }
+
+    [Fact]
+    public async Task Get_AuthenticatedUserDoesNotHavePermission_ReturnsForbidden()
+    {
+        var user = await TestData.CreateUser(userType: Models.UserType.Default, hasTrn: true);
+
+        await AuthenticatedUserDoesNotHavePermission_ReturnsForbidden(HttpMethod.Get, $"/admin/users/{user.UserId}/remove-trn");
+    }
+
+    [Fact]
+    public async Task Get_UserDoesNotExist_ReturnsNotFound()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/users/{userId}/remove-trn");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_UserDoesNotHaveTrnAssigned_ReturnsBadRequest()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: Models.UserType.Default, hasTrn: false);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/users/{user.UserId}/remove-trn");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_ReturnsOk()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: Models.UserType.Default, hasTrn: true);
+        var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/users/{user.UserId}/remove-trn");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_UnauthenticatedUser_RedirectsToSignIn()
+    {
+        var user = await TestData.CreateUser(userType: Models.UserType.Default, hasTrn: true);
+
+        await UnauthenticatedUser_RedirectsToSignIn(HttpMethod.Post, $"/admin/users/{user.UserId}/remove-trn");
+    }
+
+    [Fact]
+    public async Task Post_AuthenticatedUserDoesNotHavePermission_ReturnsForbidden()
+    {
+        var user = await TestData.CreateUser(userType: Models.UserType.Default, hasTrn: true);
+
+        await AuthenticatedUserDoesNotHavePermission_ReturnsForbidden(HttpMethod.Post, $"/admin/users/{user.UserId}/remove-trn");
+    }
+
+    [Fact]
+    public async Task Post_UserDoesNotExist_ReturnsNotFound()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{userId}/remove-trn")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "ConfirmRemoveTrn", bool.TrueString }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status404NotFound, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_UserDoesNotHaveTrnAssigned_ReturnsBadRequest()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: Models.UserType.Default, hasTrn: false);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{user.UserId}/remove-trn")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "ConfirmRemoveTrn", bool.TrueString }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_ConfirmNotChecked_ReturnsErrors()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: Models.UserType.Default, hasTrn: true);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{user.UserId}/remove-trn")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "ConfirmRemoveTrn", "Confirm you want to remove the TRN");
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_RemovesTrnCreatesEventAndRedirects()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: Models.UserType.Default, hasTrn: true);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"/admin/users/{user.UserId}/remove-trn")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "ConfirmRemoveTrn", bool.TrueString }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/admin/users/{user.UserId}", response.Headers.Location?.OriginalString);
+
+        await TestData.WithDbContext(async dbContext =>
+        {
+            user = await dbContext.Users.SingleAsync(u => u.UserId == user.UserId);
+            Assert.Null(user.Trn);
+            Assert.Null(user.TrnAssociationSource);
+            Assert.Null(user.TrnLookupStatus);
+            Assert.Equal(Clock.UtcNow, user.Updated);
+        });
+
+        EventObserver.AssertEventsSaved(
+            e =>
+            {
+                var userUpdatedEvent = Assert.IsType<UserUpdatedEvent>(e);
+                Assert.Equal(Clock.UtcNow, userUpdatedEvent.CreatedUtc);
+                Assert.Equal(UserUpdatedEventSource.SupportUi, userUpdatedEvent.Source);
+                Assert.Equal(UserUpdatedEventChanges.Trn | UserUpdatedEventChanges.TrnLookupStatus, userUpdatedEvent.Changes);
+                Assert.Equal(user.UserId, userUpdatedEvent.User.UserId);
+                Assert.Null(user.Trn);
+                Assert.Null(user.TrnLookupStatus);
+            });
+    }
+}


### PR DESCRIPTION
We have some bad data in prod where an user's account is linked to the wrong TRN. This is a quick admin UI for unlinking a TRN from an ID account. It's deliberately not linked to from the nav to make it somewhat hidden; we don't want people using this lightly.

I've had to remove a check constraint from the DB as it will now be possible for a user to have a `null` `TrnLookupStatus` even after they've gone through TRN lookup journey.