### PR TITLE
Fix NRE on TrnLookupStatus for webhook messages

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Notifications/Messages/User.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Notifications/Messages/User.cs
@@ -1,5 +1,3 @@
-using Optional;
-
 namespace TeacherIdentity.AuthServer.Notifications.Messages;
 
 public record User
@@ -13,7 +11,7 @@ public record User
     public required DateOnly? DateOfBirth { get; init; }
     public required string? Trn { get; init; }
     public required string? MobileNumber { get; init; }
-    public required Option<TrnLookupStatus> TrnLookupStatus { get; init; }
+    public required TrnLookupStatus? TrnLookupStatus { get; init; }
 
     public static User FromEvent(Events.User user) => new()
     {
@@ -24,7 +22,7 @@ public record User
         LastName = user.LastName,
         PreferredName = user.PreferredName,
         Trn = user.Trn,
-        TrnLookupStatus = user.TrnLookupStatus.ToOption(),
+        TrnLookupStatus = user.TrnLookupStatus,
         MobileNumber = user.MobileNumber,
         UserId = user.UserId
     };

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Notifications/Messages/UserUpdatedMessage.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Notifications/Messages/UserUpdatedMessage.cs
@@ -19,5 +19,5 @@ public record UserUpdatedMessageChanges
     public required Option<DateOnly?> DateOfBirth { get; init; }
     public required Option<string?> Trn { get; init; }
     public required Option<string?> MobileNumber { get; init; }
-    public required Option<TrnLookupStatus> TrnLookupStatus { get; init; }
+    public required Option<TrnLookupStatus?> TrnLookupStatus { get; init; }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Notifications/PublishNotificationsEventObserver.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Notifications/PublishNotificationsEventObserver.cs
@@ -59,7 +59,7 @@ public class PublishNotificationsEventObserver : IEventObserver
                         LastName = userUpdated.Changes.HasFlag(UserUpdatedEventChanges.LastName) ? Option.Some(userUpdated.User.LastName) : default,
                         Trn = userUpdated.Changes.HasFlag(UserUpdatedEventChanges.Trn) ? Option.Some(userUpdated.User.Trn) : default,
                         MobileNumber = userUpdated.Changes.HasFlag(UserUpdatedEventChanges.MobileNumber) ? Option.Some(userUpdated.User.MobileNumber) : default,
-                        TrnLookupStatus = userUpdated.Changes.HasFlag(UserUpdatedEventChanges.TrnLookupStatus) ? Option.Some(userUpdated.User.TrnLookupStatus!.Value) : default
+                        TrnLookupStatus = userUpdated.Changes.HasFlag(UserUpdatedEventChanges.TrnLookupStatus) ? Option.Some(userUpdated.User.TrnLookupStatus) : default
                     }
                 },
                 MessageType = UserUpdatedMessage.MessageTypeName,


### PR DESCRIPTION
With the preceding change to remove a user's TRN, it's now possible that `TrnLookupStatus` can be changed to `null`.