### PR TITLE
Added job to ensure names in identity are same as in DQT + tests

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Events/UserUpdatedEvent.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Events/UserUpdatedEvent.cs
@@ -32,4 +32,5 @@ public enum UserUpdatedEventSource
     SupportUi = 3,
     UserImport = 4,
     TrnToken = 5,
+    DqtSynchronization = 6
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Jobs/RegisterRecurringJobsHostedService.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Jobs/RegisterRecurringJobsHostedService.cs
@@ -30,5 +30,6 @@ public class RegisterRecurringJobsHostedService : IHostedService
         _recurringJobManager.AddOrUpdate<PruneTokensJob>(nameof(PruneTokensJob), job => job.Execute(CancellationToken.None), Cron.Hourly);
         _recurringJobManager.AddOrUpdate<RefreshEstablishmentDomainsJob>(nameof(RefreshEstablishmentDomainsJob), job => job.Execute(CancellationToken.None), _giasOptions.Value.RefreshEstablishmentDomainsJobSchedule);
         _recurringJobManager.AddOrUpdate<PurgeConfirmationPinsJob>(nameof(PurgeConfirmationPinsJob), job => job.Execute(CancellationToken.None), Cron.Daily);
+        _recurringJobManager.AddOrUpdate<SyncNamesWithDqtJob>(nameof(SyncNamesWithDqtJob), job => job.Execute(CancellationToken.None), Cron.Never);
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Jobs/SyncNamesWithDqtJob.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Jobs/SyncNamesWithDqtJob.cs
@@ -1,0 +1,102 @@
+using Microsoft.EntityFrameworkCore;
+using Polly;
+using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Infrastructure.Http;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Services.DqtApi;
+
+namespace TeacherIdentity.AuthServer.Jobs;
+
+public class SyncNamesWithDqtJob : IDisposable
+{
+    private const int DqtApiRetryCount = 3;
+
+    private readonly TimeSpan DqtApiDefaultRetryAfter = TimeSpan.FromSeconds(30);
+    private readonly TeacherIdentityServerDbContext _readDbContext;
+    private readonly TeacherIdentityServerDbContext _writeDbContext;
+    private readonly IDqtApiClient _dqtApiClient;
+    private readonly IClock _clock;
+
+    public SyncNamesWithDqtJob(
+        IDbContextFactory<TeacherIdentityServerDbContext> dbContextFactory,
+        IDqtApiClient dqtApiClient,
+        IClock clock)
+    {
+        _readDbContext = dbContextFactory.CreateDbContext();
+        _writeDbContext = dbContextFactory.CreateDbContext();
+        _dqtApiClient = dqtApiClient;
+        _clock = clock;
+    }
+
+    public async Task Execute(CancellationToken cancellationToken)
+    {
+        await foreach (var userWithTrn in _readDbContext.Users.Where(u => u.Trn != null).AsNoTracking().AsAsyncEnumerable())
+        {
+            var dqtTeacher = await Policy
+                    .Handle<TooManyRequestsException>()
+                    .WaitAndRetryAsync(
+                        DqtApiRetryCount,
+                        sleepDurationProvider: (retryCount, exception, context) =>
+                        {
+                            var rateLimitingException = exception as TooManyRequestsException;
+                            return rateLimitingException!.RetryAfter ?? DqtApiDefaultRetryAfter;
+                        },
+                        onRetryAsync: (exception, delay, retryCount, context) =>
+                        {
+                            return Task.CompletedTask;
+                        })
+                    .ExecuteAsync(() => _dqtApiClient.GetTeacherByTrn(userWithTrn.Trn!, cancellationToken));
+
+            if (dqtTeacher is null)
+            {
+                continue;
+            }
+
+            var changes = UserUpdatedEventChanges.None |
+                        (userWithTrn.FirstName != dqtTeacher!.FirstName ? UserUpdatedEventChanges.FirstName : UserUpdatedEventChanges.None) |
+                        (userWithTrn.MiddleName != dqtTeacher!.MiddleName ? UserUpdatedEventChanges.MiddleName : UserUpdatedEventChanges.None) |
+                        (userWithTrn.LastName != dqtTeacher!.LastName ? UserUpdatedEventChanges.LastName : UserUpdatedEventChanges.None);
+
+            if (changes == UserUpdatedEventChanges.None)
+            {
+                continue;
+            }
+
+            var userToUpdate = await _writeDbContext.Users.Where(u => u.UserId == userWithTrn.UserId).SingleAsync();
+            if (changes.HasFlag(UserUpdatedEventChanges.FirstName))
+            {
+                userToUpdate.FirstName = dqtTeacher.FirstName;
+            }
+
+            if (changes.HasFlag(UserUpdatedEventChanges.MiddleName))
+            {
+                userToUpdate.MiddleName = dqtTeacher.MiddleName;
+            }
+
+            if (changes.HasFlag(UserUpdatedEventChanges.LastName))
+            {
+                userToUpdate.LastName = dqtTeacher.LastName;
+            }
+
+            userToUpdate.Updated = _clock.UtcNow;
+
+            _writeDbContext.AddEvent(new UserUpdatedEvent()
+            {
+                Source = UserUpdatedEventSource.DqtSynchronization,
+                UpdatedByClientId = null,
+                UpdatedByUserId = null,
+                CreatedUtc = userToUpdate.Updated,
+                User = Events.User.FromModel(userToUpdate),
+                Changes = changes
+            });
+
+            await _writeDbContext.SaveChangesAsync();
+        }
+    }
+
+    public void Dispose()
+    {
+        ((IDisposable)_readDbContext).Dispose();
+        ((IDisposable)_writeDbContext).Dispose();
+    }
+}

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Jobs/SyncNamesWithDqtJobTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Jobs/SyncNamesWithDqtJobTests.cs
@@ -1,0 +1,170 @@
+using System.Text.Json;
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Jobs;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Services.DqtApi;
+using User = TeacherIdentity.AuthServer.Models.User;
+
+namespace TeacherIdentity.AuthServer.Tests.Jobs;
+
+public class SyncNamesWithDqtJobTests : IClassFixture<DbFixture>
+{
+    private readonly DbFixture _dbFixture;
+
+    public SyncNamesWithDqtJobTests(DbFixture dbFixture)
+    {
+        _dbFixture = dbFixture;
+    }
+
+    [Fact]
+    public async Task Execute_WhenDqtNamesAreDifferentToIdentity_UpdatesUserAndInsertsEvent()
+    {
+        // Arrange
+        var trn = "1234567";
+        var created = _dbFixture.Clock.UtcNow.AddDays(-5);
+        var user = new User
+        {
+            UserId = Guid.NewGuid(),
+            EmailAddress = Faker.Internet.Email(),
+            FirstName = Faker.Name.First(),
+            MiddleName = Faker.Name.Middle(),
+            LastName = Faker.Name.Last(),
+            Created = created,
+            Updated = created,
+            DateOfBirth = new DateOnly(1969, 12, 1),
+            Trn = trn,
+            TrnAssociationSource = TrnAssociationSource.Api,
+            TrnLookupStatus = TrnLookupStatus.Found,
+            UserType = UserType.Teacher
+        };
+
+        await _dbFixture.TestData.WithDbContext(async dbContext =>
+        {
+            dbContext.Users.Add(user);
+            await dbContext.SaveChangesAsync();
+        });
+
+        var dqtTeacher = new TeacherInfo()
+        {
+            Trn = trn,
+            FirstName = Faker.Name.First(),
+            MiddleName = Faker.Name.Middle(),
+            LastName = Faker.Name.Last(),
+            DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
+            NationalInsuranceNumber = null,
+            PendingNameChange = false,
+            PendingDateOfBirthChange = false,
+            Email = Faker.Internet.Email()
+        };
+
+        var dqtApiClient = Mock.Of<IDqtApiClient>();
+        Mock.Get(dqtApiClient)
+            .Setup(d => d.GetTeacherByTrn(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(dqtTeacher);
+
+        // Act
+        var job = new SyncNamesWithDqtJob(
+            _dbFixture.GetDbContextFactory(),
+            dqtApiClient,
+            _dbFixture.Clock);
+        await job.Execute(CancellationToken.None);
+
+        // Assert
+        await _dbFixture.TestData.WithDbContext(async dbContext =>
+        {
+            var updatedUser = await dbContext.Users.SingleAsync(r => r.Trn == trn);
+            Assert.Equal(dqtTeacher.FirstName, updatedUser.FirstName);
+            Assert.Equal(dqtTeacher.MiddleName, updatedUser.MiddleName);
+            Assert.Equal(dqtTeacher.LastName, updatedUser.LastName);
+            Assert.Equal(user.DateOfBirth, updatedUser.DateOfBirth); // i.e. doesn't get changed from DQT
+            Assert.Equal(user.EmailAddress, updatedUser.EmailAddress); // i.e. doesn't get changed from DQT
+            Assert.Equal(_dbFixture.Clock.UtcNow, updatedUser.Updated);
+
+            var userUpdatedEvents = await dbContext.Events
+                    .Where(e => e.EventName == "UserUpdatedEvent").ToListAsync();
+            var userUpdatedEvent = userUpdatedEvents
+                .Select(e => JsonSerializer.Deserialize<UserUpdatedEvent>(e.Payload))
+                .Where(u => u!.User.Trn == trn)
+                .SingleOrDefault();
+            Assert.NotNull(userUpdatedEvent);
+            Assert.Equal(dqtTeacher.FirstName, userUpdatedEvent.User.FirstName);
+            Assert.Equal(dqtTeacher.MiddleName, userUpdatedEvent.User.MiddleName);
+            Assert.Equal(dqtTeacher.LastName, userUpdatedEvent.User.LastName);
+        });
+    }
+
+    [Fact]
+    public async Task Execute_WhenDqtNamesAreTheSameAsIdentity_DoesNotUpdateUserOrInsertAnEvent()
+    {
+        // Arrange
+        var trn = "1234567";
+        var firstName = Faker.Name.First();
+        var middleName = Faker.Name.Middle();
+        var lastName = Faker.Name.Last();
+
+        var created = _dbFixture.Clock.UtcNow.AddDays(-5);
+
+        var user = new User
+        {
+            UserId = Guid.NewGuid(),
+            EmailAddress = Faker.Internet.Email(),
+            FirstName = firstName,
+            MiddleName = middleName,
+            LastName = lastName,
+            Created = created,
+            Updated = created,
+            DateOfBirth = new DateOnly(1969, 12, 1),
+            Trn = trn,
+            TrnAssociationSource = TrnAssociationSource.Api,
+            TrnLookupStatus = TrnLookupStatus.Found,
+            UserType = UserType.Teacher
+        };
+
+        await _dbFixture.TestData.WithDbContext(async dbContext =>
+        {
+            dbContext.Users.Add(user);
+            await dbContext.SaveChangesAsync();
+        });
+
+        var dqtTeacher = new TeacherInfo()
+        {
+            Trn = trn,
+            FirstName = firstName,
+            MiddleName = middleName,
+            LastName = lastName,
+            DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
+            NationalInsuranceNumber = null,
+            PendingNameChange = false,
+            PendingDateOfBirthChange = false,
+            Email = Faker.Internet.Email()
+        };
+
+        var dqtApiClient = Mock.Of<IDqtApiClient>();
+        Mock.Get(dqtApiClient)
+            .Setup(d => d.GetTeacherByTrn(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(dqtTeacher);
+
+        // Act
+        var job = new SyncNamesWithDqtJob(
+            _dbFixture.GetDbContextFactory(),
+            dqtApiClient,
+            _dbFixture.Clock);
+        await job.Execute(CancellationToken.None);
+
+        // Assert
+        await _dbFixture.TestData.WithDbContext(async dbContext =>
+        {
+            var updatedUser = await dbContext.Users.SingleAsync(r => r.Trn == trn);
+            Assert.Equal(created, updatedUser.Updated);
+
+            var userUpdatedEvents = await dbContext.Events
+                    .Where(e => e.EventName == "UserUpdatedEvent").ToListAsync();
+            var userUpdatedEvent = userUpdatedEvents
+                .Select(e => JsonSerializer.Deserialize<UserUpdatedEvent>(e.Payload))
+                .Where(u => u!.User.Trn == trn)
+                .SingleOrDefault();
+            Assert.Null(userUpdatedEvent);
+        });
+    }
+}


### PR DESCRIPTION
### Context

We’re amending ID accounts such that those linked to a DQT have their names synced with DQT.

### Changes proposed in this pull request

Create a Hangfire job that can be manually triggered from the Dashboard that queries DQT for every User that has a TRN and updates the FirstName, MiddleName and LastName from the corresponding DQT record.

### Guidance to review

N/A

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
