### PR TITLE
Backfill preferred name job

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Events/UserUpdatedEvent.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Events/UserUpdatedEvent.cs
@@ -32,5 +32,6 @@ public enum UserUpdatedEventSource
     SupportUi = 3,
     UserImport = 4,
     TrnToken = 5,
-    DqtSynchronization = 6
+    DqtSynchronization = 6,
+    System = 7
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Jobs/PopulatePreferredNameJob.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Jobs/PopulatePreferredNameJob.cs
@@ -1,0 +1,50 @@
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Events;
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.Jobs;
+
+public class PopulatePreferredNameJob : IDisposable
+{
+    private readonly TeacherIdentityServerDbContext _readDbContext;
+    private readonly TeacherIdentityServerDbContext _writeDbContext;
+    private readonly IClock _clock;
+
+    public PopulatePreferredNameJob(
+        IDbContextFactory<TeacherIdentityServerDbContext> dbContextFactory,
+        IClock clock)
+    {
+        _readDbContext = dbContextFactory.CreateDbContext();
+        _writeDbContext = dbContextFactory.CreateDbContext();
+        _clock = clock;
+    }
+
+    public async Task Execute(CancellationToken cancellationToken)
+    {
+        await foreach (var userWithoutPreferredName in _readDbContext.Users.Where(u => u.UserType != UserType.Staff && string.IsNullOrEmpty(u.PreferredName)).AsNoTracking().AsAsyncEnumerable())
+        {
+            var userToUpdate = await _writeDbContext.Users.Where(u => u.UserId == userWithoutPreferredName.UserId).SingleAsync();
+            userToUpdate.PreferredName = $"{userWithoutPreferredName.FirstName} {userWithoutPreferredName.LastName}";
+            userToUpdate.Updated = _clock.UtcNow;
+
+            _writeDbContext.AddEvent(new UserUpdatedEvent()
+            {
+                Source = UserUpdatedEventSource.System,
+                UpdatedByClientId = null,
+                UpdatedByUserId = null,
+                CreatedUtc = userToUpdate.Updated,
+                User = Events.User.FromModel(userToUpdate),
+                Changes = UserUpdatedEventChanges.PreferredName
+            });
+
+            await _writeDbContext.SaveChangesAsync(cancellationToken);
+        }
+    }
+
+
+    public void Dispose()
+    {
+        ((IDisposable)_readDbContext).Dispose();
+        ((IDisposable)_writeDbContext).Dispose();
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Jobs/RegisterRecurringJobsHostedService.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Jobs/RegisterRecurringJobsHostedService.cs
@@ -31,5 +31,6 @@ public class RegisterRecurringJobsHostedService : IHostedService
         _recurringJobManager.AddOrUpdate<RefreshEstablishmentDomainsJob>(nameof(RefreshEstablishmentDomainsJob), job => job.Execute(CancellationToken.None), _giasOptions.Value.RefreshEstablishmentDomainsJobSchedule);
         _recurringJobManager.AddOrUpdate<PurgeConfirmationPinsJob>(nameof(PurgeConfirmationPinsJob), job => job.Execute(CancellationToken.None), Cron.Daily);
         _recurringJobManager.AddOrUpdate<SyncNamesWithDqtJob>(nameof(SyncNamesWithDqtJob), job => job.Execute(CancellationToken.None), Cron.Never);
+        _recurringJobManager.AddOrUpdate<PopulatePreferredNameJob>(nameof(PopulatePreferredNameJob), job => job.Execute(CancellationToken.None), Cron.Never);
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Jobs/PopulatePreferredNameJobTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Jobs/PopulatePreferredNameJobTests.cs
@@ -174,9 +174,4 @@ public class PopulatePreferredNameJobTests : IClassFixture<DbFixture>, IAsyncLif
             Assert.Null(userUpdatedEvent);
         });
     }
-
-    private async Task ClearNonTestUsers()
-    {
-
-    }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Jobs/PopulatePreferredNameJobTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Jobs/PopulatePreferredNameJobTests.cs
@@ -3,17 +3,16 @@ using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Events;
 using TeacherIdentity.AuthServer.Jobs;
 using TeacherIdentity.AuthServer.Models;
