### PR TITLE
Option to update preferred name when changing official name

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -205,22 +205,25 @@ public abstract class IdentityLinkGenerator
         Page("/Account/OfficialName/Index", authenticationJourneyRequired: false)
             .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo);
 
-    public string AccountOfficialNameDetails(string? firstName, string? middleName, string? lastName, string? fileName, string? fileId, bool fromConfirmPage, ClientRedirectInfo? clientRedirectInfo) =>
+    public string AccountOfficialNameDetails(string? firstName, string? middleName, string? lastName, string? fileName, string? fileId, string? preferredName, bool fromConfirmPage, ClientRedirectInfo? clientRedirectInfo) =>
         Page("/Account/OfficialName/Details", authenticationJourneyRequired: false)
             .SetQueryParam("firstName", firstName)
             .SetQueryParam("middleName", middleName)
             .SetQueryParam("lastName", lastName)
             .SetQueryParam("fileName", fileName)
             .SetQueryParam("fileId", fileId)
+            .SetQueryParam("preferredName", preferredName)
             .SetQueryParam("fromConfirmPage", fromConfirmPage)
             .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo)
             .AppendQueryStringSignature(QueryStringSignatureHelper);
 
-    public string AccountOfficialNameEvidence(string firstName, string? middleName, string lastName, ClientRedirectInfo? clientRedirectInfo) =>
+    public string AccountOfficialNameEvidence(string firstName, string? middleName, string lastName, string? preferredName, bool fromConfirmPage, ClientRedirectInfo? clientRedirectInfo) =>
         Page("/Account/OfficialName/Evidence", authenticationJourneyRequired: false)
             .SetQueryParam("firstName", firstName)
             .SetQueryParam("middleName", middleName)
             .SetQueryParam("lastName", lastName)
+            .SetQueryParam("preferredName", preferredName)
+            .SetQueryParam("fromConfirmPage", fromConfirmPage)
             .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo)
             .AppendQueryStringSignature(QueryStringSignatureHelper);
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -224,13 +224,25 @@ public abstract class IdentityLinkGenerator
             .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo)
             .AppendQueryStringSignature(QueryStringSignatureHelper);
 
-    public string AccountOfficialNameConfirm(string firstName, string? middleName, string lastName, string fileName, string fileId, ClientRedirectInfo? clientRedirectInfo) =>
+    public string AccountOfficialNamePreferredName(string firstName, string? middleName, string lastName, string? fileName, string? fileId, string? preferredName, ClientRedirectInfo? clientRedirectInfo) =>
+        Page("/Account/OfficialName/PreferredName", authenticationJourneyRequired: false)
+        .SetQueryParam("firstName", firstName)
+        .SetQueryParam("middleName", middleName)
+        .SetQueryParam("lastName", lastName)
+        .SetQueryParam("fileName", fileName)
+        .SetQueryParam("fileId", fileId)
+        .SetQueryParam("preferredName", preferredName)
+        .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo)
+        .AppendQueryStringSignature(QueryStringSignatureHelper);
+
+    public string AccountOfficialNameConfirm(string firstName, string? middleName, string lastName, string fileName, string fileId, string preferredName, ClientRedirectInfo? clientRedirectInfo) =>
         Page("/Account/OfficialName/Confirm", authenticationJourneyRequired: false)
             .SetQueryParam("firstName", firstName)
             .SetQueryParam("middleName", middleName)
             .SetQueryParam("lastName", lastName)
             .SetQueryParam("fileName", fileName)
             .SetQueryParam("fileId", fileId)
+            .SetQueryParam("preferredName", preferredName)
             .SetQueryParam(ClientRedirectInfo.QueryParameterName, clientRedirectInfo)
             .AppendQueryStringSignature(QueryStringSignatureHelper);
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Confirm.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Confirm.cshtml
@@ -19,26 +19,23 @@
                     <govuk-summary-list-row-key>Official name</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value>@Model.FirstName @Model.MiddleName @Model.LastName</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.AccountOfficialNameDetails(Model.FirstName, Model.MiddleName, Model.LastName, Model.FileName, Model.FileId, fromConfirmPage: true, Model.ClientRedirectInfo)" visually-hidden-text="name">Change</govuk-summary-list-row-action>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AccountOfficialNameDetails(Model.FirstName, Model.MiddleName, Model.LastName, Model.FileName, Model.FileId, Model.PreferredName, fromConfirmPage: true, Model.ClientRedirectInfo)" visually-hidden-text="name">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>File upload</govuk-summary-list-row-key>
                     <govuk-summary-list-row-value>@Model.FileName</govuk-summary-list-row-value>
                     <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.AccountOfficialNameEvidence(Model.FirstName!, Model.MiddleName, Model.LastName!, Model.ClientRedirectInfo)" visually-hidden-text="file name">Change</govuk-summary-list-row-action>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AccountOfficialNameEvidence(Model.FirstName!, Model.MiddleName, Model.LastName!, Model.PreferredName, fromConfirmPage: true, Model.ClientRedirectInfo)" visually-hidden-text="file name">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
