### PR TITLE
Amended account DOB and name pages to retain entered data when going back and forth from confirm pages

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -175,9 +175,13 @@ public abstract class IdentityLinkGenerator
     public string SignOut() =>
         Page("/SignOut", authenticationJourneyRequired: false);
 
-    public string AccountName(ClientRedirectInfo? clientRedirectInfo) =>
+    public string AccountName(string? firstName, string? middleName, string? lastName, ClientRedirectInfo? clientRedirectInfo) =>
         Page("/Account/Name/Index", authenticationJourneyRequired: false)
-            .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo);
+            .SetQueryParam("firstName", firstName)
+            .SetQueryParam("middleName", middleName)
+            .SetQueryParam("lastName", lastName)
+            .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo)
+            .AppendQueryStringSignature(QueryStringSignatureHelper);
 
     public string AccountNameConfirm(string firstName, string? middleName, string lastName, ClientRedirectInfo? clientRedirectInfo) =>
         Page("/Account/Name/Confirm", authenticationJourneyRequired: false)
@@ -199,9 +203,11 @@ public abstract class IdentityLinkGenerator
             .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo)
             .AppendQueryStringSignature(QueryStringSignatureHelper);
 
-    public string AccountDateOfBirth(ClientRedirectInfo? clientRedirectInfo) =>
+    public string AccountDateOfBirth(DateOnly? dateOfBirth, ClientRedirectInfo? clientRedirectInfo) =>
         Page("/Account/DateOfBirth/Index", authenticationJourneyRequired: false)
-            .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo);
+            .SetQueryParam("dateOfBirth", dateOfBirth?.ToString(DateOfBirthFormat))
+            .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo)
+            .AppendQueryStringSignature(QueryStringSignatureHelper);
 
     public string AccountDateOfBirthConfirm(DateOnly dateOfBirth, ClientRedirectInfo? clientRedirectInfo) =>
         Page("/Account/DateOfBirth/Confirm", authenticationJourneyRequired: false)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Confirm.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Confirm.cshtml
@@ -7,7 +7,7 @@
 
 @section BeforeContent
 {
-    <govuk-back-link href="@LinkGenerator.AccountDateOfBirth(Model.ClientRedirectInfo)" />
+    <govuk-back-link href="@LinkGenerator.AccountDateOfBirth(Model.DateOfBirth, Model.ClientRedirectInfo)" />
 }
 
 <div class="govuk-grid-row">
@@ -19,7 +19,7 @@
                     <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value>@Model.DateOfBirth?.ToString(Constants.DateFormat)</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.AccountDateOfBirth(Model.ClientRedirectInfo)" visually-hidden-text="date of birth">Change</govuk-summary-list-row-action>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AccountDateOfBirth(Model.DateOfBirth, Model.ClientRedirectInfo)" visually-hidden-text="date of birth">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
             </govuk-summary-list>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/DateOfBirth/Index.cshtml
@@ -10,7 +10,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.AccountDateOfBirth(Model.ClientRedirectInfo)" method="post" asp-antiforgery="true">
+        <form action="@LinkGenerator.AccountDateOfBirth(dateOfBirth: null, Model.ClientRedirectInfo)" method="post" asp-antiforgery="true">
             <govuk-date-input asp-for="DateOfBirth">
                 <govuk-date-input-fieldset>
                     <govuk-date-input-fieldset-legend is-page-heading="true" class="govuk-fieldset__legend--l"/>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
@@ -40,7 +40,7 @@
                 <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
                 <govuk-summary-list-row-value>@Model.Name</govuk-summary-list-row-value>
                 <govuk-summary-list-row-actions>
-                    <govuk-summary-list-row-action href="@LinkGenerator.AccountName(Model.ClientRedirectInfo)" visually-hidden-text="name">Change</govuk-summary-list-row-action>
+                    <govuk-summary-list-row-action href="@LinkGenerator.AccountName(firstName: null, middleName: null, lastName: null, Model.ClientRedirectInfo)" visually-hidden-text="name">Change</govuk-summary-list-row-action>
                 </govuk-summary-list-row-actions>
             </govuk-summary-list-row>
             @if (Model.Trn is not null)
@@ -92,7 +92,7 @@
                 @if (dateOfBirthChangeEnabled)
                 {
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.AccountDateOfBirth(Model.ClientRedirectInfo)" visually-hidden-text="date of birth" data-testid="dob-change-link">Change</govuk-summary-list-row-action>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AccountDateOfBirth(dateOfBirth: null, Model.ClientRedirectInfo)" visually-hidden-text="date of birth" data-testid="dob-change-link">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 }
             </govuk-summary-list-row>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Confirm.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Confirm.cshtml
