### PR TITLE
Add end to end tests for webhooks

### DIFF
--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/HostFixture.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/HostFixture.cs
@@ -62,7 +62,7 @@ public class HostFixture : WebApplicationFactory<TeacherIdentity.AuthServer.Prog
 
     public Mock<IZendeskApiWrapper> ZendeskApiWrapper => TestScopedServices.Current.ZendeskApiWrapper;
 
-    public async Task Initialize()
+    public virtual async Task Initialize()
     {
         await DbHelper.EnsureSchema();
 
@@ -154,13 +154,13 @@ public class HostFixture : WebApplicationFactory<TeacherIdentity.AuthServer.Prog
             services.AddSingleton<IEventObserver, CaptureEventObserver>();
             services.AddTransient(_ => DqtApiClient.Object);
             services.AddTransient(_ => NotificationSender.Object);
-            services.AddTransient(_ => NotificationPublisher.Object);
             services.AddTransient(_ => RateLimitStore.Object);
             services.AddTransient<IRequestClientIpProvider, TestRequestClientIpProvider>();
             services.Decorate<IUserVerificationService>(inner => SpyRegistry.Get<IUserVerificationService>().Wrap(inner));
             services.AddTransient(_ => ZendeskApiWrapper.Object);
             services.AddTransient(_ => UserImportCsvStorageService.Object);
             services.AddTransient(_ => DqtEvidenceStorageService.Object);
+            ConfigureWebHooks(services);
         });
     }
 
@@ -170,6 +170,11 @@ public class HostFixture : WebApplicationFactory<TeacherIdentity.AuthServer.Prog
         builder.ConfigureServices(services => services.Configure<TestServerOptions>(o => o.PreserveExecutionContext = true));
 
         return base.CreateHost(builder);
+    }
+
+    protected virtual void ConfigureWebHooks(IServiceCollection services)
+    {
+        services.AddTransient(_ => NotificationPublisher.Object);
     }
 
     private class RemoveAutoValidateAntiforgeryPageApplicationModelProvider : IPageApplicationModelProvider

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Startup.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Startup.cs
@@ -1,4 +1,5 @@
 using TeacherIdentity.AuthServer.Tests.Infrastructure;
+using TeacherIdentity.AuthServer.Tests.WebHooks;
 
 namespace TeacherIdentity.AuthServer.Tests;
 
@@ -10,11 +11,14 @@ public class Startup
         var dbHelper = new DbHelper(testConfiguration.Configuration.GetConnectionString("DefaultConnection") ??
             throw new Exception("Connection string DefaultConnection is missing."));
         var hostFixture = new HostFixture(testConfiguration, dbHelper);
-
         hostFixture.Initialize().GetAwaiter().GetResult();
+
+        var webhooksHostFixture = new WebHooksHostFixture(testConfiguration, dbHelper);
+        webhooksHostFixture.Initialize().GetAwaiter().GetResult();
 
         services.AddSingleton(testConfiguration);
         services.AddSingleton(dbHelper);
         services.AddSingleton(hostFixture);