-                @if (Model.HasPreferreredNameChanged == true)
-                {
-                    <govuk-summary-list-row>
-                        <govuk-summary-list-row-key>Preferred name</govuk-summary-list-row-key>
-                        <govuk-summary-list-row-value>@Model.PreferredName</govuk-summary-list-row-value>
-                        <govuk-summary-list-row-actions>
-                            <govuk-summary-list-row-action href="@LinkGenerator.AccountOfficialNamePreferredName(Model.FirstName!, Model.MiddleName, Model.LastName!, Model.FileName, Model.FileId, Model.PreferredName, Model.ClientRedirectInfo)" visually-hidden-text="preferred name">Change</govuk-summary-list-row-action>
-                        </govuk-summary-list-row-actions>
-                    </govuk-summary-list-row>
-                }
+                <govuk-summary-list-row>
+                    <govuk-summary-list-row-key>Preferred name</govuk-summary-list-row-key>
+                    <govuk-summary-list-row-value>@Model.PreferredName</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AccountOfficialNamePreferredName(Model.FirstName!, Model.MiddleName, Model.LastName!, Model.FileName, Model.FileId, Model.PreferredName, Model.ClientRedirectInfo)" visually-hidden-text="preferred name">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                </govuk-summary-list-row>
             </govuk-summary-list>
 
             <govuk-button type="submit">Submit change</govuk-button>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Confirm.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Confirm.cshtml
@@ -6,12 +6,12 @@
 
 @section BeforeContent
 {
-    <govuk-back-link href="@LinkGenerator.AccountOfficialNameEvidence(Model.FirstName!, Model.MiddleName, Model.LastName!, Model.ClientRedirectInfo)" />
+    <govuk-back-link href="@LinkGenerator.AccountOfficialNamePreferredName(Model.FirstName!, Model.MiddleName, Model.LastName!, Model.FileName, Model.FileId, Model.PreferredName, Model.ClientRedirectInfo)" />
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.AccountOfficialNameConfirm(Model.FirstName!, Model.MiddleName, Model.LastName!, Model.FileName!, Model.FileId!, Model.ClientRedirectInfo)" method="post" asp-antiforgery="true">
+        <form action="@LinkGenerator.AccountOfficialNameConfirm(Model.FirstName!, Model.MiddleName, Model.LastName!, Model.FileName!, Model.FileId!, Model.PreferredName!, Model.ClientRedirectInfo)" method="post" asp-antiforgery="true">
             <h1 class="govuk-heading-l">@ViewBag.Title</h1>
 
             <govuk-summary-list>
@@ -29,6 +29,16 @@
                         <govuk-summary-list-row-action href="@LinkGenerator.AccountOfficialNameEvidence(Model.FirstName!, Model.MiddleName, Model.LastName!, Model.ClientRedirectInfo)" visually-hidden-text="file name">Change</govuk-summary-list-row-action>
                     </govuk-summary-list-row-actions>
                 </govuk-summary-list-row>
+                @if (Model.HasPreferreredNameChanged == true)
+                {
+                    <govuk-summary-list-row>
+                        <govuk-summary-list-row-key>Preferred name</govuk-summary-list-row-key>
+                        <govuk-summary-list-row-value>@Model.PreferredName</govuk-summary-list-row-value>
+                        <govuk-summary-list-row-actions>
+                            <govuk-summary-list-row-action href="@LinkGenerator.AccountOfficialNamePreferredName(Model.FirstName!, Model.MiddleName, Model.LastName!, Model.FileName, Model.FileId, Model.PreferredName, Model.ClientRedirectInfo)" visually-hidden-text="preferred name">Change</govuk-summary-list-row-action>
+                        </govuk-summary-list-row-actions>
+                    </govuk-summary-list-row>
+                }
             </govuk-summary-list>
 
             <govuk-button type="submit">Submit change</govuk-button>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Confirm.cshtml.cs
@@ -55,12 +55,8 @@ public class Confirm : PageModel
     [FromQuery(Name = "preferredName")]
     public string? PreferredName { get; set; }
 
-    public bool HasPreferreredNameChanged { get; set; }
-
-    public async Task OnGet()
+    public void OnGet()
     {
-        var user = await _dbContext.Users.SingleAsync(u => u.UserId == User.GetUserId());
-        HasPreferreredNameChanged = user.PreferredName != PreferredName;
     }
 
     public async Task<IActionResult> OnPost()

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Confirm.cshtml.cs
@@ -95,7 +95,7 @@ public class Confirm : PageModel
 
             await _dbContext.SaveChangesAsync();
 
-            preferredNameMessage = "<br/><br/>Your preferred name has been updated.";
+            preferredNameMessage = $"{Environment.NewLine}{Environment.NewLine}Your preferred name has been updated.";
         }
 
         TempData.SetFlashSuccess(

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Confirm.cshtml.cs
@@ -1,7 +1,10 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Filters;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Events;
 using TeacherIdentity.AuthServer.Infrastructure.Filters;
+using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Services.DqtApi;
 using TeacherIdentity.AuthServer.Services.DqtEvidence;
 
@@ -15,15 +18,21 @@ public class Confirm : PageModel
     private readonly IdentityLinkGenerator _linkGenerator;
     private readonly IDqtApiClient _dqtApiClient;
     private readonly IDqtEvidenceStorageService _dqtEvidenceStorage;
+    private readonly TeacherIdentityServerDbContext _dbContext;
+    private readonly IClock _clock;
 
     public Confirm(
         IdentityLinkGenerator linkGenerator,
         IDqtApiClient dqtApiClient,
-        IDqtEvidenceStorageService dqtEvidenceStorage)
+        IDqtEvidenceStorageService dqtEvidenceStorage,
+        TeacherIdentityServerDbContext dbContext,
+        IClock clock)
     {
         _linkGenerator = linkGenerator;
         _dqtApiClient = dqtApiClient;
         _dqtEvidenceStorage = dqtEvidenceStorage;
+        _dbContext = dbContext;
+        _clock = clock;
     }
 
     public ClientRedirectInfo? ClientRedirectInfo => HttpContext.GetClientRedirectInfo();
