### PR TITLE
Handle missing DOB on DQT record

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenHelper.cs
@@ -114,7 +114,9 @@ public class TrnTokenHelper
 
         var teacher = await _dqtApiClient.GetTeacherByTrn(trnToken.Trn);
 
-        if (teacher is null)
+        // Our journey assumes that the DQT record has a DateOfBirth but it some rare circumstances it does not;
+        // for now, fall back to standard registration flow if we don't have a DOB.
+        if (teacher is null || teacher.DateOfBirth is null)
         {
             return null;
         }
@@ -130,7 +132,7 @@ public class TrnTokenHelper
             FirstName = teacher.FirstName,
             MiddleName = teacher.MiddleName,
             LastName = teacher.LastName,
-            DateOfBirth = teacher.DateOfBirth,
+            DateOfBirth = teacher.DateOfBirth!.Value
         };
     }
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialDateOfBirth/CheckOfficialDateOfBirthChangeIsEnabledAttribute.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialDateOfBirth/CheckOfficialDateOfBirthChangeIsEnabledAttribute.cs
@@ -45,6 +45,6 @@ public class CheckOfficialDateOfBirthChangeIsEnabledAttribute : Attribute, IAsyn
                       throw new Exception($"User with TRN '{trn}' cannot be found in DQT.");
 
         httpContext.Items["DqtUser"] = dqtUser;
-        return !dqtUser.PendingDateOfBirthChange && !dqtUser.DateOfBirth.Equals(identityUserDateOfBirth!.Value);
+        return !dqtUser.PendingDateOfBirthChange && dqtUser.DateOfBirth?.Equals(identityUserDateOfBirth!.Value) == false;
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/TeacherInfo.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/TeacherInfo.cs
@@ -6,7 +6,7 @@ public record TeacherInfo
     public required string FirstName { get; init; }
     public required string LastName { get; init; }
     public required string MiddleName { get; init; }
-    public required DateOnly DateOfBirth { get; init; }
+    public required DateOnly? DateOfBirth { get; init; }
     public required string? NationalInsuranceNumber { get; init; }
     public required bool PendingNameChange { get; init; }
     public required bool PendingDateOfBirthChange { get; init; }


### PR DESCRIPTION
We've had an error from production in Sentry because a DQT DOB is `null`. Until this point we've assumed we'd never see a `null` DOB. This is a quick change to handle a `null` DOB. For the TRN token journey for now we're ignoring a token for a user who doesn't have a DOB.