### PR TITLE
Ignore trn scope when determining journey to use

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/SignInJourneyProvider.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/SignInJourneyProvider.cs
@@ -1,5 +1,4 @@
 using TeacherIdentity.AuthServer.Models;
-using TeacherIdentity.AuthServer.Oidc;
 
 namespace TeacherIdentity.AuthServer.Journeys;
 
@@ -9,7 +8,7 @@ public class SignInJourneyProvider
     {
         if (authenticationState.TryGetOAuthState(out var oAuthState) && authenticationState.UserRequirements.RequiresTrnLookup())
         {
-            if (oAuthState.TrnRequirementType == TrnRequirementType.Legacy || oAuthState.HasScope(CustomScopes.Trn))
+            if (oAuthState.TrnRequirementType == TrnRequirementType.Legacy)
             {
                 return ActivatorUtilities.CreateInstance<LegacyTrnJourney>(httpContext.RequestServices, httpContext);
             }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnInUseChooseEmailTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnInUseChooseEmailTests.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Oidc;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn;
@@ -43,14 +44,17 @@ public class TrnInUseChooseEmailTests : TestBase
             "/sign-in/trn/choose-email");
     }
 
-    [Fact]
-    public async Task Get_TrnNotFound_Redirects()
+    [Theory]
+    [InlineData(TrnRequirementType.Optional, "/sign-in/register/")]
+    [InlineData(TrnRequirementType.Required, "/sign-in/register/")]
+    [InlineData(TrnRequirementType.Legacy, "/sign-in/trn")]
+    public async Task Get_TrnNotFound_Redirects(TrnRequirementType trnRequirementType, string expectedRedirectLocation)
     {
         // Arrange
         var authStateHelper = await CreateAuthenticationStateHelper(
             c => c.Trn.TrnLookup(AuthenticationState.TrnLookupState.None, user: null),
             CustomScopes.Trn,
-            trnRequirementType: null);
+            trnRequirementType);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/choose-email?{authStateHelper.ToQueryParam()}");
 
@@ -59,7 +63,7 @@ public class TrnInUseChooseEmailTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith("/sign-in/trn", response.Headers.Location?.OriginalString);
+        Assert.StartsWith(expectedRedirectLocation, response.Headers.Location?.OriginalString);
     }
 
     [Fact]
@@ -160,8 +164,11 @@ public class TrnInUseChooseEmailTests : TestBase
             "/sign-in/trn/choose-email");
     }
 
-    [Fact]
-    public async Task Post_TrnNotFound_Redirects()
+    [Theory]
+    [InlineData(TrnRequirementType.Optional, "/sign-in/register/")]
+    [InlineData(TrnRequirementType.Required, "/sign-in/register/")]
+    [InlineData(TrnRequirementType.Legacy, "/sign-in/trn")]
+    public async Task Post_TrnNotFound_Redirects(TrnRequirementType trnRequirementType, string expectedRedirectLocation)
     {
         // Arrange
         var email = Faker.Internet.Email();
@@ -169,7 +176,7 @@ public class TrnInUseChooseEmailTests : TestBase
         var authStateHelper = await CreateAuthenticationStateHelper(
             c => c.Trn.TrnLookup(AuthenticationState.TrnLookupState.None, user: null),
             CustomScopes.Trn,
-            trnRequirementType: null);
+            trnRequirementType);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/choose-email?{authStateHelper.ToQueryParam()}")
         {
@@ -184,7 +191,7 @@ public class TrnInUseChooseEmailTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith("/sign-in/trn", response.Headers.Location?.OriginalString);
+        Assert.StartsWith(expectedRedirectLocation, response.Headers.Location?.OriginalString);
     }
 
     [Fact]

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnInUseTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnInUseTests.cs
@@ -1,4 +1,5 @@
 using Microsoft.Extensions.Options;
+using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Oidc;
 using TeacherIdentity.AuthServer.Services;
 using TeacherIdentity.AuthServer.Services.UserVerification;
@@ -44,14 +45,17 @@ public class TrnInUseTests : TestBase
             "/sign-in/trn/different-email");
     }
 
-    [Fact]
-    public async Task Get_TrnNotFound_Redirects()
+    [Theory]
+    [InlineData(TrnRequirementType.Optional, "/sign-in/register/")]
+    [InlineData(TrnRequirementType.Required, "/sign-in/register/")]
+    [InlineData(TrnRequirementType.Legacy, "/sign-in/trn")]
+    public async Task Get_TrnNotFound_Redirects(TrnRequirementType trnRequirementType, string expectedRedirectLocation)
     {
         // Arrange
         var authStateHelper = await CreateAuthenticationStateHelper(
             c => c.Trn.TrnLookup(AuthenticationState.TrnLookupState.None, user: null),
             CustomScopes.Trn,
-            trnRequirementType: null);
+            trnRequirementType);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn/different-email?{authStateHelper.ToQueryParam()}");
 
@@ -60,7 +64,7 @@ public class TrnInUseTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith("/sign-in/trn", response.Headers.Location?.OriginalString);
+        Assert.StartsWith(expectedRedirectLocation, response.Headers.Location?.OriginalString);
     }
 
     [Fact]
@@ -161,8 +165,11 @@ public class TrnInUseTests : TestBase
             "/sign-in/trn/different-email");
     }
 
-    [Fact]
-    public async Task Post_TrnNotFound_Redirects()
+    [Theory]
+    [InlineData(TrnRequirementType.Optional, "/sign-in/register/")]
+    [InlineData(TrnRequirementType.Required, "/sign-in/register/")]
+    [InlineData(TrnRequirementType.Legacy, "/sign-in/trn")]
+    public async Task Post_TrnNotFound_Redirects(TrnRequirementType trnRequirementType, string expectedRedirectLocation)
     {
         // Arrange
         var pin = "12345";
@@ -170,7 +177,7 @@ public class TrnInUseTests : TestBase
         var authStateHelper = await CreateAuthenticationStateHelper(
             c => c.Trn.TrnLookup(AuthenticationState.TrnLookupState.None, user: null),
             CustomScopes.Trn,
-            trnRequirementType: null);
+            trnRequirementType);
 
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/trn/different-email?{authStateHelper.ToQueryParam()}")
         {
@@ -185,7 +192,7 @@ public class TrnInUseTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.StartsWith("/sign-in/trn", response.Headers.Location?.OriginalString);
+        Assert.StartsWith(expectedRedirectLocation, response.Headers.Location?.OriginalString);
     }
 
     [Fact]

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/TrnTests.cs
@@ -67,7 +67,7 @@ public class TrnTests : TestBase
     public async Task Get_ValidRequest_ReturnsOk()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified(), CustomScopes.Trn);
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified(), CustomScopes.Trn, trnRequirementType: TrnRequirementType.Legacy);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn?{authStateHelper.ToQueryParam()}");
 
@@ -101,7 +101,7 @@ public class TrnTests : TestBase
     public async Task Get_WithDefaultClient_RendersCorrectContent()
     {
         // Arrange
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified(), CustomScopes.Trn);
+        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailVerified(), CustomScopes.Trn, TrnRequirementType.Legacy);
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/trn?{authStateHelper.ToQueryParam()}");
 


### PR DESCRIPTION
Before we had `TrnRequirementType` we used scope to know whether to use the Legacy journey or not. This removes that check so we can transition NPQ to the Core journey.