### PR TITLE
Prevent user changing their identity name when linked to a dqt record

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/CheckNameChangeIsEnabledAttribute.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/CheckNameChangeIsEnabledAttribute.cs
@@ -1,0 +1,47 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.EntityFrameworkCore;
+using TeacherIdentity.AuthServer.Models;
+
+namespace TeacherIdentity.AuthServer.Pages.Account.Name;
+
+[AttributeUsage(AttributeTargets.Class, AllowMultiple = false)]
+public class CheckNameChangeIsEnabledAttribute : Attribute, IAsyncPageFilter, IOrderedFilter
+{
+    public int Order => int.MinValue;
+
+    public async Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        if (!await NameChangeEnabled(context.HttpContext))
+        {
+            context.Result = new BadRequestResult();
+            return;
+        }
+
+        await next();
+    }
+
+    public Task OnPageHandlerSelectionAsync(PageHandlerSelectedContext context)
+    {
+        return Task.CompletedTask;
+    }
+
+    private async Task<bool> NameChangeEnabled(HttpContext httpContext)
+    {
+        var configuration = httpContext.RequestServices.GetRequiredService<IConfiguration>();
+        var dqtSynchronizationEnabled = configuration.GetValue("DqtSynchronizationEnabled", false);
+        if (dqtSynchronizationEnabled)
+        {
+            var dbContext = httpContext.RequestServices.GetRequiredService<TeacherIdentityServerDbContext>();
+            var user = await dbContext.Users
+                .Where(u => u.UserId == httpContext.User.GetUserId())
+                .SingleAsync();
+
+            return user.Trn is null;
+        }
+        else
+        {
+            return true;
+        }
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Confirm.cshtml.cs
@@ -9,6 +9,7 @@ using TeacherIdentity.AuthServer.Models;
 namespace TeacherIdentity.AuthServer.Pages.Account.Name;
 
 [VerifyQueryParameterSignature]
+[CheckNameChangeIsEnabled]
 public class Confirm : PageModel
 {
     private readonly TeacherIdentityServerDbContext _dbContext;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/Index.cshtml.cs
@@ -6,6 +6,7 @@ using TeacherIdentity.AuthServer.Infrastructure.Filters;
 namespace TeacherIdentity.AuthServer.Pages.Account.Name;
 
 [VerifyQueryParameterSignature]
+[CheckNameChangeIsEnabled]
 public class Name : PageModel
 {
     private readonly IdentityLinkGenerator _linkGenerator;

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Name/ConfirmTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Name/ConfirmTests.cs
@@ -13,6 +13,31 @@ public class ConfirmTests : TestBase
     }
 
     [Fact]
+    public async Task Get_NameChangeDisabled_ReturnsBadRequest()
+    {
+        // Arrange
+        var firstName = Faker.Name.First();
+        var middleName = Faker.Name.Middle();
+        var lastName = Faker.Name.Last();
+
+        HostFixture.Configuration["DqtSynchronizationEnabled"] = "true";
+        HostFixture.SetUserId(TestUsers.DefaultUserWithTrn.UserId);
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            AppendQueryParameterSignature($"/account/name/confirm?firstName={UrlEncode(firstName)}&middleName={UrlEncode(middleName)}&lastName={UrlEncode(lastName)}"));
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+
+        // Reset config
+        HostFixture.Configuration["DqtSynchronizationEnabled"] = "false";
+    }
+
+    [Fact]
     public async Task Get_NoFirstName_ReturnsBadRequest()
     {
         // Arrange

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Name/NameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Name/NameTests.cs
@@ -8,6 +8,27 @@ public class NameTests : TestBase
     }
 
     [Fact]
+    public async Task Get_NameChangeDisabled_ReturnsBadRequest()
+    {
+        // Arrange
+        HostFixture.Configuration["DqtSynchronizationEnabled"] = "true";
+        HostFixture.SetUserId(TestUsers.DefaultUserWithTrn.UserId);
+
+        var request = new HttpRequestMessage(
+            HttpMethod.Get,
+            AppendQueryParameterSignature($"/account/name"));
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
+
+        // Reset config
+        HostFixture.Configuration["DqtSynchronizationEnabled"] = "false";
+    }
+
+    [Fact]
     public async Task Post_EmptyFirstName_ReturnsError()
     {
         // Arrange


### PR DESCRIPTION
### Context

When we have DQT name synchronisation turned on we should not allow user’s to change their ID name directly.

### Changes proposed in this pull request

Amend the /account/name and /account/name/confirm pages to check if the user has a TRN linked and return a 400 response if they do if the DQT name synchronisation feature is enabled.

A filter attribute would work well here (see CheckOfficialDateOfBirthChangeIsEnabledAttribute for some prior art).

### Guidance to review

Simplish change. Does not include code to stop links being clicked in the account page as this will be part of another card.

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