@@ -43,8 +52,15 @@ public class Confirm : PageModel
     [FromQuery(Name = "fileId")]
     public string? FileId { get; set; }
 
-    public void OnGet()
+    [FromQuery(Name = "preferredName")]
+    public string? PreferredName { get; set; }
+
+    public bool HasPreferreredNameChanged { get; set; }
+
+    public async Task OnGet()
     {
+        var user = await _dbContext.Users.SingleAsync(u => u.UserId == User.GetUserId());
+        HasPreferreredNameChanged = user.PreferredName != PreferredName;
     }
 
     public async Task<IActionResult> OnPost()
@@ -63,16 +79,39 @@ public class Confirm : PageModel
 
         await _dqtApiClient.PostTeacherNameChange(teacherNameChangeRequest);
 
+        var preferredNameMessage = string.Empty;
+        var user = await _dbContext.Users.SingleAsync(u => u.UserId == User.GetUserId());
+
+        if (user.PreferredName != PreferredName)
+        {
+            user.PreferredName = PreferredName!;
+            user.Updated = _clock.UtcNow;
+
+            _dbContext.AddEvent(new UserUpdatedEvent()
+            {
+                Source = UserUpdatedEventSource.ChangedByUser,
+                CreatedUtc = _clock.UtcNow,
+                Changes = UserUpdatedEventChanges.PreferredName,
+                User = user,
+                UpdatedByUserId = User.GetUserId(),
+                UpdatedByClientId = null
+            });
+
+            await _dbContext.SaveChangesAsync();
+
+            preferredNameMessage = "<br/><br/>Your preferred name has been updated.";
+        }
+
         TempData.SetFlashSuccess(
             "We’ve received your request to change your official name",
-            "We’ll review it and get back to you within 5 working days.");
+            $"We’ll review it and get back to you within 5 working days.{preferredNameMessage}");
 
         return Redirect(_linkGenerator.Account(ClientRedirectInfo));
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)
     {
-        if (FirstName is null || LastName is null || FileName is null || FileId is null)
+        if (FirstName is null || LastName is null || FileName is null || FileId is null || PreferredName is null)
         {
             context.Result = BadRequest();
         }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Details.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Details.cshtml
@@ -10,7 +10,7 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.AccountOfficialNameDetails(Model.FileName, Model.MiddleName, Model.LastName, Model.FileName, Model.FileId, Model.FromConfirmPage, Model.ClientRedirectInfo)" method="post" asp-antiforgery="true">
+        <form action="@LinkGenerator.AccountOfficialNameDetails(Model.FileName, Model.MiddleName, Model.LastName, Model.FileName, Model.FileId, Model.PreferredName, Model.FromConfirmPage, Model.ClientRedirectInfo)" method="post" asp-antiforgery="true">
             <h1 class="govuk-heading-l">@ViewBag.Title</h1>
 
             <p>Tell us what you would like to change your name to.</p>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Details.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Details.cshtml.cs
@@ -43,6 +43,9 @@ public class Details : PageModel
     [FromQuery(Name = "fileId")]
     public string? FileId { get; set; }
 
+    [FromQuery(Name = "preferredName")]
+    public string? PreferredName { get; set; }
+
     [FromQuery(Name = "fromConfirmPage")]
     public bool FromConfirmPage { get; set; }
 
@@ -75,7 +78,7 @@ public class Details : PageModel
         }
 
         return Redirect(FromConfirmPage && FileName is not null && FileId is not null ?
-            _linkGenerator.AccountOfficialNameConfirm(FirstName!, MiddleName, LastName!, FileName, FileId, ClientRedirectInfo) :
+            _linkGenerator.AccountOfficialNamePreferredName(FirstName!, MiddleName, LastName!, FileName, FileId, PreferredName, ClientRedirectInfo) :
             _linkGenerator.AccountOfficialNameEvidence(FirstName!, MiddleName, LastName!, ClientRedirectInfo));
     }
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Details.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Details.cshtml.cs
@@ -78,8 +78,8 @@ public class Details : PageModel
         }
 
         return Redirect(FromConfirmPage && FileName is not null && FileId is not null ?
-            _linkGenerator.AccountOfficialNamePreferredName(FirstName!, MiddleName, LastName!, FileName, FileId, PreferredName, ClientRedirectInfo) :
-            _linkGenerator.AccountOfficialNameEvidence(FirstName!, MiddleName, LastName!, ClientRedirectInfo));
+            _linkGenerator.AccountOfficialNameConfirm(FirstName!, MiddleName, LastName!, FileName, FileId, PreferredName!, ClientRedirectInfo) :
+            _linkGenerator.AccountOfficialNameEvidence(FirstName!, MiddleName, LastName!, PreferredName, fromConfirmPage: false, ClientRedirectInfo));
     }
 
     public override void OnPageHandlerExecuting(PageHandlerExecutingContext context)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Evidence.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Evidence.cshtml