@@ -10,7 +10,7 @@
 
 @section BeforeContent
 {
-    <govuk-back-link href="@LinkGenerator.AccountName(Model.ClientRedirectInfo)" />
+    <govuk-back-link href="@LinkGenerator.AccountName(Model.FirstName, Model.MiddleName, Model.LastName, Model.ClientRedirectInfo)" />
 }
 
 <div class="govuk-grid-row">
@@ -23,7 +23,7 @@
                     <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value>@fullName</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.AccountName(Model.ClientRedirectInfo)" visually-hidden-text="name">Change</govuk-summary-list-row-action>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AccountName(Model.FirstName, Model.MiddleName, Model.LastName, Model.ClientRedirectInfo)" visually-hidden-text="name">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
             </govuk-summary-list>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Index.cshtml
@@ -10,7 +10,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.AccountName(Model.ClientRedirectInfo)" method="post" asp-antiforgery="true">
+        <form action="@LinkGenerator.AccountName(firstName: null, middleName: null, lastName: null, Model.ClientRedirectInfo)" method="post" asp-antiforgery="true">
             <h1 class="govuk-heading-l">@ViewBag.Title</h1>
 
             <govuk-input asp-for="FirstName" spellcheck="false" autocomplete="given-name">

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Index.cshtml.cs
@@ -1,11 +1,11 @@
 using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeacherIdentity.AuthServer.Infrastructure.Filters;
 
 namespace TeacherIdentity.AuthServer.Pages.Account.Name;
 
-[BindProperties]
+[VerifyQueryParameterSignature]
 public class Name : PageModel
 {
     private readonly IdentityLinkGenerator _linkGenerator;
@@ -15,18 +15,20 @@ public class Name : PageModel
         _linkGenerator = linkGenerator;
     }
 
-    [BindNever]
     public ClientRedirectInfo? ClientRedirectInfo => HttpContext.GetClientRedirectInfo();
 
+    [BindProperty(SupportsGet = true)]
     [Display(Name = "First name", Description = "Or given names")]
     [Required(ErrorMessage = "Enter your first name")]
     [StringLength(200, ErrorMessage = "First name must be 200 characters or less")]
     public string? FirstName { get; set; }
 
+    [BindProperty(SupportsGet = true)]
     [Display(Name = "Middle name")]
     [StringLength(200, ErrorMessage = "Middle name must be 200 characters or less")]
     public string? MiddleName { get; set; }
 
+    [BindProperty(SupportsGet = true)]
     [Display(Name = "Last name", Description = "Or family names")]
     [Required(ErrorMessage = "Enter your last name")]
     [StringLength(200, ErrorMessage = "Last name must be 200 characters or less")]