+        services.AddSingleton(webhooksHostFixture);
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/WebHooks/IWebHookRequestObserver.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/WebHooks/IWebHookRequestObserver.cs
@@ -4,7 +4,7 @@ public interface IWebHookRequestObserver
 {
     void Initialize();
 
-    Task OnWebHookRequestReceived(WebHookRequest webHookRequest);
+    void OnWebHookRequestReceived(WebHookRequest webHookRequest);
 
     void AssertWebHookRequestsReceived(params Action<WebHookRequest>[] requestInspectors);
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/WebHooks/IWebHookRequestObserver.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/WebHooks/IWebHookRequestObserver.cs
@@ -1,0 +1,10 @@
+namespace TeacherIdentity.AuthServer.Tests.WebHooks;
+
+public interface IWebHookRequestObserver
+{
+    void Initialize();
+
+    Task OnWebHookRequestReceived(WebHookRequest webHookRequest);
+
+    void AssertWebHookRequestsReceived(params Action<WebHookRequest>[] requestInspectors);
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/WebHooks/TestBase.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/WebHooks/TestBase.cs
@@ -1,0 +1,33 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Caching.Memory;
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.Tests.WebHooks;
+
+public class TestBase : IAsyncLifetime
+{
+    protected TestBase(WebHooksHostFixture hostFixture)
+    {
+        HostFixture = hostFixture;
+        HostFixture.ResetMocks();
+        HostFixture.InitializeWebHookRequestObserver();
+    }
+
+    public async Task InitializeAsync()
+    {
+        using var scope = HostFixture.Services.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<TeacherIdentityServerDbContext>();
+        await dbContext.Database.ExecuteSqlAsync($"delete from webhooks");
+
+        var memoryCache = HostFixture.Services.GetRequiredService<IMemoryCache>();
+        memoryCache.Remove(MemoryCacheKeys.WebHooks);
+    }
+
+    public Task DisposeAsync() => Task.CompletedTask;
+
+    public IWebHookRequestObserver WebHookRequestObserver => HostFixture.WebHookRequestObserver;
+
+    public WebHooksHostFixture HostFixture { get; }
+
+    public Task ConfigureTestWebHook(WebHookMessageTypes webHookMessageTypes, string secret) => HostFixture.ConfigureTestWebHook(webHookMessageTypes, secret);
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/WebHooks/TestBase.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/WebHooks/TestBase.cs
@@ -9,7 +9,6 @@ public class TestBase : IAsyncLifetime
     protected TestBase(WebHooksHostFixture hostFixture)
     {
         HostFixture = hostFixture;
-        HostFixture.ResetMocks();
         HostFixture.InitializeWebHookRequestObserver();
     }
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/WebHooks/WebHookRequest.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/WebHooks/WebHookRequest.cs
@@ -1,8 +1,8 @@
 namespace TeacherIdentity.AuthServer.Tests.WebHooks;
 
-public class WebHookRequest
+public record WebHookRequest
 {
-    public string? ContentType { get; set; }
-    public string? Signature { get; set; }
-    public string? Body { get; set; }
+    public required string ContentType { get; init; }
+    public required string Signature { get; init; }
+    public required string Body { get; init; }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/WebHooks/WebHookRequest.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/WebHooks/WebHookRequest.cs
@@ -1,0 +1,8 @@
+namespace TeacherIdentity.AuthServer.Tests.WebHooks;
+
+public class WebHookRequest
+{
+    public string? ContentType { get; set; }
+    public string? Signature { get; set; }
+    public string? Body { get; set; }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/WebHooks/WebHookRequestObserver.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/WebHooks/WebHookRequestObserver.cs
@@ -6,7 +6,7 @@ public class WebHookRequestObserver : IWebHookRequestObserver
 
     public void Initialize() => _requests.Value ??= new List<WebHookRequest>();
 
-    public Task OnWebHookRequestReceived(WebHookRequest webHookRequest)
+    public void OnWebHookRequestReceived(WebHookRequest webHookRequest)
     {
         if (_requests.Value is null)
         {
@@ -14,8 +14,6 @@ public class WebHookRequestObserver : IWebHookRequestObserver
         }
 
         _requests.Value.Add(webHookRequest);
-
-        return Task.CompletedTask;
     }
 
     public void AssertWebHookRequestsReceived(params Action<WebHookRequest>[] requestInspectors)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/WebHooks/WebHookRequestObserver.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/WebHooks/WebHookRequestObserver.cs
@@ -1,0 +1,26 @@
+namespace TeacherIdentity.AuthServer.Tests.WebHooks;
+
+public class WebHookRequestObserver : IWebHookRequestObserver
+{
+    private readonly AsyncLocal<List<WebHookRequest>> _requests = new();
+
+    public void Initialize() => _requests.Value ??= new List<WebHookRequest>();
+
+    public Task OnWebHookRequestReceived(WebHookRequest webHookRequest)
+    {
+        if (_requests.Value is null)
+        {
+            throw new InvalidOperationException("Not initialized.");
+        }
+
+        _requests.Value.Add(webHookRequest);
+
+        return Task.CompletedTask;
+    }
+
+    public void AssertWebHookRequestsReceived(params Action<WebHookRequest>[] requestInspectors)
+    {
+        var requests = (_requests.Value ?? new()).AsReadOnly();
+        Assert.Collection(requests, requestInspectors);
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/WebHooks/WebHooksEndToEndTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/WebHooks/WebHooksEndToEndTests.cs
@@ -1,5 +1,3 @@
-using System.Security.Cryptography;
-using System.Text;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Optional;
@@ -7,6 +5,7 @@ using TeacherIdentity.AuthServer.Events;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Notifications;
 using TeacherIdentity.AuthServer.Notifications.Messages;
+using TeacherIdentity.AuthServer.Notifications.WebHooks;
 using User = TeacherIdentity.AuthServer.Notifications.Messages.User;
 
 namespace TeacherIdentity.AuthServer.Tests.WebHooks;
@@ -56,7 +55,7 @@ public class WebHooksEndToEndTests : TestBase
                 Assert.NotNull(r.Signature);
                 Assert.NotNull(r.Body);
                 Assert.Equal("application/json", r.ContentType);
-                var expectedSignature = GenerateExpectedSignature(secret, r.Body);
+                var expectedSignature = WebHookNotificationSender.CalculateSignature(secret, r.Body);
                 Assert.Equal(expectedSignature, r.Signature);
 
                 var expectedJson = JsonSerializer.SerializeToNode(new
@@ -153,7 +152,7 @@ public class WebHooksEndToEndTests : TestBase
                 Assert.NotNull(r.Signature);
                 Assert.NotNull(r.Body);
                 Assert.Equal("application/json", r.ContentType);
-                var expectedSignature = GenerateExpectedSignature(secret, r.Body);
+                var expectedSignature = WebHookNotificationSender.CalculateSignature(secret, r.Body);
                 Assert.Equal(expectedSignature, r.Signature);
 
                 var expectedJson = JsonSerializer.SerializeToNode(new
@@ -298,7 +297,7 @@ public class WebHooksEndToEndTests : TestBase
                 Assert.NotNull(r.Signature);
                 Assert.NotNull(r.Body);
                 Assert.Equal("application/json", r.ContentType);
-                var expectedSignature = GenerateExpectedSignature(secret, r.Body);
+                var expectedSignature = WebHookNotificationSender.CalculateSignature(secret, r.Body);
                 Assert.Equal(expectedSignature, r.Signature);
 
                 var expectedJson = JsonSerializer.SerializeToNode(new
@@ -393,7 +392,7 @@ public class WebHooksEndToEndTests : TestBase
                 Assert.NotNull(r.Signature);
                 Assert.NotNull(r.Body);
                 Assert.Equal("application/json", r.ContentType);
-                var expectedSignature = GenerateExpectedSignature(secret, r.Body);
+                var expectedSignature = WebHookNotificationSender.CalculateSignature(secret, r.Body);
                 Assert.Equal(expectedSignature, r.Signature);
 
                 var expectedJson = JsonSerializer.SerializeToNode(new
@@ -429,12 +428,5 @@ public class WebHooksEndToEndTests : TestBase
         {
             WebHookRequestObserver.AssertWebHookRequestsReceived(Array.Empty<Action<WebHookRequest>>());
         }
-    }
-
-    private static string GenerateExpectedSignature(string secret, string content)
-    {
-        var key = Encoding.UTF8.GetBytes(secret);
-        var source = Encoding.UTF8.GetBytes(content);
-        return Convert.ToHexString(HMACSHA256.HashData(key, source));
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/WebHooks/WebHooksEndToEndTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/WebHooks/WebHooksEndToEndTests.cs
@@ -1,0 +1,440 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Optional;
+using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Notifications;
+using TeacherIdentity.AuthServer.Notifications.Messages;
+using User = TeacherIdentity.AuthServer.Notifications.Messages.User;
+
+namespace TeacherIdentity.AuthServer.Tests.WebHooks;
+
+[Collection(nameof(DisableParallelization))]
+public class WebHooksEndToEndTests : TestBase
+{
+    public WebHooksEndToEndTests(WebHooksHostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Theory]
+    [InlineData(WebHookMessageTypes.UserUpdated)]
+    [InlineData(WebHookMessageTypes.UserUpdated | WebHookMessageTypes.UserMerged)]
+    [InlineData(WebHookMessageTypes.UserUpdated | WebHookMessageTypes.UserCreated)]
+    [InlineData(WebHookMessageTypes.UserMerged)]
+    [InlineData(WebHookMessageTypes.UserMerged | WebHookMessageTypes.UserCreated)]
+    [InlineData(WebHookMessageTypes.UserCreated)]
+    [InlineData(WebHookMessageTypes.All)]
+    public async Task Ping_WhenPublished_IsReceivedByWebHookEndpointRegardlessOfMessageTypesSubscribedTo(WebHookMessageTypes webHookMessageTypesSubscribedTo)
+    {
+        // Arrange
+        var notificationPublisher = HostFixture.Services.GetRequiredService<INotificationPublisher>();
+        var secret = "Thisismywebhooksecret";
+        await ConfigureTestWebHook(webHookMessageTypesSubscribedTo, secret);
+
+        // Act
+        var pingNotification = new NotificationEnvelope()
+        {
+            NotificationId = Guid.NewGuid(),
+            Message = new PingMessage()
+            {
+                WebHookId = HostFixture.TestWebHookId
+            },
+            MessageType = PingMessage.MessageTypeName,
+            TimeUtc = HostFixture.Clock.UtcNow
+        };
+
+        await notificationPublisher.PublishNotification(pingNotification);
+
+        // Assert
+        WebHookRequestObserver.AssertWebHookRequestsReceived(
+            r =>
+            {
+                Assert.NotNull(r.ContentType);
+                Assert.NotNull(r.Signature);
+                Assert.NotNull(r.Body);
+                Assert.Equal("application/json", r.ContentType);
+                var expectedSignature = GenerateExpectedSignature(secret, r.Body);
+                Assert.Equal(expectedSignature, r.Signature);
+
+                var expectedJson = JsonSerializer.SerializeToNode(new
+                {
+                    notificationId = pingNotification.NotificationId,
+                    message = new
+                    {
+                    },
+                    messageType = PingMessage.MessageTypeName,
+                    timeUtc = HostFixture.Clock.UtcNow
+                });
+
+                AssertEx.JsonEquals(
+                    expectedJson,
+                    JsonNode.Parse(r.Body));
+            });
+    }
+
+    [Theory]
+    [InlineData(WebHookMessageTypes.UserUpdated, UserUpdatedEventChanges.DateOfBirth | UserUpdatedEventChanges.EmailAddress | UserUpdatedEventChanges.FirstName | UserUpdatedEventChanges.MiddleName | UserUpdatedEventChanges.LastName | UserUpdatedEventChanges.Trn | UserUpdatedEventChanges.MobileNumber | UserUpdatedEventChanges.TrnLookupStatus, true)]
+    [InlineData(WebHookMessageTypes.UserUpdated, UserUpdatedEventChanges.DateOfBirth, true)]
+    [InlineData(WebHookMessageTypes.UserUpdated, UserUpdatedEventChanges.EmailAddress, true)]
+    [InlineData(WebHookMessageTypes.UserUpdated, UserUpdatedEventChanges.FirstName, true)]
+    [InlineData(WebHookMessageTypes.UserUpdated, UserUpdatedEventChanges.MiddleName, true)]
+    [InlineData(WebHookMessageTypes.UserUpdated, UserUpdatedEventChanges.LastName, true)]
+    [InlineData(WebHookMessageTypes.UserUpdated, UserUpdatedEventChanges.Trn, true)]
+    [InlineData(WebHookMessageTypes.UserUpdated, UserUpdatedEventChanges.MobileNumber, true)]
+    [InlineData(WebHookMessageTypes.UserUpdated, UserUpdatedEventChanges.TrnLookupStatus, true)]
+    [InlineData(WebHookMessageTypes.UserUpdated | WebHookMessageTypes.UserMerged, UserUpdatedEventChanges.DateOfBirth, true)]
+    [InlineData(WebHookMessageTypes.UserUpdated | WebHookMessageTypes.UserCreated, UserUpdatedEventChanges.DateOfBirth, true)]
+    [InlineData(WebHookMessageTypes.UserMerged, UserUpdatedEventChanges.DateOfBirth, false)]
+    [InlineData(WebHookMessageTypes.UserMerged | WebHookMessageTypes.UserCreated, UserUpdatedEventChanges.DateOfBirth, false)]
+    [InlineData(WebHookMessageTypes.UserCreated, UserUpdatedEventChanges.DateOfBirth, false)]
+    [InlineData(WebHookMessageTypes.All, UserUpdatedEventChanges.DateOfBirth, true)]
+    public async Task UserUpdated_WhenPublished_IsOnlySentToWebHookEndpointsWhichSubscribe(
+        WebHookMessageTypes webHookMessageTypesSubscribedTo,
+        UserUpdatedEventChanges userUpdatedEventChanges,
+        bool expectedToReceiveMessage)
+    {
+        // Arrange
+        var notificationPublisher = HostFixture.Services.GetRequiredService<INotificationPublisher>();
+        var secret = "Thisismywebhooksecret";
+        await ConfigureTestWebHook(webHookMessageTypesSubscribedTo, secret);
+
+        var user = new User()
+        {
+            UserId = new Guid("3828dc03-7500-402a-beeb-acd45b635fc3"),
+            DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
+            EmailAddress = Faker.Internet.Email(),
+            FirstName = Faker.Name.First(),
+            MiddleName = Faker.Name.Middle(),
+            LastName = Faker.Name.Last(),
+            PreferredName = Faker.Name.FullName(),
+            MobileNumber = Faker.Phone.Number(),
+            Trn = "7754311",
+            TrnLookupStatus = TrnLookupStatus.Found,
+        };
+
+        var UserUpdatedMessageChanges = new UserUpdatedMessageChanges
+        {
+            DateOfBirth = userUpdatedEventChanges.HasFlag(UserUpdatedEventChanges.DateOfBirth) ? Option.Some(user.DateOfBirth) : default,
+            EmailAddress = userUpdatedEventChanges.HasFlag(UserUpdatedEventChanges.EmailAddress) ? Option.Some(user.EmailAddress) : default,
+            FirstName = userUpdatedEventChanges.HasFlag(UserUpdatedEventChanges.FirstName) ? Option.Some(user.FirstName) : default,
+            MiddleName = userUpdatedEventChanges.HasFlag(UserUpdatedEventChanges.MiddleName) ? Option.Some<string?>(user.MiddleName) : default,
+            LastName = userUpdatedEventChanges.HasFlag(UserUpdatedEventChanges.LastName) ? Option.Some(user.LastName) : default,
+            Trn = userUpdatedEventChanges.HasFlag(UserUpdatedEventChanges.Trn) ? Option.Some<string?>(user.Trn) : default,
+            MobileNumber = userUpdatedEventChanges.HasFlag(UserUpdatedEventChanges.MobileNumber) ? Option.Some<string?>(user.MobileNumber) : default,
+            TrnLookupStatus = userUpdatedEventChanges.HasFlag(UserUpdatedEventChanges.TrnLookupStatus) ? Option.Some(user.TrnLookupStatus) : default
+        };
+
+        // Act
+        var userUpdatedNotification = new NotificationEnvelope()
+        {
+            NotificationId = Guid.NewGuid(),
+            Message = new UserUpdatedMessage()
+            {
+                User = user,
+                Changes = UserUpdatedMessageChanges
+
+            },
+            MessageType = UserUpdatedMessage.MessageTypeName,
+            TimeUtc = HostFixture.Clock.UtcNow
+        };
+
+        await notificationPublisher.PublishNotification(userUpdatedNotification);
+
+        // Assert
+        if (expectedToReceiveMessage)
+        {
+            WebHookRequestObserver.AssertWebHookRequestsReceived(
+            r =>
+            {
+                Assert.NotNull(r.ContentType);
+                Assert.NotNull(r.Signature);
+                Assert.NotNull(r.Body);
+                Assert.Equal("application/json", r.ContentType);
+                var expectedSignature = GenerateExpectedSignature(secret, r.Body);
+                Assert.Equal(expectedSignature, r.Signature);
+
+                var expectedJson = JsonSerializer.SerializeToNode(new
+                {
+                    notificationId = userUpdatedNotification.NotificationId,
+                    message = new
+                    {
+                        user = new
+                        {
+                            userId = user.UserId,
+                            dateOfBirth = user.DateOfBirth,
+                            emailAddress = user.EmailAddress,
+                            firstName = user.FirstName,
+                            middleName = user.MiddleName,
+                            lastName = user.LastName,
+                            preferredName = user.PreferredName,
+                            mobileNumber = user.MobileNumber,
+                            trn = user.Trn,
+                            trnLookupStatus = user.TrnLookupStatus.ToString()
+                        },
+                        changes = new
+                        {
+                            dateOfBirth = user.DateOfBirth,
+                            emailAddress = user.EmailAddress,
+                            firstName = user.FirstName,
+                            middleName = user.MiddleName,
+                            lastName = user.LastName,
+                            mobileNumber = user.MobileNumber,
+                            trn = user.Trn,
+                            trnLookupStatus = user.TrnLookupStatus.ToString()
+                        }
+                    },
+                    messageType = UserUpdatedMessage.MessageTypeName,
+                    timeUtc = HostFixture.Clock.UtcNow
+                });
+
+                var changes = expectedJson!["message"]!["changes"]!.AsObject();
+                if (!userUpdatedEventChanges.HasFlag(UserUpdatedEventChanges.DateOfBirth))
+                {
+                    changes.Remove("dateOfBirth");
+                }
+
+                if (!userUpdatedEventChanges.HasFlag(UserUpdatedEventChanges.EmailAddress))
+                {
+                    changes.Remove("emailAddress");
+                }
+
+                if (!userUpdatedEventChanges.HasFlag(UserUpdatedEventChanges.FirstName))
+                {
+                    changes.Remove("firstName");
+                }
+
+                if (!userUpdatedEventChanges.HasFlag(UserUpdatedEventChanges.MiddleName))
+                {
+                    changes.Remove("middleName");
+                }
+
+                if (!userUpdatedEventChanges.HasFlag(UserUpdatedEventChanges.LastName))
+                {
+                    changes.Remove("lastName");
+                }
+
+                if (!userUpdatedEventChanges.HasFlag(UserUpdatedEventChanges.MobileNumber))
+                {
+                    changes.Remove("mobileNumber");
+                }
+
+                if (!userUpdatedEventChanges.HasFlag(UserUpdatedEventChanges.Trn))
+                {
+                    changes.Remove("trn");
+                }
+
+                if (!userUpdatedEventChanges.HasFlag(UserUpdatedEventChanges.TrnLookupStatus))
+                {
+                    changes.Remove("trnLookupStatus");
+                }
+
+                AssertEx.JsonEquals(
+                    expectedJson,
+                    JsonNode.Parse(r.Body));
+            });
+        }
+        else
+        {
+            WebHookRequestObserver.AssertWebHookRequestsReceived(Array.Empty<Action<WebHookRequest>>());
+        }
+    }
+
+    [Theory]
+    [InlineData(WebHookMessageTypes.UserUpdated, false)]
+    [InlineData(WebHookMessageTypes.UserUpdated | WebHookMessageTypes.UserMerged, false)]
+    [InlineData(WebHookMessageTypes.UserUpdated | WebHookMessageTypes.UserCreated, true)]
+    [InlineData(WebHookMessageTypes.UserMerged, false)]
+    [InlineData(WebHookMessageTypes.UserMerged | WebHookMessageTypes.UserCreated, true)]
+    [InlineData(WebHookMessageTypes.UserCreated, true)]
+    [InlineData(WebHookMessageTypes.All, true)]
+    public async Task UserCreated_WhenPublished_IsOnlySentToWebHookEndpointsWhichSubscribe(
+        WebHookMessageTypes webHookMessageTypesSubscribedTo,
+        bool expectedToReceiveMessage)
+    {
+        // Arrange
+        var notificationPublisher = HostFixture.Services.GetRequiredService<INotificationPublisher>();
+        var secret = "Thisismywebhooksecret";
+        await ConfigureTestWebHook(webHookMessageTypesSubscribedTo, secret);
+
+        var user = new User()
+        {
+            UserId = new Guid("3828dc03-7500-402a-beeb-acd45b635fc3"),
+            DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
+            EmailAddress = Faker.Internet.Email(),
+            FirstName = Faker.Name.First(),
+            MiddleName = Faker.Name.Middle(),
+            LastName = Faker.Name.Last(),
+            PreferredName = Faker.Name.FullName(),
+            MobileNumber = Faker.Phone.Number(),
+            Trn = "7754311",
+            TrnLookupStatus = TrnLookupStatus.Found,
+        };
+
+        // Act
+        var userCreatedNotification = new NotificationEnvelope()
+        {
+            NotificationId = Guid.NewGuid(),
+            Message = new UserCreatedMessage()
+            {
+                User = user
+
+            },
+            MessageType = UserCreatedMessage.MessageTypeName,
+            TimeUtc = HostFixture.Clock.UtcNow
+        };
+
+        await notificationPublisher.PublishNotification(userCreatedNotification);
+
+        // Assert
+        if (expectedToReceiveMessage)
+        {
+            WebHookRequestObserver.AssertWebHookRequestsReceived(
+            r =>
+            {
+                Assert.NotNull(r.ContentType);
+                Assert.NotNull(r.Signature);
+                Assert.NotNull(r.Body);
+                Assert.Equal("application/json", r.ContentType);
+                var expectedSignature = GenerateExpectedSignature(secret, r.Body);
+                Assert.Equal(expectedSignature, r.Signature);
+
+                var expectedJson = JsonSerializer.SerializeToNode(new
+                {
+                    notificationId = userCreatedNotification.NotificationId,
+                    message = new
+                    {
+                        user = new
+                        {
+                            userId = user.UserId,
+                            dateOfBirth = user.DateOfBirth,
+                            emailAddress = user.EmailAddress,
+                            firstName = user.FirstName,
+                            middleName = user.MiddleName,
+                            lastName = user.LastName,
+                            preferredName = user.PreferredName,
+                            mobileNumber = user.MobileNumber,
+                            trn = user.Trn,
+                            trnLookupStatus = user.TrnLookupStatus.ToString()
+                        }
+                    },
+                    messageType = UserCreatedMessage.MessageTypeName,
+                    timeUtc = HostFixture.Clock.UtcNow
+                });
+
+                AssertEx.JsonEquals(
+                    expectedJson,
+                    JsonNode.Parse(r.Body));
+            });
+        }
+        else
+        {
+            WebHookRequestObserver.AssertWebHookRequestsReceived(Array.Empty<Action<WebHookRequest>>());
+        }
+    }
+
+    [Theory]
+    [InlineData(WebHookMessageTypes.UserUpdated, false)]
+    [InlineData(WebHookMessageTypes.UserUpdated | WebHookMessageTypes.UserMerged, true)]
+    [InlineData(WebHookMessageTypes.UserUpdated | WebHookMessageTypes.UserCreated, false)]
+    [InlineData(WebHookMessageTypes.UserMerged, true)]
+    [InlineData(WebHookMessageTypes.UserMerged | WebHookMessageTypes.UserCreated, true)]
+    [InlineData(WebHookMessageTypes.UserCreated, false)]
+    [InlineData(WebHookMessageTypes.All, true)]
+    public async Task UserMerged_WhenPublished_IsOnlySentToWebHookEndpointsWhichSubscribe(
+        WebHookMessageTypes webHookMessageTypesSubscribedTo,
+        bool expectedToReceiveMessage)
+    {
+        // Arrange
+        var notificationPublisher = HostFixture.Services.GetRequiredService<INotificationPublisher>();
+        var secret = "Thisismywebhooksecret";
+        await ConfigureTestWebHook(webHookMessageTypesSubscribedTo, secret);
+
+        var user = new User()
+        {
+            UserId = new Guid("3828dc03-7500-402a-beeb-acd45b635fc3"),
+            DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
+            EmailAddress = Faker.Internet.Email(),
+            FirstName = Faker.Name.First(),
+            MiddleName = Faker.Name.Middle(),
+            LastName = Faker.Name.Last(),
+            PreferredName = Faker.Name.FullName(),
+            MobileNumber = Faker.Phone.Number(),
+            Trn = "7754311",
+            TrnLookupStatus = TrnLookupStatus.Found,
+        };
+
+        var mergedUserId = Guid.NewGuid();
+
+        // Act
+        var userCreatedNotification = new NotificationEnvelope()
+        {
+            NotificationId = Guid.NewGuid(),
+            Message = new UserMergedMessage()
+            {
+                MasterUser = user,
+                MergedUserId = mergedUserId
+            },
+            MessageType = UserMergedMessage.MessageTypeName,
+            TimeUtc = HostFixture.Clock.UtcNow
+        };
+
+        await notificationPublisher.PublishNotification(userCreatedNotification);
+
+        // Assert
+        if (expectedToReceiveMessage)
+        {
+            WebHookRequestObserver.AssertWebHookRequestsReceived(
+            r =>
+            {
+                Assert.NotNull(r.ContentType);
+                Assert.NotNull(r.Signature);
+                Assert.NotNull(r.Body);
+                Assert.Equal("application/json", r.ContentType);
+                var expectedSignature = GenerateExpectedSignature(secret, r.Body);
+                Assert.Equal(expectedSignature, r.Signature);
+
+                var expectedJson = JsonSerializer.SerializeToNode(new
+                {
+                    notificationId = userCreatedNotification.NotificationId,
+                    message = new
+                    {
+                        masterUser = new
+                        {
+                            userId = user.UserId,
+                            dateOfBirth = user.DateOfBirth,
+                            emailAddress = user.EmailAddress,
+                            firstName = user.FirstName,
+                            middleName = user.MiddleName,
+                            lastName = user.LastName,
+                            preferredName = user.PreferredName,
+                            mobileNumber = user.MobileNumber,
+                            trn = user.Trn,
+                            trnLookupStatus = user.TrnLookupStatus.ToString()
+                        },
+                        mergedUserId = mergedUserId
+                    },
+                    messageType = UserMergedMessage.MessageTypeName,
+                    timeUtc = HostFixture.Clock.UtcNow
+                });
+
+                AssertEx.JsonEquals(
+                    expectedJson,
+                    JsonNode.Parse(r.Body));
+            });
+        }
+        else
+        {
+            WebHookRequestObserver.AssertWebHookRequestsReceived(Array.Empty<Action<WebHookRequest>>());
+        }
+    }
+
+    private static string GenerateExpectedSignature(string secret, string content)
+    {
+        var key = Encoding.UTF8.GetBytes(secret);
+        var source = Encoding.UTF8.GetBytes(content);
+        return Convert.ToHexString(HMACSHA256.HashData(key, source));
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/WebHooks/WebHooksHostFixture.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/WebHooks/WebHooksHostFixture.cs
@@ -1,0 +1,90 @@
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Notifications;
+using TeacherIdentity.AuthServer.Notifications.WebHooks;
+using TeacherIdentity.AuthServer.Tests.Infrastructure;
+
+namespace TeacherIdentity.AuthServer.Tests.WebHooks;
+
+public class WebHooksHostFixture : HostFixture
+{
+    private const string TestWebHookEndpointUri = "/test-webhooks";
+
+    public readonly Guid TestWebHookId = Guid.NewGuid();
+
+    public WebHooksHostFixture(TestConfiguration testConfiguration, DbHelper dbHelper)
+        : base(testConfiguration, dbHelper)
+    {
+    }
+
+    public IWebHookRequestObserver WebHookRequestObserver => Services.GetRequiredService<IWebHookRequestObserver>();
+
+    public override async Task Initialize()
+    {
+        await DbHelper.EnsureSchema();
+    }
+
+    public void InitializeWebHookRequestObserver() => WebHookRequestObserver.Initialize();
+
+    public async Task ConfigureTestWebHook(WebHookMessageTypes webHookMessageTypes, string secret)
+    {
+        using var scope = Services.CreateAsyncScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<TeacherIdentityServerDbContext>();
+        dbContext.WebHooks.Add(new WebHook()
+        {
+            WebHookId = TestWebHookId,
+            Enabled = true,
+            Endpoint = $"http://localhost{TestWebHookEndpointUri}",
+            Secret = secret,
+            WebHookMessageTypes = webHookMessageTypes,
+            Created = Clock.UtcNow,
+            Updated = Clock.UtcNow
+        });
+
+        await dbContext.SaveChangesAsync();
+    }
+
+    protected override void ConfigureWebHooks(IServiceCollection services)
+    {
+        services
+            .AddSingleton<INotificationPublisher, WebHookNotificationPublisher>()
+            .AddSingleton<IWebHookNotificationSender>((sp) =>
+            {
+                var httpClient = CreateClient();
+                return new WebHookNotificationSender(httpClient);
+            })
+            .AddSingleton<IWebHookRequestObserver, WebHookRequestObserver>();
+    }
+
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        base.ConfigureWebHost(builder);
+        builder.Configure(app =>
+        {
+            app.UseRouting();
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapPost(TestWebHookEndpointUri, async (HttpContext context, IWebHookRequestObserver webHookRequestObserver) =>
+                {
+                    string? contentType = context.Request.Headers.ContentType;
+                    string? signature = null;
+                    if (context.Request.Headers.TryGetValue("X-Hub-Signature-256", out var signatureValue))
+                    {
+                        signature = signatureValue;
+                    }
+
+                    using var sr = new StreamReader(context.Request.Body);
+                    var body = await sr.ReadToEndAsync();
+
+                    var webHookRequest = new WebHookRequest()
+                    {
+                        ContentType = contentType,
+                        Signature = signature,
+                        Body = body
+                    };
+
+                    await webHookRequestObserver.OnWebHookRequestReceived(webHookRequest);
+                });
+            });
+        });
+    }
+}


### PR DESCRIPTION
### Context

We’re adding more logic to our webhook dispatcher and we don’t currently have tests that cover actually delivering a webhook.

### Changes proposed in this pull request

We want tests that call INotificationPublisher.PublishNotification then assert that a particular JSON message was received over HTTP and that the signature was correct. We should cover all message types and include logic around message type filtering.

Add a new set of tests under Tests.WebHooks with a new TestBase plus a new fixture that derives from HostFixture. This new fixture should add a new endpoint that can receive the webhook messages (e.g. /test-webhook ) and add a new WebHook into the database that matches its address. The endpoint itself should stash away all messages (as JSON) somewhere that tests can subsequently access and Assert on. Note that since our tests use a fake in-memory server, the HttpClient used by WebHookNotificationSender will need to be reconfigured to use HostFixture.CreateClient so that the message can successfully be sent to the in-memory endpoint.

We will likely need to run these tests within the DisableParallelization collection so they run reliably.

### Guidance to review

As per changes.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