-using TeacherIdentity.AuthServer.Services.DqtApi;
 using User = TeacherIdentity.AuthServer.Models.User;
 
 namespace TeacherIdentity.AuthServer.Tests.Jobs;
 
 [Collection(nameof(DisableParallelization))]
-public class SyncNamesWithDqtJobTests : IClassFixture<DbFixture>, IAsyncLifetime
+public class PopulatePreferredNameJobTests : IClassFixture<DbFixture>, IAsyncLifetime
 {
     private readonly DbFixture _dbFixture;
 
-    public SyncNamesWithDqtJobTests(DbFixture dbFixture)
+    public PopulatePreferredNameJobTests(DbFixture dbFixture)
     {
         _dbFixture = dbFixture;
     }
@@ -30,7 +29,7 @@ public class SyncNamesWithDqtJobTests : IClassFixture<DbFixture>, IAsyncLifetime
     public Task DisposeAsync() => Task.CompletedTask;
 
     [Fact]
-    public async Task Execute_WhenDqtNamesAreDifferentToIdentity_UpdatesUserAndInsertsEvent()
+    public async Task Execute_WhenPreferredNameIsNullAndUserTypeIsTeacher_UpdatesUserAndInsertsEvent()
     {
         // Arrange
         var trn = "1234567";
@@ -57,40 +56,17 @@ public class SyncNamesWithDqtJobTests : IClassFixture<DbFixture>, IAsyncLifetime
             await dbContext.SaveChangesAsync();
         });
 