@@ -34,9 +36,14 @@ public class Name : PageModel
 
     public void OnGet()
     {
-        FirstName = User.GetFirstName();
-        MiddleName = User.GetMiddleName();
-        LastName = User.GetLastName();
+        if (FirstName is null && LastName is null)
+        {
+            FirstName = User.GetFirstName();
+            MiddleName = User.GetMiddleName();
+            LastName = User.GetLastName();
+        }
+
+        ModelState.Clear();
     }
 
     public IActionResult OnPost()

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/PreferredName/Confirm.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/PreferredName/Confirm.cshtml
@@ -6,7 +6,7 @@
 
 @section BeforeContent
 {
-    <govuk-back-link href="@LinkGenerator.AccountName(Model.ClientRedirectInfo)" />
+    <govuk-back-link href="@LinkGenerator.AccountPreferredName(Model.PreferredName, Model.ClientRedirectInfo)" />
 }
 
 <div class="govuk-grid-row">

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/PreferredName/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/PreferredName/Index.cshtml
@@ -11,7 +11,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.AccountPreferredName(Model.PreferredName, Model.ClientRedirectInfo)" method="post" asp-antiforgery="true">
+        <form action="@LinkGenerator.AccountPreferredName(preferredName: null, Model.ClientRedirectInfo)" method="post" asp-antiforgery="true">
             <govuk-radios asp-for="PreferredNameChoice">
                 <govuk-radios-fieldset>
                     <govuk-radios-fieldset-legend>

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Name/NameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Name/NameTests.cs
@@ -11,7 +11,9 @@ public class NameTests : TestBase
     public async Task Post_EmptyFirstName_ReturnsError()
     {
         // Arrange
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/name")
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            AppendQueryParameterSignature($"/account/name"))
         {
             Content = new FormUrlEncodedContentBuilder()
             {
@@ -30,7 +32,9 @@ public class NameTests : TestBase
     public async Task Post_EmptyLastName_ReturnsError()
     {
         // Arrange
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/name")
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            AppendQueryParameterSignature($"/account/name"))
         {
             Content = new FormUrlEncodedContentBuilder()
             {
@@ -49,7 +53,9 @@ public class NameTests : TestBase
     public async Task Post_TooLongFirstName_ReturnsError()
     {
         // Arrange
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/name")
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            AppendQueryParameterSignature($"/account/name"))
         {
             Content = new FormUrlEncodedContentBuilder()
             {
@@ -69,7 +75,9 @@ public class NameTests : TestBase
     public async Task Post_TooLongMiddleName_ReturnsError()
     {
         // Arrange
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/name")
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            AppendQueryParameterSignature($"/account/name"))
         {
             Content = new FormUrlEncodedContentBuilder()
             {
@@ -90,7 +98,9 @@ public class NameTests : TestBase
     public async Task Post_TooLongLastName_ReturnsError()
     {
         // Arrange
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/name")
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            AppendQueryParameterSignature($"/account/name"))
         {
             Content = new FormUrlEncodedContentBuilder()
             {
@@ -110,7 +120,9 @@ public class NameTests : TestBase
     public async Task Post_ValidName_RedirectsToConfirmPage()
     {
         // Arrange
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/name")
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            AppendQueryParameterSignature($"/account/name"))
         {
             Content = new FormUrlEncodedContentBuilder()
             {
@@ -134,7 +146,9 @@ public class NameTests : TestBase
         // Arrange
         var clientRedirectInfo = CreateClientRedirectInfo();
 
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/account/name?{clientRedirectInfo.ToQueryParam()}")
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            AppendQueryParameterSignature($"/account/name?{clientRedirectInfo.ToQueryParam()}"))
         {
             Content = new FormUrlEncodedContentBuilder()
             {
@@ -152,10 +166,37 @@ public class NameTests : TestBase
     }
 
     [Fact]
-    public async Task Get_Prepopulates_FirstMiddleAndLastName()
+    public async Task Get_ValidRequestWithNamesInQueryParam_PopulatesFieldsFromQueryParams()
     {
         // Arrange
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/account/name");
+        var previouslyStatedFirstName = Faker.Name.First();
+        var previouslyStatedMiddleName = Faker.Name.Middle();
+        var previouslyStatedLastName = Faker.Name.Last();
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            AppendQueryParameterSignature(
+                $"/account/name" +
+                $"?firstName={Uri.EscapeDataString(previouslyStatedFirstName)}" +
+                $"&middleName={Uri.EscapeDataString(previouslyStatedMiddleName)}" +
+                $"&lastName={Uri.EscapeDataString(previouslyStatedLastName)}"));
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await response.GetDocument();
+        Assert.Equal(previouslyStatedFirstName, doc.GetElementById("FirstName")?.GetAttribute("value"));
+        Assert.Equal(previouslyStatedMiddleName, doc.GetElementById("MiddleName")?.GetAttribute("value"));
+        Assert.Equal(previouslyStatedLastName, doc.GetElementById("LastName")?.GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithoutNamesInQueryParam_PopulatesFieldsFromDatabase()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            AppendQueryParameterSignature($"/account/name"));
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -163,8 +204,8 @@ public class NameTests : TestBase
         // Assert
         var doc = await response.GetDocument();
 
-        Assert.True(doc.GetElementById("FirstName")?.GetAttribute("value")?.Length > 0);
-        Assert.True(doc.GetElementById("MiddleName")?.GetAttribute("value")?.Length > 0);
-        Assert.True(doc.GetElementById("LastName")?.GetAttribute("value")?.Length > 0);
+        Assert.Equal(TestUsers.DefaultUser.FirstName, doc.GetElementById("FirstName")?.GetAttribute("value"));
+        Assert.Equal(TestUsers.DefaultUser.MiddleName, doc.GetElementById("MiddleName")?.GetAttribute("value"));
+        Assert.Equal(TestUsers.DefaultUser.LastName, doc.GetElementById("LastName")?.GetAttribute("value"));
     }
 }


### PR DESCRIPTION
### Context

When a user clicks the Change link on the confirm pages of the `/account/name` and `/account/date-of-birth` pages they’re redirected back to the input screen but the values are not what was entered, they’re the existing values.

### Changes proposed in this pull request

Amend the Change links to pass back the entered values as query parameters (with a signature). Amend the logic that populates the inputs to look for query parameters first then fallback to the DB values.

### Guidance to review

Realtively small change.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
