### PR TITLE
Added ability to change account preferred name + associated tests

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Events/UserUpdatedEvent.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Events/UserUpdatedEvent.cs
@@ -21,6 +21,7 @@ public enum UserUpdatedEventChanges
     TrnLookupStatus = 1 << 5,
     MobileNumber = 1 << 6,
     MiddleName = 1 << 7,
+    PreferredName = 1 << 8
 }
 
 public enum UserUpdatedEventSource

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -187,6 +187,18 @@ public abstract class IdentityLinkGenerator
             .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo)
             .AppendQueryStringSignature(QueryStringSignatureHelper);
 
+    public string AccountPreferredName(string? preferredName, ClientRedirectInfo? clientRedirectInfo) =>
+        Page("/Account/PreferredName/Index", authenticationJourneyRequired: false)
+            .SetQueryParam("preferredName", preferredName)
+            .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo)
+            .AppendQueryStringSignature(QueryStringSignatureHelper);
+
+    public string AccountPreferredNameConfirm(string preferredName, ClientRedirectInfo? clientRedirectInfo) =>
+        Page("/Account/PreferredName/Confirm", authenticationJourneyRequired: false)
+            .SetQueryParam("preferredName", preferredName)
+            .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo)
+            .AppendQueryStringSignature(QueryStringSignatureHelper);
+
     public string AccountDateOfBirth(ClientRedirectInfo? clientRedirectInfo) =>
         Page("/Account/DateOfBirth/Index", authenticationJourneyRequired: false)
             .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Notifications/Messages/UserUpdatedMessage.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Notifications/Messages/UserUpdatedMessage.cs
@@ -16,6 +16,7 @@ public record UserUpdatedMessageChanges
     public required Option<string> FirstName { get; init; }
     public required Option<string?> MiddleName { get; init; }
     public required Option<string> LastName { get; init; }
+    public required Option<string?> PreferredName { get; init; }
     public required Option<DateOnly?> DateOfBirth { get; init; }
     public required Option<string?> Trn { get; init; }
     public required Option<string?> MobileNumber { get; init; }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Notifications/PublishNotificationsEventObserver.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Notifications/PublishNotificationsEventObserver.cs
@@ -57,6 +57,7 @@ public class PublishNotificationsEventObserver : IEventObserver
                         FirstName = userUpdated.Changes.HasFlag(UserUpdatedEventChanges.FirstName) ? Option.Some(userUpdated.User.FirstName) : default,
                         MiddleName = userUpdated.Changes.HasFlag(UserUpdatedEventChanges.MiddleName) ? Option.Some(userUpdated.User.MiddleName) : default,
                         LastName = userUpdated.Changes.HasFlag(UserUpdatedEventChanges.LastName) ? Option.Some(userUpdated.User.LastName) : default,
+                        PreferredName = userUpdated.Changes.HasFlag(UserUpdatedEventChanges.PreferredName) ? Option.Some(userUpdated.User.PreferredName) : default,
                         Trn = userUpdated.Changes.HasFlag(UserUpdatedEventChanges.Trn) ? Option.Some(userUpdated.User.Trn) : default,
                         MobileNumber = userUpdated.Changes.HasFlag(UserUpdatedEventChanges.MobileNumber) ? Option.Some(userUpdated.User.MobileNumber) : default,
                         TrnLookupStatus = userUpdated.Changes.HasFlag(UserUpdatedEventChanges.TrnLookupStatus) ? Option.Some(userUpdated.User.TrnLookupStatus) : default

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
@@ -68,6 +68,15 @@
                 </govuk-summary-list-row>
             }
             <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Preferred name</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value>
+                    <span fallback-text="Not provided">@Model.PreferredName</span>
+                </govuk-summary-list-row-value>
+                <govuk-summary-list-row-actions>
+                    <govuk-summary-list-row-action href="@LinkGenerator.AccountPreferredName(preferredName: null, Model.ClientRedirectInfo)" visually-hidden-text="preferred name" data-testid="preferred-name-change-link">Change</govuk-summary-list-row-action>
+                </govuk-summary-list-row-actions>
+            </govuk-summary-list-row>
+            <govuk-summary-list-row>
                 <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
                 <govuk-summary-list-row-value>
                     @Model.DateOfBirth?.ToString(Constants.DateFormat)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml.cs
@@ -28,6 +28,7 @@ public class IndexModel : PageModel
 
     public string? Name { get; set; }
     public string? OfficialName { get; set; }
