### PR TITLE
Serialize access to journey state

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Oidc/AuthenticationStateCurrentClientProvider.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Oidc/AuthenticationStateCurrentClientProvider.cs
@@ -28,7 +28,7 @@ public class AuthenticationStateCurrentClientProvider : ICurrentClientProvider
             return null;
         }
 
-        var clientId = (await _authenticationStateProvider.GetAuthenticationState(_httpContextAccessor.HttpContext))?.OAuthState?.ClientId ??
+        var clientId = _httpContextAccessor.HttpContext.Features.Get<AuthenticationStateFeature>()?.AuthenticationState.OAuthState?.ClientId ??
             _httpContextAccessor.HttpContext.GetOpenIddictServerRequest()?.ClientId;
 
         if (clientId is null)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/State/DbAuthenticationStateProvider.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/State/DbAuthenticationStateProvider.cs
@@ -1,13 +1,15 @@
+using System.Diagnostics;
 using System.Security.Cryptography;
 using System.Text.Json;
 using Microsoft.AspNetCore.DataProtection;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
 using Npgsql;
 using TeacherIdentity.AuthServer.Models;
 
 namespace TeacherIdentity.AuthServer.State;
 
-public class DbAuthenticationStateProvider : IAuthenticationStateProvider
+public sealed class DbAuthenticationStateProvider : IAuthenticationStateProvider, IAsyncDisposable
 {
     private const string JourneyIdsCookieName = "tis-session2";
 
@@ -15,6 +17,7 @@ public class DbAuthenticationStateProvider : IAuthenticationStateProvider
     private readonly IClock _clock;
     private readonly ILogger<DbAuthenticationStateProvider> _logger;
     private readonly IDataProtector _dataProtector;
+    private IDbContextTransaction? _transaction;
 
     public DbAuthenticationStateProvider(
         TeacherIdentityServerDbContext dbContext,
@@ -32,12 +35,14 @@ public class DbAuthenticationStateProvider : IAuthenticationStateProvider
     {
         var userJourneyIds = GetUserJourneyIdsFromCookie(httpContext);
 
+        _transaction ??= await _dbContext.Database.BeginTransactionAsync(System.Data.IsolationLevel.RepeatableRead);
+
         if (httpContext.Request.Query.TryGetValue(AuthenticationStateMiddleware.IdQueryParameterName, out var asidStr) &&
             Guid.TryParse(asidStr, out var journeyId) &&
             userJourneyIds.Contains(journeyId))
         {
             var dbAuthState = await _dbContext.AuthenticationStates.FromSqlInterpolated(
-                    $"select * from authentication_states where journey_id = {journeyId}")
+                    $"select * from authentication_states where journey_id = {journeyId} for update")
                 .SingleOrDefaultAsync();
 
             if (dbAuthState is not null)
@@ -58,6 +63,8 @@ public class DbAuthenticationStateProvider : IAuthenticationStateProvider
 
     public async Task SetAuthenticationState(HttpContext httpContext, AuthenticationState authenticationState)
     {
+        Debug.Assert(_transaction is not null);
+
         var journeyId = authenticationState.JourneyId;
         var serializedState = authenticationState.Serialize();
 
@@ -74,6 +81,8 @@ public class DbAuthenticationStateProvider : IAuthenticationStateProvider
             journeyIdParameter,
             payloadParameter,
             nowParameter);
+
+        await _transaction.CommitAsync();
 
         EnsureUserJourneyIdInCookie(httpContext, journeyId);
     }
@@ -109,6 +118,14 @@ public class DbAuthenticationStateProvider : IAuthenticationStateProvider
                 httpContext.Response.Cookies.Append(JourneyIdsCookieName, protcted);
                 return Task.CompletedTask;
             });
+        }
+    }
+
+    async ValueTask IAsyncDisposable.DisposeAsync()
+    {
+        if (_transaction is not null)
+        {
+            await _transaction.DisposeAsync();
         }
     }
 


### PR DESCRIPTION
This ensures there's only a single request reading & writing `AuthenticationState` for a given journey at once.