### PR TITLE
Shorten TRN tokens

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Handlers/CreateTrnTokenHandler.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Api/V1/Handlers/CreateTrnTokenHandler.cs
@@ -25,7 +25,7 @@ public class CreateTrnTokenHandler : IRequestHandler<CreateTrnTokenRequest, Crea
         string trnToken;
         do
         {
-            var buffer = new byte[64];
+            var buffer = new byte[8];
             RandomNumberGenerator.Fill(buffer);
             trnToken = Convert.ToHexString(buffer).ToLower();
         } while (await _dbContext.TrnTokens.AnyAsync(t => t.TrnToken == trnToken, cancellationToken));

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230703143539_VariableSizeTrnToken.Designer.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230703143539_VariableSizeTrnToken.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeacherIdentity.AuthServer.Models;
@@ -12,9 +13,11 @@ using TeacherIdentity.AuthServer.Models;
 namespace TeacherIdentity.AuthServer.Migrations
 {
     [DbContext(typeof(TeacherIdentityServerDbContext))]
-    partial class TeacherIdentityServerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230703143539_VariableSizeTrnToken")]
+    partial class VariableSizeTrnToken
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230703143539_VariableSizeTrnToken.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230703143539_VariableSizeTrnToken.cs
@@ -1,0 +1,40 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeacherIdentity.AuthServer.Migrations
+{
+    /// <inheritdoc />
+    public partial class VariableSizeTrnToken : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "trn_token",
+                table: "trn_tokens",
+                type: "character varying(128)",
+                maxLength: 128,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character(128)",
+                oldFixedLength: true,
+                oldMaxLength: 128);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "trn_token",
+                table: "trn_tokens",
+                type: "character(128)",
+                fixedLength: true,
+                maxLength: 128,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "character varying(128)",
+                oldMaxLength: 128);
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/Mappings/TrnTokenMapping.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/Mappings/TrnTokenMapping.cs
@@ -8,7 +8,7 @@ public class TrnTokenMapping : IEntityTypeConfiguration<TrnTokenModel>
     public void Configure(EntityTypeBuilder<TrnTokenModel> builder)
     {
         builder.ToTable("trn_tokens");
-        builder.Property(t => t.TrnToken).HasMaxLength(128).IsFixedLength();
+        builder.Property(t => t.TrnToken).HasMaxLength(128);
         builder.HasKey(t => t.TrnToken);
         builder.Property(t => t.Email).HasMaxLength(TrnTokenModel.EmailAddressMaxLength).IsRequired().UseCollation("case_insensitive");
         builder.HasIndex(u => u.Email).HasDatabaseName(TrnTokenModel.EmailAddressUniqueIndexName);


### PR DESCRIPTION
Our 128 character TRN tokens look alarming when used in the content of an email. This shortens them to 16 characters.