+    public string? PreferredName { get; set; }
     public DateOnly? DateOfBirth { get; set; }
     public string? Email { get; set; }
     public string? MobileNumber { get; set; }
@@ -48,6 +49,7 @@ public class IndexModel : PageModel
                 u.FirstName,
                 u.MiddleName,
                 u.LastName,
+                u.PreferredName,
                 u.DateOfBirth,
                 u.EmailAddress,
                 u.MobileNumber,
@@ -56,6 +58,7 @@ public class IndexModel : PageModel
             .SingleAsync();
 
         Name = string.IsNullOrEmpty(user.MiddleName) ? $"{user.FirstName} {user.LastName}" : $"{user.FirstName} {user.MiddleName} {user.LastName}";
+        PreferredName = user.PreferredName;
         DateOfBirth = user.DateOfBirth;
         Email = user.EmailAddress;
         MobileNumber = user.MobileNumber;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/PreferredName/Confirm.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/PreferredName/Confirm.cshtml
@@ -1,0 +1,31 @@
+@page "/account/preferred-name/confirm"
+@model TeacherIdentity.AuthServer.Pages.Account.PreferredName.ConfirmModel
+@{
+    ViewBag.Title = "Confirm change";
+}
+
+@section BeforeContent
+{
+    <govuk-back-link href="@LinkGenerator.AccountName(Model.ClientRedirectInfo)" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.AccountPreferredNameConfirm(Model.PreferredName!, Model.ClientRedirectInfo)" method="post" asp-antiforgery="true">
+            <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+
+            <govuk-summary-list>
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Preferred name</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.PreferredName</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AccountPreferredName(Model.PreferredName, Model.ClientRedirectInfo)" visually-hidden-text="name">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
+            </govuk-summary-list>
+
+            <govuk-button type="submit">Submit change</govuk-button>
+        </form>
+    </div>
+</div>
+

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/PreferredName/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/PreferredName/Confirm.cshtml.cs
@@ -1,0 +1,84 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Infrastructure.Filters;
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.Pages.Account.PreferredName;
+
+[VerifyQueryParameterSignature]
+public class ConfirmModel : PageModel
+{
+    private readonly IdentityLinkGenerator _linkGenerator;
+    private readonly TeacherIdentityServerDbContext _dbContext;
+    private readonly IClock _clock;
+
+    public ConfirmModel(
+        IdentityLinkGenerator linkGenerator,
+        TeacherIdentityServerDbContext dbContext,
+        IClock clock)
+    {
+        _linkGenerator = linkGenerator;
+        _dbContext = dbContext;
+        _clock = clock;
+    }
+
+    public ClientRedirectInfo? ClientRedirectInfo => HttpContext.GetClientRedirectInfo();
+
+    [FromQuery(Name = "preferredName")]
+    public string? PreferredName { get; set; }
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        await UpdateUserName(User.GetUserId());
+        return Redirect(_linkGenerator.Account(ClientRedirectInfo));
+    }
+
+    public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
+    {
+        if (PreferredName is null)
+        {
+            context.Result = BadRequest();
+        }
+    }
+
+    private async Task UpdateUserName(Guid userId)
+    {
+        var user = await _dbContext.Users.SingleAsync(u => u.UserId == userId);
+
+        UserUpdatedEventChanges changes = UserUpdatedEventChanges.None;
+
+        if (user.PreferredName != PreferredName)
+        {
+            changes |= UserUpdatedEventChanges.PreferredName;
+        }
+
+        if (changes != UserUpdatedEventChanges.None)
+        {
+            user.PreferredName = PreferredName!;
+            user.Updated = _clock.UtcNow;
+
+            _dbContext.AddEvent(new UserUpdatedEvent()
+            {
+                Source = UserUpdatedEventSource.ChangedByUser,
+                CreatedUtc = _clock.UtcNow,
+                Changes = changes,
+                User = user,
+                UpdatedByUserId = User.GetUserId(),
+                UpdatedByClientId = null
+            });
+
+            await _dbContext.SaveChangesAsync();
+
+            await HttpContext.SignInCookies(user, resetIssued: false);
+
+            TempData.SetFlashSuccess("Your preferred name has been updated");
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/PreferredName/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/PreferredName/Index.cshtml
@@ -1,17 +1,17 @@
-@page "/sign-in/register/preferred-name"
+@page "/account/preferred-name"
 @using TeacherIdentity.AuthServer.Pages.Common;
-@model TeacherIdentity.AuthServer.Pages.SignIn.Register.PreferredNamePage
+@model TeacherIdentity.AuthServer.Pages.Account.PreferredName.PreferredNameModel
 @{
-    ViewBag.Title = "What is your preferred name?";
+    ViewBag.Title = "Your preferred name";
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@Model.BackLink" />
+    <govuk-back-link href="@LinkGenerator.Account(Model.ClientRedirectInfo)" />
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.RegisterPreferredName()" method="post" asp-antiforgery="true">
+        <form action="@LinkGenerator.AccountPreferredName(Model.PreferredName, Model.ClientRedirectInfo)" method="post" asp-antiforgery="true">
             <govuk-radios asp-for="PreferredNameChoice">
                 <govuk-radios-fieldset>
                     <govuk-radios-fieldset-legend>
@@ -28,9 +28,10 @@
                             Use @Model.ExistingName(includeMiddleName: true)
                         </govuk-radios-item>
                     }
-                    <govuk-radios-item value="@PreferredNameOption.PreferredName">Other
+                    <govuk-radios-item value="@PreferredNameOption.PreferredName">
+                        Other
                         <govuk-radios-item-conditional>
-                            <govuk-input asp-for="PreferredName" spellcheck="false"/>
+                            <govuk-input asp-for="PreferredName" spellcheck="false" />
                         </govuk-radios-item-conditional>
                     </govuk-radios-item>
                 </govuk-radios-fieldset>
@@ -40,4 +41,3 @@
         </form>
     </div>
 </div>
-

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/PreferredName/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/PreferredName/Index.cshtml.cs
@@ -1,0 +1,105 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Infrastructure.Filters;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Pages.Common;
+
+namespace TeacherIdentity.AuthServer.Pages.Account.PreferredName;
+
+[VerifyQueryParameterSignature]
+public class PreferredNameModel : PageModel
+{
+    private readonly IdentityLinkGenerator _linkGenerator;
+    private readonly TeacherIdentityServerDbContext _dbContext;
+
+    public PreferredNameModel(
+        IdentityLinkGenerator linkGenerator,
+        TeacherIdentityServerDbContext dbContext)
+    {
+        _linkGenerator = linkGenerator;
+        _dbContext = dbContext;
+    }
+
+    public ClientRedirectInfo? ClientRedirectInfo => HttpContext.GetClientRedirectInfo();
+
+    public bool HasMiddleName => !string.IsNullOrEmpty(User.GetMiddleName());
+
+    [BindProperty]
+    [Display(Name = " ")]
+    [Required(ErrorMessage = "Select which name to use")]
+    public PreferredNameOption? PreferredNameChoice { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    [Display(Name = "Your preferred name")]
+    [RequiredIfTrue(nameof(PreferredNameChoice), "PreferredName", ErrorMessage = "Enter your preferred name")]
+    [StringLengthIfTrue(nameof(PreferredNameChoice), 200, "PreferredName", ErrorMessage = "Preferred name must be 200 characters or less")]
+    public string? PreferredName { get; set; }
+
+    public async Task OnGet()
+    {
+        string? preferredName = null;
+        if (PreferredName is null)
+        {
+            var userId = User.GetUserId();
+            var user = await _dbContext.Users.Where(u => u.UserId == userId).SingleAsync();
+            preferredName = user.PreferredName;
+        }
+        else
+        {
+            preferredName = PreferredName;
+        }
+
+        if (string.IsNullOrEmpty(preferredName))
+        {
+            return;
+        }
+
+        var middleName = User.GetMiddleName();
+        if (!string.IsNullOrEmpty(middleName) && preferredName == ExistingName(includeMiddleName: true))
+        {
+            PreferredNameChoice = PreferredNameOption.ExistingFullName;
+            PreferredName = null;
+        }
+        else if (preferredName == ExistingName(includeMiddleName: false))
+        {
+            PreferredNameChoice = PreferredNameOption.ExistingName;
+            PreferredName = null;
+        }
+        else
+        {
+            PreferredNameChoice = PreferredNameOption.PreferredName;
+            PreferredName = preferredName;
+        }
+
+        ModelState.Clear();
+    }
+
+    public IActionResult OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        var preferredName = PreferredNameChoice switch
+        {
+            PreferredNameOption.ExistingFullName => ExistingName(includeMiddleName: true),
+            PreferredNameOption.ExistingName => ExistingName(includeMiddleName: false),
+            PreferredNameOption.PreferredName => PreferredName,
+            _ => throw new ArgumentOutOfRangeException(nameof(PreferredNameChoice), PreferredNameChoice, "Invalid preferred name option chosen")
+        };
+
+        return Redirect(_linkGenerator.AccountPreferredNameConfirm(preferredName!, ClientRedirectInfo));
+    }
+
+    public string ExistingName(bool includeMiddleName)
+    {
+        var firstName = User.GetFirstName();
+        var middleName = User.GetMiddleName();
+        var lastName = User.GetLastName();
+
+        return !includeMiddleName || string.IsNullOrEmpty(middleName) ? $"{firstName} {lastName}" : $"{firstName} {middleName} {lastName}";
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Common/PreferredNameOption.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Common/PreferredNameOption.cs
@@ -1,0 +1,8 @@
+namespace TeacherIdentity.AuthServer.Pages.Common;
+
+public enum PreferredNameOption
+{
+    ExistingFullName,
+    ExistingName,
+    PreferredName
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/PreferredNamePage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/PreferredNamePage.cshtml.cs
@@ -2,6 +2,7 @@ using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeacherIdentity.AuthServer.Journeys;
+using TeacherIdentity.AuthServer.Pages.Common;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
 
@@ -81,12 +82,5 @@ public class PreferredNamePage : PageModel
             PreferredNameChoice = PreferredNameOption.PreferredName;
             PreferredName = authState.PreferredName;
         }
-    }
-
-    public enum PreferredNameOption
-    {
-        ExistingFullName,
-        ExistingName,
-        PreferredName
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/IndexTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/IndexTests.cs
@@ -78,7 +78,7 @@ public class IndexTests : TestBase
     public async Task Get_ValidRequest_ReturnsUserDetails()
     {
         // Arrange
-        var user = await TestData.CreateUser();
+        var user = await TestData.CreateUser(hasPreferredName: true);
         HostFixture.SetUserId(user.UserId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, "/account");
@@ -90,6 +90,29 @@ public class IndexTests : TestBase
         var doc = await response.GetDocument();
 
         Assert.Equal($"{user.FirstName} {user.MiddleName} {user.LastName}", doc.GetSummaryListValueForKey("Name"));
+        Assert.Equal(user.PreferredName, doc.GetSummaryListValueForKey("Preferred name"));
+        Assert.Equal($"{user.DateOfBirth?.ToString(Constants.DateFormat)}", doc.GetSummaryListValueForKey("Date of birth"));
+        Assert.Equal(user.EmailAddress, doc.GetSummaryListValueForKey("Email"));
+        Assert.Equal(user.MobileNumber, doc.GetSummaryListValueForKey("Mobile number"));
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestForUserWithoutPreferredName_ReturnsUserDetailsWithPlaceholderForPreferredName()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(hasPreferredName: false);
+        HostFixture.SetUserId(user.UserId);
+
+        var request = new HttpRequestMessage(HttpMethod.Get, "/account");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await response.GetDocument();
+
+        Assert.Equal($"{user.FirstName} {user.MiddleName} {user.LastName}", doc.GetSummaryListValueForKey("Name"));
+        Assert.Equal("Not provided", doc.GetSummaryListValueForKey("Preferred name"));
         Assert.Equal($"{user.DateOfBirth?.ToString(Constants.DateFormat)}", doc.GetSummaryListValueForKey("Date of birth"));
         Assert.Equal(user.EmailAddress, doc.GetSummaryListValueForKey("Email"));
         Assert.Equal(user.MobileNumber, doc.GetSummaryListValueForKey("Mobile number"));

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/PreferredName/ConfirmTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/PreferredName/ConfirmTests.cs
@@ -1,0 +1,103 @@
+using System.Text.Encodings.Web;
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Account.PreferredName;
+
+public class ConfirmTests : TestBase
+{
+    public ConfirmTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_NoPreferredName_ReturnsBadRequest()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            AppendQueryParameterSignature($"/account/preferred-name/confirm"));
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_ReturnsSuccess()
+    {
+        // Arrange
+        var preferredName = Faker.Name.FullName();
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            AppendQueryParameterSignature($"/account/preferred-name/confirm?preferredName={UrlEncode(preferredName)}"));
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_NoPreferredName_ReturnsBadRequest()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            AppendQueryParameterSignature($"/account/preferred-name/confirm"));
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_ValidForm_UpdatesPreferredNameEmitsEventAndRedirectsToAccountPage()
+    {
+        // Arrange
+        var user = await TestData.CreateUser(userType: UserType.Default);
+        HostFixture.SetUserId(user.UserId);
+
+        var clientRedirectInfo = CreateClientRedirectInfo();
+        var newPreferredName = Faker.Name.FullName();
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            AppendQueryParameterSignature($"/account/preferred-name/confirm?preferredName={UrlEncode(newPreferredName)}&{clientRedirectInfo.ToQueryParam()}"))
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.Equal($"/account?{clientRedirectInfo.ToQueryParam()}", response.Headers.Location?.OriginalString);
+
+        user = await TestData.WithDbContext(dbContext => dbContext.Users.SingleAsync(u => u.UserId == user.UserId));
+        Assert.Equal(Clock.UtcNow, user.Updated);
+
+        EventObserver.AssertEventsSaved(
+            e =>
+            {
+                var userUpdatedEvent = Assert.IsType<UserUpdatedEvent>(e);
+                Assert.Equal(Clock.UtcNow, userUpdatedEvent.CreatedUtc);
+                Assert.Equal(UserUpdatedEventSource.ChangedByUser, userUpdatedEvent.Source);
+                Assert.Equal(UserUpdatedEventChanges.PreferredName, userUpdatedEvent.Changes);
+                Assert.Equal(user.UserId, userUpdatedEvent.User.UserId);
+            });
+
+        var redirectedResponse = await response.FollowRedirect(HttpClient);
+        var redirectedDoc = await redirectedResponse.GetDocument();
+        AssertEx.HtmlDocumentHasFlashSuccess(redirectedDoc, "Your preferred name has been updated");
+    }
+
+    private static string UrlEncode(string value) => UrlEncoder.Default.Encode(value);
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/PreferredName/PreferredNameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/PreferredName/PreferredNameTests.cs
@@ -1,0 +1,157 @@
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Account.PreferredName;
+
+public class PreferredNameTests : TestBase
+{
+    public PreferredNameTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithPreferredNameInQueryParam_PopulatesFieldFromQueryParam()
+    {
+        // Arrange
+        var previouslyStatedPreferredName = Faker.Name.FullName();
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            AppendQueryParameterSignature(
+                $"/account/preferred-name" +
+                $"?preferredName={Uri.EscapeDataString(previouslyStatedPreferredName)}"));
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await response.GetDocument();
+        Assert.Equal(previouslyStatedPreferredName, doc.GetElementById("PreferredName")?.GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task Post_WhenPreferredNameChoiceHasNoSelection_ReturnsError()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            AppendQueryParameterSignature($"/account/preferred-name"))
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "PreferredNameChoice", "Select which name to use");
+    }
+
+    [Fact]
+    public async Task Post_WhenPreferredNameChoiceIsPreferredNameAndPreferredNameIsEmpty_ReturnsError()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            AppendQueryParameterSignature($"/account/preferred-name"))
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "PreferredNameChoice", "PreferredName" },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "PreferredName", "Enter your preferred name");
+    }
+
+    [Fact]
+    public async Task Post_WhenPreferredNameChoiceIsPreferredNameAndPreferredNameIsTooLong_ReturnsError()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            AppendQueryParameterSignature($"/account/preferred-name"))
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "PreferredNameChoice", "PreferredName" },
+                { "PreferredName", new string('a', 201) }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "PreferredName", "Preferred name must be 200 characters or less");
+    }
+
+    [Fact]
+    public async Task Post_WhenPreferredNameChoiceIsPreferredNameAndPreferredNameIsValid_RedirectsToConfirmPage()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            AppendQueryParameterSignature($"/account/preferred-name"))
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "PreferredNameChoice", "PreferredName" },
+                { "PreferredName", Faker.Name.FullName() }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/account/preferred-name/confirm", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_WhenPreferredNameChoiceIsExistingName_RedirectsToConfirmPage()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            AppendQueryParameterSignature($"/account/preferred-name"))
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "PreferredNameChoice", "ExistingName" }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/account/preferred-name/confirm", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_WhenPreferredNameChoiceIsExistingFullName_RedirectsToConfirmPage()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            AppendQueryParameterSignature($"/account/preferred-name"))
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "PreferredNameChoice", "ExistingFullName" }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/account/preferred-name/confirm", response.Headers.Location?.OriginalString);
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/WebHooks/WebHooksEndToEndTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/WebHooks/WebHooksEndToEndTests.cs
@@ -75,12 +75,13 @@ public class WebHooksEndToEndTests : TestBase
     }
 
     [Theory]
