### PR TITLE
Amended DQT name syncing feature to only overwrite names on creation fror new users

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -74,6 +74,12 @@ public class AuthenticationState
     [JsonInclude]
     public string? PreviousOfficialLastName { get; private set; }
     [JsonInclude]
+    public string? DqtFirstName { get; private set; }
+    [JsonInclude]
+    public string? DqtMiddleName { get; private set; }
+    [JsonInclude]
+    public string? DqtLastName { get; private set; }
+    [JsonInclude]
     public DateOnly? DateOfBirth { get; private set; }
     [JsonInclude]
     public string? Trn { get; private set; }
@@ -682,9 +688,9 @@ public class AuthenticationState
 
         if (dqtSynchronizationEnabled && findTeachersResult is not null)
         {
-            FirstName = findTeachersResult.FirstName;
-            MiddleName = findTeachersResult.MiddleName;
-            LastName = findTeachersResult.LastName;
+            DqtFirstName = findTeachersResult.FirstName;
+            DqtMiddleName = findTeachersResult.MiddleName;
+            DqtLastName = findTeachersResult.LastName;
         }
     }
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/CheckAnswers.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/CheckAnswers.cshtml
@@ -23,23 +23,14 @@
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>First names</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value class="empty-hyphens">@Model.FirstName</govuk-summary-list-row-value>
-                    <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="" visually-hidden-text="first names">Change</govuk-summary-list-row-action>
-                    </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Middle names</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value>@Model.MiddleName</govuk-summary-list-row-value>
-                    <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="" visually-hidden-text="middle names">Change</govuk-summary-list-row-action>
-                    </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Last names</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value>@Model.LastName</govuk-summary-list-row-value>
-                    <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="" visually-hidden-text="last names">Change</govuk-summary-list-row-action>
-                    </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Preferred name</govuk-summary-list-row-key>


### PR DESCRIPTION
### Context

With the changes to keep the ID name in sync with DQT name we’re overwriting the entered name as soon as we get a result in the TRN lookup. This is potentially confusing to the user as they may see a different name to what they entered on the Check answers page.

### Changes proposed in this pull request

Amend the DQT lookup process to populate new fields on AuthenticationState - Dqt{First|Middle|Last}Name instead of overwriting the entered names. Amend the user creation process to use these names instead of the names the user entered.

### Guidance to review

Simple-ish change

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
