### PR TITLE
Increase default rate limit to 1000 calls per min for clients of identity

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Production.json
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Production.json
@@ -2,7 +2,7 @@
   "RateLimiting": {
     "DefaultRateLimit": {
       "Window": "00:01:00",
-      "PermitLimit": 300
+      "PermitLimit": 1000
     }
   },
   "Sentry": {


### PR DESCRIPTION
### Context

Identity now has a default rate limit set of 300 calls per minute for any clients calling an API endpoint.

The Qualified Teachers API calls the endpoint to generate TRN tokens to insert in emails to allow users to create an Identity account and access their qualifications.

During testing it was found that the generation of emails was slowed down due to 429 Too Many Request responses from the Identity endpoint.

### Changes proposed in this pull request

As an interim solution, increase the default rate limit for all clients. 

### Guidance to review

Simple config change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
