### PR TITLE
Reset all state related properties

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -214,6 +214,7 @@ public class AuthenticationState
 
     public void Reset(DateTime utcNow)
     {
+        // Reset all state except Visited which is used for debugging
         StartedAt = utcNow;
         UserId = default;
         FirstTimeSignInForEmail = default;
@@ -222,6 +223,7 @@ public class AuthenticationState
         FirstName = default;
         MiddleName = default;
         LastName = default;
+        HasName = default;
         OfficialFirstName = default;
         OfficialLastName = default;
         PreviousOfficialFirstName = default;
@@ -238,10 +240,21 @@ public class AuthenticationState
         NationalInsuranceNumber = default;
         AwardedQts = default;
         HasIttProvider = default;
+        IttProviderName = default;
         HasTrn = default;
         StatedTrn = default;
         HasPreviousName = default;
+        MobileNumber = default;
+        MobileNumberVerified = default;
+        ExistingAccountUserId = default;
+        ExistingAccountEmail = default;
+        ExistingAccountMobileNumber = default;
+        ExistingAccountChosen = default;
         TrnToken = default;
+        IsInstitutionEmail = default;
+        InstitutionEmailChosen = default;
+        PreferredName = default;
+        HaveResumedCompletedJourney = default;
     }
 
     public void OnEmailSet(string email, bool isInstitutionEmail = false)


### PR DESCRIPTION
### Context

Currently if a user signs out of identity and then re-starts a journey (e.g. to create an account) some values such as Preferred Name and Mobile Number are retained from the previous state. These should be empty.

### Changes proposed in this pull request

Amend the Reset method in AuthenticationState to reset ALL state related properties to their default values.

### Guidance to review

Simple change.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