-        var dqtTeacher = new TeacherInfo()
-        {
-            Trn = trn,
-            FirstName = Faker.Name.First(),
-            MiddleName = Faker.Name.Middle(),
-            LastName = Faker.Name.Last(),
-            DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
-            NationalInsuranceNumber = null,
-            PendingNameChange = false,
-            PendingDateOfBirthChange = false,
-            Email = Faker.Internet.Email()
-        };
-
-        var dqtApiClient = Mock.Of<IDqtApiClient>();
-        Mock.Get(dqtApiClient)
-            .Setup(d => d.GetTeacherByTrn(trn, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(dqtTeacher);
-
         // Act
-        var job = new SyncNamesWithDqtJob(
+        var job = new PopulatePreferredNameJob(
             _dbFixture.GetDbContextFactory(),
-            dqtApiClient,
             _dbFixture.Clock);
         await job.Execute(CancellationToken.None);
 
         // Assert
         await _dbFixture.TestData.WithDbContext(async dbContext =>
         {
-            var updatedUser = await dbContext.Users.SingleAsync(r => r.Trn == trn);
-            Assert.Equal(dqtTeacher.FirstName, updatedUser.FirstName);
-            Assert.Equal(dqtTeacher.MiddleName, updatedUser.MiddleName);
-            Assert.Equal(dqtTeacher.LastName, updatedUser.LastName);
-            Assert.Equal(user.DateOfBirth, updatedUser.DateOfBirth); // i.e. doesn't get changed from DQT
-            Assert.Equal(user.EmailAddress, updatedUser.EmailAddress); // i.e. doesn't get changed from DQT
+            var updatedUser = await dbContext.Users.SingleAsync(r => r.UserId == user.UserId);
+            Assert.Equal($"{user.FirstName} {user.LastName}", updatedUser.PreferredName);
             Assert.Equal(_dbFixture.Clock.UtcNow, updatedUser.Updated);
 
             var userUpdatedEvents = await dbContext.Events
@@ -100,36 +76,26 @@ public class SyncNamesWithDqtJobTests : IClassFixture<DbFixture>, IAsyncLifetime
                 .Where(u => u!.User.Trn == trn)
                 .SingleOrDefault();
             Assert.NotNull(userUpdatedEvent);
-            Assert.Equal(dqtTeacher.FirstName, userUpdatedEvent.User.FirstName);
-            Assert.Equal(dqtTeacher.MiddleName, userUpdatedEvent.User.MiddleName);
-            Assert.Equal(dqtTeacher.LastName, userUpdatedEvent.User.LastName);
+            Assert.Equal($"{user.FirstName} {user.LastName}", userUpdatedEvent.User.PreferredName);
         });
     }
 
     [Fact]
-    public async Task Execute_WhenDqtNamesAreTheSameAsIdentity_DoesNotUpdateUserOrInsertAnEvent()
+    public async Task Execute_WhenPreferredNameIsAlreadySetAndUserTypeIsTeacher_DoesNotUpdateUserOrInsertAnEvent()
     {
         // Arrange
-        var trn = "1234567";
-        var firstName = Faker.Name.First();
-        var middleName = Faker.Name.Middle();
-        var lastName = Faker.Name.Last();
-
         var created = _dbFixture.Clock.UtcNow.AddDays(-5);
-
         var user = new User
         {
             UserId = Guid.NewGuid(),
             EmailAddress = Faker.Internet.Email(),
-            FirstName = firstName,
-            MiddleName = middleName,
-            LastName = lastName,
+            FirstName = Faker.Name.First(),
+            MiddleName = Faker.Name.Middle(),
+            LastName = Faker.Name.Last(),
+            PreferredName = Faker.Name.FullName(),
             Created = created,
             Updated = created,
             DateOfBirth = new DateOnly(1969, 12, 1),
-            Trn = trn,
-            TrnAssociationSource = TrnAssociationSource.Api,
-            TrnLookupStatus = TrnLookupStatus.Found,
             UserType = UserType.Teacher
         };
 
@@ -139,44 +105,78 @@ public class SyncNamesWithDqtJobTests : IClassFixture<DbFixture>, IAsyncLifetime
             await dbContext.SaveChangesAsync();
         });
 
-        var dqtTeacher = new TeacherInfo()
-        {
-            Trn = trn,
-            FirstName = firstName,
-            MiddleName = middleName,
-            LastName = lastName,
-            DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
-            NationalInsuranceNumber = null,
-            PendingNameChange = false,
-            PendingDateOfBirthChange = false,
-            Email = Faker.Internet.Email()
-        };
-
-        var dqtApiClient = Mock.Of<IDqtApiClient>();
-        Mock.Get(dqtApiClient)
-            .Setup(d => d.GetTeacherByTrn(trn, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(dqtTeacher);
-
         // Act
-        var job = new SyncNamesWithDqtJob(
+        var job = new PopulatePreferredNameJob(
             _dbFixture.GetDbContextFactory(),
-            dqtApiClient,
             _dbFixture.Clock);
         await job.Execute(CancellationToken.None);
 
         // Assert
         await _dbFixture.TestData.WithDbContext(async dbContext =>
         {
-            var nonUpdatedUser = await dbContext.Users.SingleAsync(r => r.Trn == trn);
+            var nonUpdatedUser = await dbContext.Users.SingleAsync(r => r.UserId == user.UserId);
+            Assert.Equal(user.PreferredName, nonUpdatedUser.PreferredName);
             Assert.Equal(created, nonUpdatedUser.Updated);
 
             var userUpdatedEvents = await dbContext.Events
                     .Where(e => e.EventName == "UserUpdatedEvent").ToListAsync();
             var userUpdatedEvent = userUpdatedEvents
                 .Select(e => JsonSerializer.Deserialize<UserUpdatedEvent>(e.Payload))
-                .Where(u => u!.User.Trn == trn)
+                .Where(u => u!.User.UserId == user.UserId)
                 .SingleOrDefault();
             Assert.Null(userUpdatedEvent);
         });
+    }
+
+    [Fact]
+    public async Task Execute_WhenPreferredNameIsNullAndUserTypeIsStaff_DoesNotUpdateUserOrInsertAnEvent()
+    {
+        // Arrange
+        var created = _dbFixture.Clock.UtcNow.AddDays(-5);
+        var user = new User
+        {
+            UserId = Guid.NewGuid(),
+            EmailAddress = Faker.Internet.Email(),
+            FirstName = Faker.Name.First(),
+            MiddleName = Faker.Name.Middle(),
+            LastName = Faker.Name.Last(),
+            Created = created,
+            Updated = created,
+            DateOfBirth = null,
+            UserType = UserType.Staff
+        };
+
+        await _dbFixture.TestData.WithDbContext(async dbContext =>
+        {
+            dbContext.Users.Add(user);
+            await dbContext.SaveChangesAsync();
+        });
+
+        // Act
+        var job = new PopulatePreferredNameJob(
+            _dbFixture.GetDbContextFactory(),
+            _dbFixture.Clock);
+        await job.Execute(CancellationToken.None);
+
+        // Assert
+        await _dbFixture.TestData.WithDbContext(async dbContext =>
+        {
+            var nonUpdatedUser = await dbContext.Users.SingleAsync(r => r.UserId == user.UserId);
+            Assert.Null(nonUpdatedUser.PreferredName);
+            Assert.Equal(created, nonUpdatedUser.Updated);
+
+            var userUpdatedEvents = await dbContext.Events
+                    .Where(e => e.EventName == "UserUpdatedEvent").ToListAsync();
+            var userUpdatedEvent = userUpdatedEvents
+                .Select(e => JsonSerializer.Deserialize<UserUpdatedEvent>(e.Payload))
+                .Where(u => u!.User.UserId == user.UserId)
+                .SingleOrDefault();
+            Assert.Null(userUpdatedEvent);
+        });
+    }
+
+    private async Task ClearNonTestUsers()
+    {
+
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Services/UserImport/UserImportProcessorTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Services/UserImport/UserImportProcessorTests.cs
@@ -22,7 +22,11 @@ public class UserImportProcessorTests : IClassFixture<DbFixture>, IAsyncLifetime
 
     public async Task InitializeAsync()
     {
-        await ClearNonTestUsers();
+        await _dbFixture.TestData.WithDbContext(async dbContext =>
+        {
+            await TestUsers.DeleteNonTestUsers(dbContext);
+            await dbContext.Database.ExecuteSqlAsync($"truncate table events");
+        });
     }
 
     public Task DisposeAsync() => Task.CompletedTask;
@@ -874,14 +878,6 @@ public class UserImportProcessorTests : IClassFixture<DbFixture>, IAsyncLifetime
 
                 Assert.Collection(userImportJobRow!.Notes, elementInspectors.ToArray());
             }
-        });
-    }
-
-    private async Task ClearNonTestUsers()
-    {
-        await _dbFixture.TestData.WithDbContext(async dbContext =>
-        {
-            await TestUsers.DeleteNonTestUsers(dbContext);
         });
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/TestUsers.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/TestUsers.cs
@@ -42,6 +42,7 @@ public static class TestUsers
         FirstName = Faker.Name.First(),
         MiddleName = Faker.Name.Middle(),
         LastName = Faker.Name.Last(),
+        PreferredName = Faker.Name.FullName(),
         Updated = DateTime.UtcNow,
         UserType = UserType.Default,
         StaffRoles = StaffRoles.None
@@ -56,6 +57,7 @@ public static class TestUsers
         FirstName = Faker.Name.First(),
         MiddleName = Faker.Name.Middle(),
         LastName = Faker.Name.Last(),
+        PreferredName = Faker.Name.FullName(),
         Updated = DateTime.UtcNow,
         UserType = UserType.Default,
         StaffRoles = StaffRoles.None,


### PR DESCRIPTION
### Context

We’ve added preferred name to the Core registration journey but some accounts pre-date that change (or have used the Legacy TRN journey which doesn’t capture preferred name) so don’t have a preferred name set. Before we overwrite names with DQT names we need to populate preferred name for all users.

### Changes proposed in this pull request

Create a Hangfire job that can be manually triggered that sets a preferred name for all non-Staff users. The preferred name should be FirstName + " " + LastName. A UserUpdatedEvent should be created as appropriate. Existing preferred names should not be overwritten.

### Guidance to review

N/A

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