@@ -7,12 +7,12 @@
 
 @section BeforeContent
 {
-    <govuk-back-link href="@LinkGenerator.AccountOfficialNameDetails(Model.FirstName, Model.MiddleName, Model.LastName, fileName: null, fileId: null, fromConfirmPage: false, Model.ClientRedirectInfo)" />
+    <govuk-back-link href="@LinkGenerator.AccountOfficialNameDetails(Model.FirstName, Model.MiddleName, Model.LastName, fileName: null, fileId: null, Model.PreferredName, fromConfirmPage: false, Model.ClientRedirectInfo)" />
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <form action="@LinkGenerator.AccountOfficialNameEvidence(Model.FirstName!, Model.MiddleName ?? String.Empty, Model.LastName!, Model.ClientRedirectInfo)" method="post" enctype="multipart/form-data" asp-antiforgery="true">
+        <form action="@LinkGenerator.AccountOfficialNameEvidence(Model.FirstName!, Model.MiddleName ?? String.Empty, Model.LastName!, Model.PreferredName, Model.FromConfirmPage, Model.ClientRedirectInfo)" method="post" enctype="multipart/form-data" asp-antiforgery="true">
             <h1 class="govuk-heading-l">@ViewBag.Title</h1>
 
             <p>Your evidence must be a photo or scan of one of the following:</p>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Evidence.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Evidence.cshtml.cs
@@ -30,6 +30,12 @@ public class Evidence : BaseEvidencePage
     [FromQuery(Name = "lastName")]
     public string? LastName { get; set; }
 
+    [FromQuery(Name = "preferredName")]
+    public string? PreferredName { get; set; }
+
+    [FromQuery(Name = "fromConfirmPage")]
+    public bool FromConfirmPage { get; set; }
+
     public void OnGet()
     {
     }
@@ -45,7 +51,9 @@ public class Evidence : BaseEvidencePage
         var fileId = GenerateFileId();
 
         return await TryUploadEvidence(fileId) ?
-            Redirect(_linkGenerator.AccountOfficialNamePreferredName(FirstName!, MiddleName, LastName!, fileName, fileId, null, ClientRedirectInfo)) :
+            Redirect(FromConfirmPage ?
+                _linkGenerator.AccountOfficialNameConfirm(FirstName!, MiddleName, LastName!, fileName, fileId, PreferredName!, ClientRedirectInfo) :
+                _linkGenerator.AccountOfficialNamePreferredName(FirstName!, MiddleName, LastName!, fileName, fileId, PreferredName, ClientRedirectInfo)) :
             this.PageWithErrors();
     }
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Evidence.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Evidence.cshtml.cs
@@ -45,7 +45,7 @@ public class Evidence : BaseEvidencePage
         var fileId = GenerateFileId();
 
         return await TryUploadEvidence(fileId) ?
