### PR TITLE
Don't show Change link next to Name for DQT synced accounts

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
@@ -39,9 +39,12 @@
             <govuk-summary-list-row>
                 <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
                 <govuk-summary-list-row-value>@Model.Name</govuk-summary-list-row-value>
-                <govuk-summary-list-row-actions>
-                    <govuk-summary-list-row-action href="@LinkGenerator.AccountName(firstName: null, middleName: null, lastName: null, Model.ClientRedirectInfo)" visually-hidden-text="name">Change</govuk-summary-list-row-action>
-                </govuk-summary-list-row-actions>
+                @if (Model.NameChangeEnabled)
+                {
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AccountName(firstName: null, middleName: null, lastName: null, Model.ClientRedirectInfo)" visually-hidden-text="name" data-testid="name-change-link">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                }                
             </govuk-summary-list-row>
             @if (Model.Trn is not null)
             {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml.cs
@@ -12,15 +12,18 @@ public class IndexModel : PageModel
     private readonly TeacherIdentityServerDbContext _dbContext;
     private readonly IDqtApiClient _dqtApiClient;
     private readonly TeacherIdentityApplicationManager _applicationManager;
+    private readonly bool _dqtSynchronizationEnabled;
 
     public IndexModel(
         TeacherIdentityServerDbContext dbContext,
+        IConfiguration configuration,
         IDqtApiClient dqtApiClient,
         TeacherIdentityApplicationManager applicationManager)
     {
         _dbContext = dbContext;
         _dqtApiClient = dqtApiClient;
         _applicationManager = applicationManager;
+        _dqtSynchronizationEnabled = configuration.GetValue("DqtSynchronizationEnabled", false);
     }
 
     public ClientRedirectInfo? ClientRedirectInfo => HttpContext.GetClientRedirectInfo();
@@ -37,6 +40,7 @@ public class IndexModel : PageModel
     public bool PendingDqtNameChange { get; set; }
     public bool PendingDqtDateOfBirthChange { get; set; }
     public bool DateOfBirthConflict { get; set; }
+    public bool NameChangeEnabled { get; set; }
 
     public async Task OnGet()
     {
@@ -82,6 +86,15 @@ public class IndexModel : PageModel
                 DateOfBirthConflict = true;
                 HttpContext.Features.Get<WebRequestEventFeature>()?.Event.AddTag("DateOfBirthConflict");
             }
+
+            if (!_dqtSynchronizationEnabled)
+            {
+                NameChangeEnabled = true;
+            }
+        }
+        else if (_dqtSynchronizationEnabled)
+        {
+            NameChangeEnabled = true;
         }
 
         if (ClientRedirectInfo is not null)


### PR DESCRIPTION
### Context

When we have DQT name synchronisation turned on we should not allow user’s to change their ID name directly.

### Changes proposed in this pull request

Amend the /account page to check if the user has a TRN linked and remove the Change link next to the Name label if the DqtSynchronizationEnabled feature is on.

### Guidance to review

Simple change to account page

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
