### PR TITLE
Don't use Session for API or infra endpoints

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
@@ -560,7 +560,9 @@ public class Program
 
         app.UseStaticFiles();
 
-        app.UseSession();
+        app.UseWhen(
+            ctx => !ctx.Request.Path.StartsWithSegments("/api") && ctx.Request.Path != "/health" && ctx.Request.Path != "/status" && ctx.Request.Path != "/_sha",
+            x => x.UseSession());
 
         app.UseMiddleware<AuthenticationStateMiddleware>();
         app.UseWhen(ctx => ctx.Request.Path.StartsWithSegments("/account"), x => x.UseMiddleware<Infrastructure.Middleware.ClientRedirectInfoMiddleware>());


### PR DESCRIPTION
We've got errors in Sentry for Redis timeouts for session loading for endpoints that don't even need Session. This change removes the SessionMiddleware for API endpoints and some health/status-like endpoints where it's not required.