-    [InlineData(WebHookMessageTypes.UserUpdated, UserUpdatedEventChanges.DateOfBirth | UserUpdatedEventChanges.EmailAddress | UserUpdatedEventChanges.FirstName | UserUpdatedEventChanges.MiddleName | UserUpdatedEventChanges.LastName | UserUpdatedEventChanges.Trn | UserUpdatedEventChanges.MobileNumber | UserUpdatedEventChanges.TrnLookupStatus, true)]
+    [InlineData(WebHookMessageTypes.UserUpdated, UserUpdatedEventChanges.DateOfBirth | UserUpdatedEventChanges.EmailAddress | UserUpdatedEventChanges.FirstName | UserUpdatedEventChanges.MiddleName | UserUpdatedEventChanges.LastName | UserUpdatedEventChanges.PreferredName | UserUpdatedEventChanges.Trn | UserUpdatedEventChanges.MobileNumber | UserUpdatedEventChanges.TrnLookupStatus, true)]
     [InlineData(WebHookMessageTypes.UserUpdated, UserUpdatedEventChanges.DateOfBirth, true)]
     [InlineData(WebHookMessageTypes.UserUpdated, UserUpdatedEventChanges.EmailAddress, true)]
     [InlineData(WebHookMessageTypes.UserUpdated, UserUpdatedEventChanges.FirstName, true)]
     [InlineData(WebHookMessageTypes.UserUpdated, UserUpdatedEventChanges.MiddleName, true)]
     [InlineData(WebHookMessageTypes.UserUpdated, UserUpdatedEventChanges.LastName, true)]
