### PR TITLE
Pass the correct name to Zendesk ticket

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
@@ -49,7 +49,7 @@ public class CoreSignInJourneyWithTrnLookup : CoreSignInJourney
                     await _backgroundJobScheduler.Enqueue<UserHelper>(
                         u => u.CreateTrnResolutionZendeskTicket(
                             user.UserId,
-                            AuthenticationState.GetOfficialName(),
+                            AuthenticationState.GetName(/*includeMiddleName:*/ true),
                             preferredName,
                             AuthenticationState.EmailAddress,
                             AuthenticationState.GetPreviousOfficialName(),


### PR DESCRIPTION
The official name fields aren't populated by the Core journey.