-            Redirect(_linkGenerator.AccountOfficialNameConfirm(FirstName!, MiddleName, LastName!, fileName, fileId, ClientRedirectInfo)) :
+            Redirect(_linkGenerator.AccountOfficialNamePreferredName(FirstName!, MiddleName, LastName!, fileName, fileId, null, ClientRedirectInfo)) :
             this.PageWithErrors();
     }
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Index.cshtml
@@ -14,6 +14,6 @@
         <p>If you’ve changed your name, you’ll need to provide evidence to update it.</p>
         <p>We’ll give you detailed information about providing evidence. Changes can take up to 5 working days.</p>
         <p>We’ll email you to confirm that we’ve made the changes.</p>
-        <govuk-button-link href="@LinkGenerator.AccountOfficialNameDetails(firstName: null, middleName: null, lastName: null, fileName: null, fileId: null, fromConfirmPage: false, Model.ClientRedirectInfo)">Continue</govuk-button-link>
+        <govuk-button-link href="@LinkGenerator.AccountOfficialNameDetails(firstName: null, middleName: null, lastName: null, fileName: null, fileId: null, preferredName: null, fromConfirmPage: false, Model.ClientRedirectInfo)">Continue</govuk-button-link>
     </div>
 </div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/PreferredName.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/PreferredName.cshtml