+    [InlineData(WebHookMessageTypes.UserUpdated, UserUpdatedEventChanges.PreferredName, true)]
     [InlineData(WebHookMessageTypes.UserUpdated, UserUpdatedEventChanges.Trn, true)]
     [InlineData(WebHookMessageTypes.UserUpdated, UserUpdatedEventChanges.MobileNumber, true)]
     [InlineData(WebHookMessageTypes.UserUpdated, UserUpdatedEventChanges.TrnLookupStatus, true)]
@@ -121,6 +122,7 @@ public class WebHooksEndToEndTests : TestBase
             FirstName = userUpdatedEventChanges.HasFlag(UserUpdatedEventChanges.FirstName) ? Option.Some(user.FirstName) : default,
             MiddleName = userUpdatedEventChanges.HasFlag(UserUpdatedEventChanges.MiddleName) ? Option.Some<string?>(user.MiddleName) : default,
             LastName = userUpdatedEventChanges.HasFlag(UserUpdatedEventChanges.LastName) ? Option.Some(user.LastName) : default,
+            PreferredName = userUpdatedEventChanges.HasFlag(UserUpdatedEventChanges.PreferredName) ? Option.Some<string?>(user.PreferredName) : default,
             Trn = userUpdatedEventChanges.HasFlag(UserUpdatedEventChanges.Trn) ? Option.Some<string?>(user.Trn) : default,
             MobileNumber = userUpdatedEventChanges.HasFlag(UserUpdatedEventChanges.MobileNumber) ? Option.Some<string?>(user.MobileNumber) : default,
             TrnLookupStatus = userUpdatedEventChanges.HasFlag(UserUpdatedEventChanges.TrnLookupStatus) ? Option.Some(user.TrnLookupStatus) : default
@@ -180,6 +182,7 @@ public class WebHooksEndToEndTests : TestBase
                             firstName = user.FirstName,
                             middleName = user.MiddleName,
                             lastName = user.LastName,
+                            preferredName = user.PreferredName,
                             mobileNumber = user.MobileNumber,
                             trn = user.Trn,
                             trnLookupStatus = user.TrnLookupStatus.ToString()
@@ -213,6 +216,11 @@ public class WebHooksEndToEndTests : TestBase
                 if (!userUpdatedEventChanges.HasFlag(UserUpdatedEventChanges.LastName))
                 {
                     changes.Remove("lastName");
+                }
+
+                if (!userUpdatedEventChanges.HasFlag(UserUpdatedEventChanges.PreferredName))
+                {
+                    changes.Remove("preferredName");
                 }
 
                 if (!userUpdatedEventChanges.HasFlag(UserUpdatedEventChanges.MobileNumber))


### PR DESCRIPTION
### Context

Registration journeys now allow a user to specify their preferred name. We should add this to the account page so that it can be updated.

### Changes proposed in this pull request

Add new pages at `/account/preferred-name` and `/account/preferred-name/confirm` and row for Preferred name + link on `/account` page.

### Guidance to review

Essentially changes to 3 pages and unit tests.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
