### PR TITLE
Add UI for generating a TRN token

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Events/TrnTokenAddedEvent.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Events/TrnTokenAddedEvent.cs
@@ -1,0 +1,11 @@
+namespace TeacherIdentity.AuthServer.Events;
+
+public record TrnTokenAddedEvent : EventBase
+{
+    public required string TrnToken { get; init; }
+    public required string Trn { get; set; }
+    public required string Email { get; set; }
+    public required DateTime ExpiresUtc { get; set; }
+    public required Guid? AddedByUserId { get; init; }
+    public required string? AddedByApiClientId { get; init; }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/GenerateTrnToken.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/GenerateTrnToken.cshtml
@@ -1,0 +1,20 @@
+@page "/admin/trn-tokens/new"
+@model TeacherIdentity.AuthServer.Pages.Admin.GenerateTrnTokenModel
+@{
+    ViewBag.Title = "Generate TRN token";
+}
+
+<form asp-page="GenerateTrnToken">
+    <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+
+    <govuk-input asp-for="Email" type="email" input-class="govuk-input--width-20" autocomplete="off" />
+
+    <govuk-input asp-for="Trn" input-class="govuk-!-width-one-quarter" spellcheck="false" />
+
+    @if (Model.TrnToken is not null)
+    {
+        <govuk-input asp-for="TrnToken" disabled input-class="govuk-input--width-20" />
+    }
+
+    <govuk-button type="submit">Generate</govuk-button>
+</form>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/GenerateTrnToken.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/GenerateTrnToken.cshtml.cs
@@ -1,0 +1,47 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeacherIdentity.AuthServer.Infrastructure.Security;
+using TeacherIdentity.AuthServer.Services.TrnTokens;
+
+namespace TeacherIdentity.AuthServer.Pages.Admin;
+
+[Authorize(AuthorizationPolicies.GetAnIdentityAdmin)]
+[BindProperties]
+public class GenerateTrnTokenModel : PageModel
+{
+    private readonly TrnTokenService _trnTokenService;
+
+    public GenerateTrnTokenModel(TrnTokenService trnTokenService)
+    {
+        _trnTokenService = trnTokenService;
+    }
+
+    [Display(Name = "Email address")]
+    [Required(ErrorMessage = "Enter the email address")]
+    public string? Email { get; set; }
+
+    [Display(Name = "TRN")]
+    [Required(ErrorMessage = "Enter the TRN")]
+    public string? Trn { get; set; }
+
+    [Display(Name = "TRN token")]
+    public string? TrnToken { get; set; }
+
+    public void OnGet()
+    {
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        TrnToken = (await _trnTokenService.GenerateToken(Email!, Trn!, apiClientId: null, currentUserId: User.GetUserId())).TrnToken;
+
+        return Page();
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/ServiceCollectionExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/ServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using TeacherIdentity.AuthServer.Services.DqtEvidence;
 using TeacherIdentity.AuthServer.Services.Establishment;
 using TeacherIdentity.AuthServer.Services.EventPublishing;
 using TeacherIdentity.AuthServer.Services.Notification;
+using TeacherIdentity.AuthServer.Services.TrnTokens;
 using TeacherIdentity.AuthServer.Services.UserImport;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 using TeacherIdentity.AuthServer.Services.Zendesk;
@@ -30,6 +31,7 @@ public static class ServiceCollectionExtensions
             .AddUserVerification(environment, configuration)
             .AddSingleton<Redactor>()
             .AddZendesk(environment, configuration)
-            .AddEventPublishing(environment);
+            .AddEventPublishing(environment)
+            .AddTrnTokens(configuration);
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/TrnTokens/ServiceCollectionExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/TrnTokens/ServiceCollectionExtensions.cs
@@ -1,0 +1,18 @@
+namespace TeacherIdentity.AuthServer.Services.TrnTokens;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddTrnTokens(
+        this IServiceCollection services,
+        IConfiguration configuration)
+    {
+        services.AddOptions<TrnTokenOptions>()
+            .Bind(configuration.GetSection("TrnTokens"))
+            .ValidateDataAnnotations()
+            .ValidateOnStart();
+
+        services.AddTransient<TrnTokenService>();
+
+        return services;
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/TrnTokens/TrnTokenOptions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/TrnTokens/TrnTokenOptions.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace TeacherIdentity.AuthServer.Services.TrnTokens;
+
+public class TrnTokenOptions
+{
+    [Required]
+    public required int TokenLifetimeDays { get; set; }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/TrnTokens/TrnTokenService.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/TrnTokens/TrnTokenService.cs
@@ -1,0 +1,73 @@
+using System.Security.Cryptography;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.Services.TrnTokens;
+
+public class TrnTokenService
+{
+    private readonly TrnTokenOptions _options;
+    private readonly TeacherIdentityServerDbContext _dbContext;
+    private readonly IClock _clock;
+
+    public TrnTokenService(
+        TeacherIdentityServerDbContext dbContext,
+        IClock clock,
+        IOptions<TrnTokenOptions> optionsAccessor)
+    {
+        _options = optionsAccessor.Value;
+        _dbContext = dbContext;
+        _clock = clock;
+    }
+
+    public async Task<TrnTokenModel> GenerateToken(
+        string email,
+        string trn,
+        string? apiClientId,
+        Guid? currentUserId)
+    {
+        if (apiClientId is null && currentUserId is null)
+        {
+            throw new ArgumentException($"Exactly one of {nameof(apiClientId)} and {nameof(currentUserId)} should be specified.");
+        }
+
+        string trnToken;
+        do
+        {
+            var buffer = new byte[8];
+            RandomNumberGenerator.Fill(buffer);
+            trnToken = Convert.ToHexString(buffer).ToLower();
+        } while (await _dbContext.TrnTokens.AnyAsync(t => t.TrnToken == trnToken));
+
+        var created = _clock.UtcNow;
+        var expires = created.AddDays(_options.TokenLifetimeDays);
+
+        var model = new TrnTokenModel()
+        {
+            TrnToken = trnToken,
+            Trn = trn,
+            Email = email,
+            CreatedUtc = created,
+            ExpiresUtc = expires,
+        };
+
+        _dbContext.TrnTokens.Add(model);
+
+        _dbContext.AddEvent(new TrnTokenAddedEvent()
+        {
+            AddedByApiClientId = apiClientId,
+            AddedByUserId = currentUserId,
+            CreatedUtc = created,
+            ExpiresUtc = expires,
+            Email = email,
+            Trn = trn,
+            TrnToken = trnToken
+        });
+
+        await _dbContext.SaveChangesAsync();
+
+        return model;
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.json
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.json
@@ -31,5 +31,8 @@
   },
   "RegisterWithTrnTokenEnabled": true,
   "BlockEstablishmentEmailDomains": false,
-  "SupportEmail": "qts.enquiries@education.gov.uk"
+  "SupportEmail": "qts.enquiries@education.gov.uk",
+  "TrnTokens": {
+    "TokenLifetimeDays": 180
+  }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/GenerateTrnTokenTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/GenerateTrnTokenTests.cs
@@ -1,0 +1,134 @@
+using TeacherIdentity.AuthServer.Events;
+
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Admin;
+
+public class GenerateTrnTokenTests : TestBase
+{
+    public GenerateTrnTokenTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_UnauthenticatedUser_RedirectsToSignIn()
+    {
+        await UnauthenticatedUser_RedirectsToSignIn(HttpMethod.Get, "/admin/trn-tokens/new");
+    }
+
+    [Fact]
+    public async Task Get_AuthenticatedUserDoesNotHavePermission_ReturnsForbidden()
+    {
+        await AuthenticatedUserDoesNotHavePermission_ReturnsForbidden(HttpMethod.Get, "/admin/trn-tokens/new");
+    }
+
+    [Fact]
+    public async Task Get_ValidRequest_RendersExpectedContent()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(HttpMethod.Get, "/admin/trn-tokens/new");
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Post_UnauthenticatedUser_RedirectsToSignIn()
+    {
+        await UnauthenticatedUser_RedirectsToSignIn(HttpMethod.Post, "/admin/trn-tokens/new");
+    }
+
+    [Fact]
+    public async Task Post_AuthenticatedUserDoesNotHavePermission_ReturnsForbidden()
+    {
+        await AuthenticatedUserDoesNotHavePermission_ReturnsForbidden(HttpMethod.Post, "/admin/trn-tokens/new");
+    }
+
+    [Fact]
+    public async Task Post_MissingEmail_RendersError()
+    {
+        // Arrange
+        var email = string.Empty;
+        var trn = TestData.GenerateTrn();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "/admin/trn-tokens/new")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Email", email },
+                { "Trn", trn }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await response.GetDocument();
+        AssertEx.HtmlDocumentHasError(doc, "Email", "Enter the email address");
+    }
+
+    [Fact]
+    public async Task Post_MissingTrn_RendersError()
+    {
+        // Arrange
+        var email = Faker.Internet.Email();
+        var trn = string.Empty;
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "/admin/trn-tokens/new")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Email", email },
+                { "Trn", trn }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await response.GetDocument();
+        AssertEx.HtmlDocumentHasError(doc, "Trn", "Enter the TRN");
+    }
+
+    [Fact]
+    public async Task Post_ValidRequest_EmitsEventAndRendersToken()
+    {
+        // Arrange
+        var userId = TestUsers.AdminUserWithAllRoles.UserId;
+        HostFixture.SetUserId(userId);
+
+        var email = Faker.Internet.Email();
+        var trn = TestData.GenerateTrn();
+
+        var request = new HttpRequestMessage(HttpMethod.Post, "/admin/trn-tokens/new")
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "Email", email },
+                { "Trn", trn }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status200OK, (int)response.StatusCode);
+        var doc = await response.GetDocument();
+        Assert.NotNull(doc.GetElementById("TrnToken")?.GetAttribute("value"));
+
+        EventObserver.AssertEventsSaved(e =>
+        {
+            var trnTokenAddedEvent = Assert.IsType<TrnTokenAddedEvent>(e);
+            Assert.Equal(Clock.UtcNow, trnTokenAddedEvent.CreatedUtc);
+            Assert.True(trnTokenAddedEvent.ExpiresUtc > Clock.UtcNow);
+            Assert.Equal(email, trnTokenAddedEvent.Email);
+            Assert.Equal(trn, trnTokenAddedEvent.Trn);
+            Assert.Equal(userId, trnTokenAddedEvent.AddedByUserId);
+        });
+    }
+}


### PR DESCRIPTION
This enables ad-hoc generation of TRN tokens so that we can more-easily test the magic link journey without relying on the QTS awardee email jobs.

As part of this I've moved all the TRN token generation logic into a service (so it can be re-used by the API endpoint as well as a Razor Page). I've also added a new event type for when a token is generated.