### PR TITLE
Fix TRN re-lookup when TRN already in use

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -326,11 +326,6 @@ public class AuthenticationState
             throw new InvalidOperationException($"Email has not been verified.");
         }
 
-        if (TrnLookup != TrnLookupState.None)
-        {
-            throw new InvalidOperationException($"TRN lookup is invalid: '{TrnLookup}', expected {TrnLookupState.None}.");
-        }
-
         HaveCompletedTrnLookup = true;
         TrnLookup = TrnLookupState.ExistingTrnFound;
         TrnOwnerEmailAddress = existingTrnOwnerEmail;


### PR DESCRIPTION
If a TRN lookup happens multiple times and resolves to an existing account, it was blowing up after the first time due to a check on `TrnLookupState == None`. This removes the check.