### PR TITLE
Added interceptor to prevent specific entities being updated by tests and affecting other tests

### DIFF
--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/PreventChangesToEntitiesInterceptor.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.TestCommon/PreventChangesToEntitiesInterceptor.cs
@@ -1,0 +1,38 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
+namespace TeacherIdentity.AuthServer.TestCommon;
+
+public class PreventChangesToEntitiesInterceptor<TEntity, TId> : SaveChangesInterceptor where TEntity : class
+{
+    private readonly IEnumerable<TId> _entityIds;
+    private readonly Func<TEntity, TId> _idAccessor;
+
+    public PreventChangesToEntitiesInterceptor(IEnumerable<TId> entityIds, Func<TEntity, TId> idAccessor)
+    {
+        _entityIds = entityIds;
+        _idAccessor = idAccessor;
+    }
+
+    public override InterceptionResult<int> SavingChanges(DbContextEventData eventData, InterceptionResult<int> result)
+    {
+        throw new NotImplementedException();
+    }
+
+    public override ValueTask<InterceptionResult<int>> SavingChangesAsync(DbContextEventData eventData, InterceptionResult<int> result, CancellationToken cancellationToken = default)
+    {
+        var entities = eventData.Context!.ChangeTracker.Entries<TEntity>();
+
+        foreach (var entity in entities)
+        {
+            if ((entity.State == EntityState.Modified
+                || entity.State == EntityState.Deleted)
+                && _entityIds.Contains(_idAccessor(entity.Entity)))
+            {
+                throw new InvalidOperationException("Existing entity cannot be modified or deleted, consider using new entities within tests.");
+            }
+        }
+
+        return base.SavingChangesAsync(eventData, result, cancellationToken);
+    }
+}


### PR DESCRIPTION
### Context

There are some default users set up in the test project which should NOT be changed by individual tests as
it may have a knock-on affect on other tests and lead to flakey results.

### Changes proposed in this pull request

Add an interceptor in the DbContext SaveChangesAsync execution path to stop changes to specific entities.
At the moment this is just certain default users.

### Guidance to review

N/A

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