@@ -6,7 +6,7 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link href="@LinkGenerator.AccountOfficialNameEvidence(Model.FirstName!, Model.MiddleName, Model.LastName!, Model.ClientRedirectInfo)" />
+    <govuk-back-link href="@LinkGenerator.AccountOfficialNameEvidence(Model.FirstName!, Model.MiddleName, Model.LastName!, Model.PreferredName, fromConfirmPage: false, Model.ClientRedirectInfo)" />
 }
 
 <div class="govuk-grid-row">

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/PreferredName.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/PreferredName.cshtml
@@ -1,4 +1,4 @@
-@page
+@page "/account/official-name/preferred-name"
 @using TeacherIdentity.AuthServer.Pages.Common;
 @model TeacherIdentity.AuthServer.Pages.Account.OfficialName.PreferredNameModel
 @{

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/PreferredName.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/PreferredName.cshtml
@@ -20,7 +20,7 @@
                         <p>We’ll use your preferred name in correspondence. We use official names on teaching certificates.</p>
                     </govuk-radios-fieldset-legend>
                     <govuk-radios-item value="@PreferredNameOption.ExistingPreferredName">
-                        Keep @Model.ExistingName(includeMiddleName: false)
+                        Keep @Model.ExistingPreferredName
                     </govuk-radios-item>
                     <govuk-radios-item value="@PreferredNameOption.ExistingName">
                         Use @Model.ExistingName(includeMiddleName: false)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/PreferredName.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/PreferredName.cshtml
@@ -1,0 +1,46 @@
+@page
+@using TeacherIdentity.AuthServer.Pages.Common;
+@model TeacherIdentity.AuthServer.Pages.Account.OfficialName.PreferredNameModel
+@{
+    ViewBag.Title = "Do you want to update your preferred name?";
+}
+
+@section BeforeContent {
+    <govuk-back-link href="@LinkGenerator.AccountOfficialNameEvidence(Model.FirstName!, Model.MiddleName, Model.LastName!, Model.ClientRedirectInfo)" />
+}
+
+<div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds-from-desktop">
+        <form action="@LinkGenerator.AccountOfficialNamePreferredName(Model.FirstName!, Model.MiddleName, Model.LastName!, Model.FileName, Model.FileId, preferredName: null, Model.ClientRedirectInfo)" method="post" asp-antiforgery="true">
+            <govuk-radios asp-for="PreferredNameChoice">
+                <govuk-radios-fieldset>
+                    <govuk-radios-fieldset-legend>
+                        <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+                        <p>For example, Mike Smith instead of Michael Smith.</p>
+                        <p>We’ll use your preferred name in correspondence. We use official names on teaching certificates.</p>
+                    </govuk-radios-fieldset-legend>
+                    <govuk-radios-item value="@PreferredNameOption.ExistingPreferredName">
+                        Keep @Model.ExistingName(includeMiddleName: false)
+                    </govuk-radios-item>
+                    <govuk-radios-item value="@PreferredNameOption.ExistingName">
+                        Use @Model.ExistingName(includeMiddleName: false)
+                    </govuk-radios-item>
+                    @if (Model.HasMiddleName)
+                    {
+                        <govuk-radios-item value="@PreferredNameOption.ExistingFullName">
+                            Use @Model.ExistingName(includeMiddleName: true)
+                        </govuk-radios-item>
+                    }
+                    <govuk-radios-item value="@PreferredNameOption.PreferredName">
+                        Use a different preferred name
+                        <govuk-radios-item-conditional>
+                            <govuk-input asp-for="PreferredName" spellcheck="false" />
+                        </govuk-radios-item-conditional>
+                    </govuk-radios-item>
+                </govuk-radios-fieldset>
+            </govuk-radios>
+
+            <govuk-button type="submit">Continue</govuk-button>
+        </form>
+    </div>
+</div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/PreferredName.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/PreferredName.cshtml.cs
@@ -1,0 +1,135 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Infrastructure.Filters;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Pages.Common;
+
+namespace TeacherIdentity.AuthServer.Pages.Account.OfficialName;
+
+[VerifyQueryParameterSignature]
+public class PreferredNameModel : PageModel
+{
+    private readonly IdentityLinkGenerator _linkGenerator;
+    private readonly TeacherIdentityServerDbContext _dbContext;
+
+    public PreferredNameModel(
+        IdentityLinkGenerator linkGenerator,
+        TeacherIdentityServerDbContext dbContext)
+    {
+        _linkGenerator = linkGenerator;
+        _dbContext = dbContext;
+    }
+
+    public ClientRedirectInfo? ClientRedirectInfo => HttpContext.GetClientRedirectInfo();
+
+    public bool HasMiddleName => !string.IsNullOrEmpty(MiddleName);
+
+    public string? ExistingPreferredName { get; set; }
+
+    [FromQuery(Name = "firstName")]
+    public string? FirstName { get; set; }
+
+    [FromQuery(Name = "middleName")]
+    public string? MiddleName { get; set; }
+
+    [FromQuery(Name = "lastName")]
+    public string? LastName { get; set; }
+
+    [FromQuery(Name = "fileName")]
+    public string? FileName { get; set; }
+
+    [FromQuery(Name = "fileId")]
+    public string? FileId { get; set; }
+
+    [BindProperty]
+    [Display(Name = " ")]
+    [Required(ErrorMessage = "Select which name to use")]
+    public PreferredNameOption? PreferredNameChoice { get; set; }
+
+    [BindProperty(SupportsGet = true)]
+    [Display(Name = "Your preferred name")]
+    [RequiredIfTrue(nameof(PreferredNameChoice), "PreferredName", ErrorMessage = "Enter your preferred name")]
+    [StringLengthIfTrue(nameof(PreferredNameChoice), 200, "PreferredName", ErrorMessage = "Preferred name must be 200 characters or less")]
+    public string? PreferredName { get; set; }
+
+    public async Task OnGet()
+    {
+        string? preferredName = null;
+        var userId = User.GetUserId();
+        var user = await _dbContext.Users.Where(u => u.UserId == userId).SingleAsync();
+        ExistingPreferredName = user.PreferredName;
+
+        if (PreferredName is null)
+        {
+            preferredName = ExistingPreferredName;
+        }
+        else
+        {
+            preferredName = PreferredName;
+        }
+
+        var middleName = User.GetMiddleName();
+        if (preferredName == ExistingPreferredName)
+        {
+            PreferredNameChoice = PreferredNameOption.ExistingPreferredName;
+            PreferredName = null;
+        }
+        else if (!string.IsNullOrEmpty(middleName) && preferredName == ExistingName(includeMiddleName: true))
+        {
+            PreferredNameChoice = PreferredNameOption.ExistingFullName;
+            PreferredName = null;
+        }
+        else if (preferredName == ExistingName(includeMiddleName: false))
+        {
+            PreferredNameChoice = PreferredNameOption.ExistingName;
+            PreferredName = null;
+        }
+        else
+        {
+            PreferredNameChoice = PreferredNameOption.PreferredName;
+            PreferredName = preferredName;
+        }
+
+        ModelState.Clear();
+    }
+
+    public async Task<IActionResult> OnPost()
+    {
+        if (!ModelState.IsValid)
+        {
+            return this.PageWithErrors();
+        }
+
+        var userId = User.GetUserId();
+        var user = await _dbContext.Users.Where(u => u.UserId == userId).SingleAsync();
+        string? existingPreferredName = user.PreferredName;
+
+        if (PreferredNameChoice == PreferredNameOption.PreferredName && PreferredName == existingPreferredName)
+        {
+            ModelState.AddModelError(nameof(PreferredName), "The preferred name entered matches your existing preferred name");
+            return this.PageWithErrors();
+        }
+
+        var preferredName = PreferredNameChoice switch
+        {
+            PreferredNameOption.ExistingPreferredName => existingPreferredName,
+            PreferredNameOption.ExistingFullName => ExistingName(includeMiddleName: true),
+            PreferredNameOption.ExistingName => ExistingName(includeMiddleName: false),
+            PreferredNameOption.PreferredName => PreferredName,
+            _ => throw new ArgumentOutOfRangeException(nameof(PreferredNameChoice), PreferredNameChoice, "Invalid preferred name option chosen")
+        };
+
+        return Redirect(_linkGenerator.AccountOfficialNameConfirm(FirstName!, MiddleName, LastName!, FileName!, FileId!, preferredName!, ClientRedirectInfo));
+    }
+
+    public string ExistingName(bool includeMiddleName)
+    {
+        var firstName = User.GetFirstName();
+        var middleName = User.GetMiddleName();
+        var lastName = User.GetLastName();
+
+        return !includeMiddleName || string.IsNullOrEmpty(middleName) ? $"{firstName} {lastName}" : $"{firstName} {middleName} {lastName}";
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/PreferredName.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/PreferredName.cshtml.cs
@@ -70,13 +70,12 @@ public class PreferredNameModel : PageModel
             preferredName = PreferredName;
         }
 
-        var middleName = User.GetMiddleName();
         if (preferredName == ExistingPreferredName)
         {
             PreferredNameChoice = PreferredNameOption.ExistingPreferredName;
             PreferredName = null;
         }
-        else if (!string.IsNullOrEmpty(middleName) && preferredName == ExistingName(includeMiddleName: true))
+        else if (!string.IsNullOrEmpty(MiddleName) && preferredName == ExistingName(includeMiddleName: true))
         {
             PreferredNameChoice = PreferredNameOption.ExistingFullName;
             PreferredName = null;
@@ -126,10 +125,6 @@ public class PreferredNameModel : PageModel
 
     public string ExistingName(bool includeMiddleName)
     {
-        var firstName = User.GetFirstName();
-        var middleName = User.GetMiddleName();
-        var lastName = User.GetLastName();
-
-        return !includeMiddleName || string.IsNullOrEmpty(middleName) ? $"{firstName} {lastName}" : $"{firstName} {middleName} {lastName}";
+        return !includeMiddleName || string.IsNullOrEmpty(MiddleName) ? $"{FirstName} {LastName}" : $"{FirstName} {MiddleName} {LastName}";
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Common/PreferredNameOption.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Common/PreferredNameOption.cs
@@ -4,5 +4,6 @@ public enum PreferredNameOption
 {
     ExistingFullName,
     ExistingName,
-    PreferredName
+    PreferredName,
+    ExistingPreferredName
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Views/Shared/_Layout.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Views/Shared/_Layout.cshtml
@@ -61,7 +61,10 @@
         <p class="govuk-notification-banner__heading">@flashSuccess.Value.heading</p>
         @if (flashSuccess.Value.message is not null)
         {
-            <p>@flashSuccess.Value.message</p>
+            @foreach (var line in flashSuccess.Value.message.Split(Environment.NewLine))
+            {
+                <span>@line</span><br/>
+            }            
         }
     </govuk-notification-banner>
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Account.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Account.cs
@@ -191,6 +191,13 @@ public class Account : IClassFixture<HostFixture>
             });
         await page.ClickContinueButton();
 
+        var newPreferredName = Faker.Name.FullName();
+
+        await page.WaitForUrlPathAsync("/account/official-name/preferred-name");
+        await page.ClickAsync("label:text-is('Use a different preferred name')");
+        await page.FillAsync("label:text-is('Your preferred name')", newPreferredName);
+        await page.ClickContinueButton();
+
         await page.WaitForUrlPathAsync("/account/official-name/confirm");
         await page.ClickAsync("button:text-is('Submit change')");
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialName/PreferredNameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialName/PreferredNameTests.cs
@@ -1,0 +1,179 @@
+namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Account.OfficialName;
+
+public class PreferredNameTests : TestBase
+{
+    public PreferredNameTests(HostFixture hostFixture)
+        : base(hostFixture)
+    {
+    }
+
+    [Fact]
+    public async Task Get_ValidRequestWithPreferredNameInQueryParam_PopulatesFieldFromQueryParam()
+    {
+        // Arrange
+        var previouslyStatedPreferredName = Faker.Name.FullName();
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            AppendQueryParameterSignature(
+                $"/account/official-name/preferred-name" +
+                $"?preferredName={Uri.EscapeDataString(previouslyStatedPreferredName)}"));
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        var doc = await response.GetDocument();
+        Assert.Equal(previouslyStatedPreferredName, doc.GetElementById("PreferredName")?.GetAttribute("value"));
+    }
+
+    [Fact]
+    public async Task Post_WhenPreferredNameChoiceHasNoSelection_ReturnsError()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            AppendQueryParameterSignature($"/account/official-name/preferred-name"))
+        {
+            Content = new FormUrlEncodedContentBuilder()
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "PreferredNameChoice", "Select which name to use");
+    }
+
+    [Fact]
+    public async Task Post_WhenPreferredNameChoiceIsPreferredNameAndPreferredNameIsEmpty_ReturnsError()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            AppendQueryParameterSignature($"/account/official-name/preferred-name"))
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "PreferredNameChoice", "PreferredName" },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "PreferredName", "Enter your preferred name");
+    }
+
+    [Fact]
+    public async Task Post_WhenPreferredNameChoiceIsPreferredNameAndPreferredNameIsTooLong_ReturnsError()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            AppendQueryParameterSignature($"/account/official-name/preferred-name"))
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "PreferredNameChoice", "PreferredName" },
+                { "PreferredName", new string('a', 201) }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "PreferredName", "Preferred name must be 200 characters or less");
+    }
+
+    [Fact]
+    public async Task Post_WhenPreferredNameChoiceIsPreferredNameAndPreferredNameIsValid_RedirectsToConfirmPage()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            AppendQueryParameterSignature($"/account/official-name/preferred-name"))
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "PreferredNameChoice", "PreferredName" },
+                { "PreferredName", Faker.Name.FullName() }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/account/official-name/confirm", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_WhenPreferredNameChoiceIsExistingName_RedirectsToConfirmPage()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            AppendQueryParameterSignature($"/account/official-name/preferred-name"))
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "PreferredNameChoice", "ExistingName" }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/account/official-name/confirm", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_WhenPreferredNameChoiceIsExistingFullName_RedirectsToConfirmPage()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            AppendQueryParameterSignature($"/account/official-name/preferred-name"))
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "PreferredNameChoice", "ExistingFullName" }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/account/official-name/confirm", response.Headers.Location?.OriginalString);
+    }
+
+    [Fact]
+    public async Task Post_WhenPreferredNameChoiceIsExistingPreferredName_RedirectsToConfirmPage()
+    {
+        // Arrange
+        var request = new HttpRequestMessage(
+            HttpMethod.Post,
+            AppendQueryParameterSignature($"/account/official-name/preferred-name"))
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "PreferredNameChoice", "ExistingPreferredName" }
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
+        Assert.StartsWith("/account/official-name/confirm", response.Headers.Location?.OriginalString);
+    }
+}


### PR DESCRIPTION
### Context

We want to try to keep the preferred name in sync with official names. If users update their official name, we will prompt to see if they’d like to also update their preferred name.

### Changes proposed in this pull request

Add a new page at /account/official-name/preferred-name following the designs at [Collecting a preferred name in addition to official name](https://tra-digital-design-history.herokuapp.com/get-an-identity/adding-preferred-name/#when-users-update-their-official-name) We should offer an option for the same combinations of first/middle/last names we do on the Change preferred name page. Redirect to this new page after /account/official-name/evidence.

If no option is chosen, show an error ‘Select which name to use’. If ‘Use a different preferred name’ is chosen, show a text box labelled ‘Your preferred name’. If this is empty, show an error ‘Enter your preferred name’.

If the name chosen is valid, redirect to /account/official-name/confirm and pass along the chosen preferred name. Update this page to update the user’s preferred name as well as submitting the official name change request to DQT.

### Guidance to review

N/A

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
