### PR TITLE
Move AuthenticationState into Postgres

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
@@ -27,6 +27,7 @@ public class AuthorizationController : Controller
     private readonly TeacherIdentityServerDbContext _dbContext;
     private readonly IClock _clock;
     private readonly TrnTokenHelper _trnTokenHelper;
+
     public AuthorizationController(
         TeacherIdentityApplicationManager applicationManager,
         IOpenIddictAuthorizationManager authorizationManager,

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230721130100_AuthenticationStates.Designer.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230721130100_AuthenticationStates.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeacherIdentity.AuthServer.Models;
@@ -12,9 +13,11 @@ using TeacherIdentity.AuthServer.Models;
 namespace TeacherIdentity.AuthServer.Migrations
 {
     [DbContext(typeof(TeacherIdentityServerDbContext))]
-    partial class TeacherIdentityServerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20230721130100_AuthenticationStates")]
+    partial class AuthenticationStates
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230721130100_AuthenticationStates.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20230721130100_AuthenticationStates.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeacherIdentity.AuthServer.Migrations
+{
+    /// <inheritdoc />
+    public partial class AuthenticationStates : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "authentication_states",
+                columns: table => new
+                {
+                    journey_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    payload = table.Column<string>(type: "jsonb", nullable: false),
+                    created = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    last_accessed = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("pk_authentication_states", x => x.journey_id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_authentication_states_payload",
+                table: "authentication_states",
+                column: "payload")
+                .Annotation("Npgsql:IndexMethod", "gin");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "authentication_states");
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/AuthenticationState.cs
@@ -1,0 +1,9 @@
+namespace TeacherIdentity.AuthServer.Models;
+
+public class AuthenticationState
+{
+    public required Guid JourneyId { get; init; }
+    public required string Payload { get; set; }
+    public required DateTime Created { get; init; }
+    public required DateTime LastAccessed { get; set; }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/Mappings/AuthenticationStateMapping.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/Mappings/AuthenticationStateMapping.cs
@@ -1,0 +1,16 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace TeacherIdentity.AuthServer.Models.Mappings;
+
+public class AuthenticationStateMapping : IEntityTypeConfiguration<AuthenticationState>
+{
+    public void Configure(EntityTypeBuilder<AuthenticationState> builder)
+    {
+        builder.HasKey(s => s.JourneyId);
+        builder.Property(e => e.Payload).IsRequired().HasColumnType("jsonb");
+        builder.Property(e => e.Created).IsRequired();
+        builder.Property(e => e.LastAccessed).IsRequired();
+        builder.HasIndex(e => e.Payload).HasMethod("gin");
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/TeacherIdentityServerDbContext.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Models/TeacherIdentityServerDbContext.cs
@@ -53,6 +53,8 @@ public class TeacherIdentityServerDbContext : DbContext
 
     public DbSet<TrnTokenModel> TrnTokens => Set<TrnTokenModel>();
 
+    public DbSet<AuthenticationState> AuthenticationStates => Set<AuthenticationState>();
+
     public void AddEvent(EventBase @event)
     {
         Events.Add(Event.FromEventBase(@event));

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Oidc/AuthenticationStateCurrentClientProvider.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Oidc/AuthenticationStateCurrentClientProvider.cs
@@ -28,7 +28,7 @@ public class AuthenticationStateCurrentClientProvider : ICurrentClientProvider
             return null;
         }
 
-        var clientId = _authenticationStateProvider.GetAuthenticationState(_httpContextAccessor.HttpContext)?.OAuthState?.ClientId ??
+        var clientId = (await _authenticationStateProvider.GetAuthenticationState(_httpContextAccessor.HttpContext))?.OAuthState?.ClientId ??
             _httpContextAccessor.HttpContext.GetOpenIddictServerRequest()?.ClientId;
 
         if (clientId is null)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Program.cs
@@ -480,7 +480,9 @@ public class Program
 
         builder.Services
             .AddSingleton<IClock, SystemClock>()
-            .AddSingleton<IAuthenticationStateProvider, SessionAuthenticationStateProvider>()
+            .AddScoped<IAuthenticationStateProvider, DbWithSessionFallbackAuthenticationStateProvider>()
+            .AddSingleton<SessionAuthenticationStateProvider>()
+            .AddTransient<DbAuthenticationStateProvider>()
             .AddTransient<IRequestClientIpProvider, RequestClientIpProvider>()
             .AddSingleton<IdentityLinkGenerator, MvcIdentityLinkGenerator>()
             .AddSingleton<IApiClientRepository, ConfigurationApiClientRepository>()

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/State/AuthenticationStateMiddleware.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/State/AuthenticationStateMiddleware.cs
@@ -5,17 +5,15 @@ public class AuthenticationStateMiddleware
     public const string IdQueryParameterName = "asid";
 
     private readonly RequestDelegate _next;
-    private readonly IAuthenticationStateProvider _authenticationStateProvider;
 
-    public AuthenticationStateMiddleware(RequestDelegate next, IAuthenticationStateProvider authenticationStateProvider)
+    public AuthenticationStateMiddleware(RequestDelegate next)
     {
         _next = next;
-        _authenticationStateProvider = authenticationStateProvider;
     }
 
-    public async Task InvokeAsync(HttpContext context)
+    public async Task InvokeAsync(HttpContext context, IAuthenticationStateProvider authenticationStateProvider)
     {
-        var authenticationState = _authenticationStateProvider.GetAuthenticationState(context);
+        var authenticationState = await authenticationStateProvider.GetAuthenticationState(context);
 
         if (authenticationState is not null)
         {
@@ -33,7 +31,7 @@ public class AuthenticationStateMiddleware
                 throw new InvalidOperationException($"{nameof(AuthenticationState)} must have {nameof(AuthenticationState.JourneyId)} set.");
             }
 
-            _authenticationStateProvider.SetAuthenticationState(context, authenticationStateFeature.AuthenticationState);
+            await authenticationStateProvider.SetAuthenticationState(context, authenticationStateFeature.AuthenticationState);
         }
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/State/DbAuthenticationStateProvider.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/State/DbAuthenticationStateProvider.cs
@@ -1,0 +1,119 @@
+using System.Security.Cryptography;
+using System.Text.Json;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.EntityFrameworkCore;
+using Npgsql;
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.State;
+
+public class DbAuthenticationStateProvider : IAuthenticationStateProvider
+{
+    private const string JourneyIdsCookieName = "tis-session2";
+
+    private readonly TeacherIdentityServerDbContext _dbContext;
+    private readonly IClock _clock;
+    private readonly ILogger<DbAuthenticationStateProvider> _logger;
+    private readonly IDataProtector _dataProtector;
+
+    public DbAuthenticationStateProvider(
+        TeacherIdentityServerDbContext dbContext,
+        IClock clock,
+        IDataProtectionProvider dataProtectionProvider,
+        ILogger<DbAuthenticationStateProvider> logger)
+    {
+        _dbContext = dbContext;
+        _clock = clock;
+        _logger = logger;
+        _dataProtector = dataProtectionProvider.CreateProtector(nameof(DbAuthenticationStateProvider));
+    }
+
+    public async Task<AuthenticationState?> GetAuthenticationState(HttpContext httpContext)
+    {
+        var userJourneyIds = GetUserJourneyIdsFromCookie(httpContext);
+
+        if (httpContext.Request.Query.TryGetValue(AuthenticationStateMiddleware.IdQueryParameterName, out var asidStr) &&
+            Guid.TryParse(asidStr, out var journeyId) &&
+            userJourneyIds.Contains(journeyId))
+        {
+            var dbAuthState = await _dbContext.AuthenticationStates.FromSqlInterpolated(
+                    $"select * from authentication_states where journey_id = {journeyId}")
+                .SingleOrDefaultAsync();
+
+            if (dbAuthState is not null)
+            {
+                try
+                {
+                    return AuthenticationState.Deserialize(dbAuthState.Payload);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, $"Failed deserializing {nameof(AuthenticationState)}.");
+                }
+            }
+        }
+
+        return null;
+    }
+
+    public async Task SetAuthenticationState(HttpContext httpContext, AuthenticationState authenticationState)
+    {
+        var journeyId = authenticationState.JourneyId;
+        var serializedState = authenticationState.Serialize();
+
+        var journeyIdParameter = new NpgsqlParameter("p1", NpgsqlTypes.NpgsqlDbType.Uuid) { Value = journeyId };
+        var payloadParameter = new NpgsqlParameter("p3", NpgsqlTypes.NpgsqlDbType.Jsonb) { Value = serializedState };
+        var nowParameter = new NpgsqlParameter("p4", NpgsqlTypes.NpgsqlDbType.TimestampTz) { Value = _clock.UtcNow };
+
+        await _dbContext.Database.ExecuteSqlRawAsync(
+            """
+            insert into authentication_states (journey_id, payload, created, last_accessed)
+            values (@p1, @p3, @p4, @p4)
+            on conflict (journey_id) do update set payload = excluded.payload, last_accessed = excluded.last_accessed;
+            """,
+            journeyIdParameter,
+            payloadParameter,
+            nowParameter);
+
+        EnsureUserJourneyIdInCookie(httpContext, journeyId);
+    }
+
+    private IEnumerable<Guid> GetUserJourneyIdsFromCookie(HttpContext httpContext)
+    {
+        if (httpContext.Request.Cookies.TryGetValue(JourneyIdsCookieName, out var journeyIdsCookieValue))
+        {
+            try
+            {
+                var serialized = _dataProtector.Unprotect(journeyIdsCookieValue);
+                return JsonSerializer.Deserialize<JourneyIdsCookie>(serialized)?.JourneyIds ?? Enumerable.Empty<Guid>();
+            }
+            catch (CryptographicException)
+            {
+            }
+        }
+
+        return Enumerable.Empty<Guid>();
+    }
+
+    private void EnsureUserJourneyIdInCookie(HttpContext httpContext, Guid journeyId)
+    {
+        var userJourneyIds = GetUserJourneyIdsFromCookie(httpContext);
+
+        if (!userJourneyIds.Contains(journeyId))
+        {
+            var serialized = JsonSerializer.Serialize(new JourneyIdsCookie { JourneyIds = userJourneyIds.Append(journeyId) });
+            var protcted = _dataProtector.Protect(serialized);
+
+            httpContext.Response.OnStarting(() =>
+            {
+                httpContext.Response.Cookies.Append(JourneyIdsCookieName, protcted);
+                return Task.CompletedTask;
+            });
+        }
+    }
+
+    private class JourneyIdsCookie
+    {
+        public required IEnumerable<Guid> JourneyIds { get; set; }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/State/DbWithSessionFallbackAuthenticationStateProvider.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/State/DbWithSessionFallbackAuthenticationStateProvider.cs
@@ -1,0 +1,42 @@
+namespace TeacherIdentity.AuthServer.State;
+
+public class DbWithSessionFallbackAuthenticationStateProvider : IAuthenticationStateProvider
+{
+    private readonly SessionAuthenticationStateProvider _sessionProvider;
+    private readonly DbAuthenticationStateProvider _dbProvider;
+    private bool _useDbProvider;
+
+    public DbWithSessionFallbackAuthenticationStateProvider(
+        SessionAuthenticationStateProvider sessionProvider,
+        DbAuthenticationStateProvider dbProvider)
+    {
+        _sessionProvider = sessionProvider;
+        _dbProvider = dbProvider;
+    }
+
+    public async Task<AuthenticationState?> GetAuthenticationState(HttpContext httpContext)
+    {
+        var result = await _sessionProvider.GetAuthenticationState(httpContext);
+
+        if (result is not null)
+        {
+            return result;
+        }
+
+        _useDbProvider = true;
+
+        return await _dbProvider.GetAuthenticationState(httpContext);
+    }
+
+    public async Task SetAuthenticationState(HttpContext httpContext, AuthenticationState authenticationState)
+    {
+        if (_useDbProvider)
+        {
+            await _dbProvider.SetAuthenticationState(httpContext, authenticationState);
+        }
+        else
+        {
+            await _sessionProvider.SetAuthenticationState(httpContext, authenticationState);
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/State/IAuthenticationStateProvider.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/State/IAuthenticationStateProvider.cs
@@ -2,7 +2,6 @@ namespace TeacherIdentity.AuthServer.State;
 
 public interface IAuthenticationStateProvider
 {
-    void ClearAuthenticationState(HttpContext httpContext);
-    AuthenticationState? GetAuthenticationState(HttpContext httpContext);
-    void SetAuthenticationState(HttpContext httpContext, AuthenticationState authenticationState);
+    Task<AuthenticationState?> GetAuthenticationState(HttpContext httpContext);
+    Task SetAuthenticationState(HttpContext httpContext, AuthenticationState authenticationState);
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Infrastructure/TestAuthenticationStateProvider.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Infrastructure/TestAuthenticationStateProvider.cs
@@ -10,22 +10,14 @@ public class TestAuthenticationStateProvider : IAuthenticationStateProvider
 
     public void ClearAllAuthenticationState() => _state.Clear();
 
-    public void ClearAuthenticationState(HttpContext httpContext)
-    {
-        if (httpContext.Request.Query.TryGetValue(AuthenticationStateMiddleware.IdQueryParameterName, out var asid))
-        {
-            _state.Remove(asid.ToString(), out _);
-        }
-    }
-
     public IReadOnlyDictionary<string, AuthenticationState> GetAllAuthenticationState() =>
         new ReadOnlyDictionary<string, AuthenticationState>(_state);
 
-    public AuthenticationState? GetAuthenticationState(HttpContext httpContext) =>
+    public Task<AuthenticationState?> GetAuthenticationState(HttpContext httpContext) => Task.FromResult(
         httpContext.Request.Query.TryGetValue(AuthenticationStateMiddleware.IdQueryParameterName, out var asid) &&
             _state.TryGetValue(asid.ToString(), out var authenticationState) ?
                 authenticationState :
-                null;
+                null);
 
     public AuthenticationState? GetAuthenticationState(Guid journeyId) =>
         _state.TryGetValue(journeyId.ToString(), out var authState) ? authState : null;
@@ -33,6 +25,9 @@ public class TestAuthenticationStateProvider : IAuthenticationStateProvider
     public void SetAuthenticationState(AuthenticationState authenticationState) =>
         _state[authenticationState.JourneyId.ToString()] = authenticationState;
 
-    public void SetAuthenticationState(HttpContext? httpContext, AuthenticationState authenticationState) =>
+    public Task SetAuthenticationState(HttpContext? httpContext, AuthenticationState authenticationState)
+    {
         SetAuthenticationState(authenticationState);
+        return Task.CompletedTask;
+    }
 }


### PR DESCRIPTION
We've got a number of errors in Sentry around timeouts for Redis and Redis is where `AuthenticationState` is currently stored (via `Session`). We've also got some 'impossible' errors around invalid state.

This change adds an `IAuthenticationStateProvider` that stores data in Postgres. With this we will alleviate the load on Redis plus we'll be able to get at the state more easily to debug these weird errors.

For now I've set this up such that Redis will continue to be used for any journeys that started there. That way users who are mid way through the journey when this is deployed shouldn't experience problems.