### PR TITLE
Amended account landing page to reflect most recent design history

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml
@@ -1,7 +1,7 @@
 @page "/account"
 @model TeacherIdentity.AuthServer.Pages.Account.IndexModel
 @{
-    ViewBag.Title = "DfE Identity account";
+    ViewBag.Title = "Confirm your details";
 
     var dateOfBirthChangeEnabled = Model.DqtDateOfBirth is null || (Model.DateOfBirthConflict && !Model.PendingDqtDateOfBirthChange);
 }
@@ -31,53 +31,92 @@
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
-        <span class="govuk-caption-l">DfE Identity account</span>
-        <h1 class="govuk-heading-l">Your details</h1>
+        <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+        <p>Check the details we have for you from your DfE teaching record.</p>
+        <p>You’ll need to provide evidence for some name changes and all date of birth changes.</p>
 
-        <h3 class="govuk-heading-m">Personal details</h3>
+        <h3 class="govuk-heading-m">Teaching record</h3>
         <govuk-summary-list>
             <govuk-summary-list-row>
-                <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
-                <govuk-summary-list-row-value>@Model.Name</govuk-summary-list-row-value>
-                @if (Model.NameChangeEnabled)
+                <govuk-summary-list-row-key>First names</govuk-summary-list-row-key>
+                @if (Model.Trn is not null)
                 {
-                    <govuk-summary-list-row-actions>
-                        <govuk-summary-list-row-action href="@LinkGenerator.AccountName(firstName: null, middleName: null, lastName: null, Model.ClientRedirectInfo)" visually-hidden-text="name" data-testid="name-change-link">Change</govuk-summary-list-row-action>
-                    </govuk-summary-list-row-actions>
-                }                
-            </govuk-summary-list-row>
-            @if (Model.Trn is not null)
-            {
-                <govuk-summary-list-row>
-                    <govuk-summary-list-row-key>Official name</govuk-summary-list-row-key>
                     @if (Model.PendingDqtNameChange)
                     {
                         <govuk-summary-list-row-value>
-                            @Model.OfficialName
-                            <p class="govuk-hint govuk-!-font-size-14">Displayed on teaching certificates </p>
-                            <govuk-tag class="govuk-tag--yellow" data-testid="name-pending-review-tag">PENDING REVIEW</govuk-tag>
+                            @Model.OfficialFirstName
+                            <govuk-tag class="govuk-tag--yellow" data-testid="first-name-pending-review-tag">PENDING REVIEW</govuk-tag>
                         </govuk-summary-list-row-value>
                     }
                     else
                     {
-                        <govuk-summary-list-row-value>
-                            @Model.OfficialName
-                            <p class="govuk-hint govuk-!-font-size-14">Displayed on teaching certificates </p>
-                        </govuk-summary-list-row-value>
+                        <govuk-summary-list-row-value>@Model.OfficialFirstName</govuk-summary-list-row-value>
                         <govuk-summary-list-row-actions>
-                            <govuk-summary-list-row-action href="@LinkGenerator.AccountOfficialName(Model.ClientRedirectInfo)" visually-hidden-text="official name" data-testid="dqt-name-change-link">Change</govuk-summary-list-row-action>
+                            <govuk-summary-list-row-action href="@LinkGenerator.AccountOfficialName(Model.ClientRedirectInfo)" visually-hidden-text="first names" data-testid="dqt-first-name-change-link">Change</govuk-summary-list-row-action>
                         </govuk-summary-list-row-actions>
                     }
-                </govuk-summary-list-row>
-            }
+                }
+                else
+                {
+                    <govuk-summary-list-row-value>@Model.FirstName</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AccountName(firstName: null, middleName: null, lastName: null, Model.ClientRedirectInfo)" visually-hidden-text="first names" data-testid="first-name-change-link">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                }
+            </govuk-summary-list-row>
             <govuk-summary-list-row>
-                <govuk-summary-list-row-key>Preferred name</govuk-summary-list-row-key>
-                <govuk-summary-list-row-value>
-                    <span fallback-text="Not provided">@Model.PreferredName</span>
-                </govuk-summary-list-row-value>
-                <govuk-summary-list-row-actions>
-                    <govuk-summary-list-row-action href="@LinkGenerator.AccountPreferredName(preferredName: null, Model.ClientRedirectInfo)" visually-hidden-text="preferred name" data-testid="preferred-name-change-link">Change</govuk-summary-list-row-action>
-                </govuk-summary-list-row-actions>
+                <govuk-summary-list-row-key>Middle names</govuk-summary-list-row-key>
+                @if (Model.Trn is not null)
+                {
+                    @if (Model.PendingDqtNameChange)
+                    {
+                        <govuk-summary-list-row-value>
+                            @Model.OfficialMiddleName
+                            <govuk-tag class="govuk-tag--yellow" data-testid="middle-name-pending-review-tag">PENDING REVIEW</govuk-tag>
+                        </govuk-summary-list-row-value>
+                    }
+                    else
+                    {
+                        <govuk-summary-list-row-value>@Model.OfficialMiddleName</govuk-summary-list-row-value>
+                        <govuk-summary-list-row-actions>
+                            <govuk-summary-list-row-action href="@LinkGenerator.AccountOfficialName(Model.ClientRedirectInfo)" visually-hidden-text="middle names" data-testid="dqt-middle-name-change-link">Change</govuk-summary-list-row-action>
+                        </govuk-summary-list-row-actions>
+                    }
+                }
+                else
+                {
+                    <govuk-summary-list-row-value>@Model.MiddleName</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AccountName(firstName: null, middleName: null, lastName: null, Model.ClientRedirectInfo)" visually-hidden-text="middle names" data-testid="middle-name-change-link">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                }
+            </govuk-summary-list-row>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Last names</govuk-summary-list-row-key>
+                @if (Model.Trn is not null)
+                {
+                    @if (Model.PendingDqtNameChange)
+                    {
+                        <govuk-summary-list-row-value>
+                            @Model.OfficialLastName
+                            <govuk-tag class="govuk-tag--yellow" data-testid="last-name-pending-review-tag">PENDING REVIEW</govuk-tag>
+                        </govuk-summary-list-row-value>
+                    }
+                    else
+                    {
+                        <govuk-summary-list-row-value>@Model.OfficialLastName</govuk-summary-list-row-value>
+                        <govuk-summary-list-row-actions>
+                            <govuk-summary-list-row-action href="@LinkGenerator.AccountOfficialName(Model.ClientRedirectInfo)" visually-hidden-text="last names" data-testid="dqt-last-name-change-link">Change</govuk-summary-list-row-action>
+                        </govuk-summary-list-row-actions>
+                    }
+                }
+                else
+                {
+                    <govuk-summary-list-row-value>@Model.LastName</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-actions>
+                        <govuk-summary-list-row-action href="@LinkGenerator.AccountName(firstName: null, middleName: null, lastName: null, Model.ClientRedirectInfo)" visually-hidden-text="last names" data-testid="last-name-change-link">Change</govuk-summary-list-row-action>
+                    </govuk-summary-list-row-actions>
+                }
             </govuk-summary-list-row>
             <govuk-summary-list-row>
                 <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
@@ -123,19 +162,17 @@
             }
         </govuk-summary-list>
 
-        @if (Model.Trn is not null)
-        {
-            <h3 class="govuk-heading-m">Teacher reference number (TRN)</h3>
-            <govuk-summary-list>
-                <govuk-summary-list-row>
-                    <govuk-summary-list-row-key>TRN</govuk-summary-list-row-key>
-                    <govuk-summary-list-row-value>@Model.Trn</govuk-summary-list-row-value>
-                </govuk-summary-list-row>
-            </govuk-summary-list>
-        }
-
-        <h3 class="govuk-heading-m">Sign in details</h3>
+        <h3 class="govuk-heading-m">Account details</h3>
         <govuk-summary-list>
+            <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Preferred name</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value>
+                    <span fallback-text="Not provided">@Model.PreferredName</span>
+                </govuk-summary-list-row-value>
+                <govuk-summary-list-row-actions>
+                    <govuk-summary-list-row-action href="@LinkGenerator.AccountPreferredName(preferredName: null, Model.ClientRedirectInfo)" visually-hidden-text="preferred name" data-testid="preferred-name-change-link">Change</govuk-summary-list-row-action>
+                </govuk-summary-list-row-actions>
+            </govuk-summary-list-row>
             <govuk-summary-list-row>
                 <govuk-summary-list-row-key>Email</govuk-summary-list-row-key>
                 <govuk-summary-list-row-value class="empty-hyphens">@Html.ShyEmail(Model.Email!)</govuk-summary-list-row-value>
@@ -144,10 +181,10 @@
                 </govuk-summary-list-row-actions>
             </govuk-summary-list-row>
             <govuk-summary-list-row>
-                <govuk-summary-list-row-key>Mobile number</govuk-summary-list-row-key>
+                <govuk-summary-list-row-key>Mobile phone</govuk-summary-list-row-key>
                 <govuk-summary-list-row-value>@Model.MobileNumber</govuk-summary-list-row-value>
                 <govuk-summary-list-row-actions>
-                    <govuk-summary-list-row-action href="@LinkGenerator.AccountPhone(Model.ClientRedirectInfo)" visually-hidden-text="mobile number">Change</govuk-summary-list-row-action>
+                    <govuk-summary-list-row-action href="@LinkGenerator.AccountPhone(Model.ClientRedirectInfo)" visually-hidden-text="mobile phone">Change</govuk-summary-list-row-action>
                 </govuk-summary-list-row-actions>
             </govuk-summary-list-row>
         </govuk-summary-list>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml.cs
@@ -12,18 +12,15 @@ public class IndexModel : PageModel
     private readonly TeacherIdentityServerDbContext _dbContext;
     private readonly IDqtApiClient _dqtApiClient;
     private readonly TeacherIdentityApplicationManager _applicationManager;
-    private readonly bool _dqtSynchronizationEnabled;
 
     public IndexModel(
         TeacherIdentityServerDbContext dbContext,
-        IConfiguration configuration,
         IDqtApiClient dqtApiClient,
         TeacherIdentityApplicationManager applicationManager)
     {
         _dbContext = dbContext;
         _dqtApiClient = dqtApiClient;
         _applicationManager = applicationManager;
-        _dqtSynchronizationEnabled = configuration.GetValue("DqtSynchronizationEnabled", false);
     }
 
     public ClientRedirectInfo? ClientRedirectInfo => HttpContext.GetClientRedirectInfo();
@@ -44,7 +41,6 @@ public class IndexModel : PageModel
     public bool PendingDqtNameChange { get; set; }
     public bool PendingDqtDateOfBirthChange { get; set; }
     public bool DateOfBirthConflict { get; set; }
-    public bool NameChangeEnabled { get; set; }
 
     public async Task OnGet()
     {
@@ -91,15 +87,6 @@ public class IndexModel : PageModel
                 DateOfBirthConflict = true;
                 HttpContext.Features.Get<WebRequestEventFeature>()?.Event.AddTag("DateOfBirthConflict");
             }
-
-            if (!_dqtSynchronizationEnabled)
-            {
-                NameChangeEnabled = true;
-            }
-        }
-        else if (_dqtSynchronizationEnabled)
-        {
-            NameChangeEnabled = true;
         }
 
         if (ClientRedirectInfo is not null)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Index.cshtml.cs
@@ -29,8 +29,12 @@ public class IndexModel : PageModel
     public ClientRedirectInfo? ClientRedirectInfo => HttpContext.GetClientRedirectInfo();
     public string? ClientDisplayName { get; set; }
 
-    public string? Name { get; set; }
-    public string? OfficialName { get; set; }
+    public string? FirstName { get; set; }
+    public string? MiddleName { get; set; }
+    public string? LastName { get; set; }
+    public string? OfficialFirstName { get; set; }
+    public string? OfficialMiddleName { get; set; }
+    public string? OfficialLastName { get; set; }
     public string? PreferredName { get; set; }
     public DateOnly? DateOfBirth { get; set; }
     public string? Email { get; set; }
@@ -61,7 +65,9 @@ public class IndexModel : PageModel
             })
             .SingleAsync();
 
-        Name = string.IsNullOrEmpty(user.MiddleName) ? $"{user.FirstName} {user.LastName}" : $"{user.FirstName} {user.MiddleName} {user.LastName}";
+        FirstName = user.FirstName;
+        MiddleName = user.MiddleName;
+        LastName = user.LastName;
         PreferredName = user.PreferredName;
         DateOfBirth = user.DateOfBirth;
         Email = user.EmailAddress;
@@ -73,10 +79,9 @@ public class IndexModel : PageModel
             var dqtUser = await _dqtApiClient.GetTeacherByTrn(Trn) ??
                 throw new Exception($"User with TRN '{Trn}' cannot be found in DQT.");
 
-            OfficialName = string.Join(' ', new[] { dqtUser.FirstName, dqtUser.MiddleName, dqtUser.LastName }
-                .Select(n => n.Trim())
-                .Where(n => !string.IsNullOrEmpty(n)));
-
+            OfficialFirstName = dqtUser.FirstName;
+            OfficialMiddleName = dqtUser.MiddleName;
+            OfficialLastName = dqtUser.LastName;
             DqtDateOfBirth = dqtUser.DateOfBirth;
             PendingDqtNameChange = dqtUser.PendingNameChange;
             PendingDqtDateOfBirthChange = dqtUser.PendingDateOfBirthChange;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Details.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Details.cshtml.cs
@@ -97,7 +97,7 @@ public class Details : PageModel
     private bool NamesUnchanged()
     {
         return FirstName == DqtUser!.FirstName &&
-               MiddleName == DqtUser.MiddleName &&
+               (MiddleName ?? string.Empty) == DqtUser.MiddleName &&
                LastName == DqtUser.LastName;
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Index.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Phone/Index.cshtml
@@ -1,7 +1,7 @@
 @page "/account/phone"
 @model TeacherIdentity.AuthServer.Pages.Account.Phone.PhonePage
 @{
-    ViewBag.Title = "Your mobile number";
+    ViewBag.Title = "Your mobile phone";
 }
 
 @section BeforeContent {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Account.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Account.cs
@@ -167,9 +167,9 @@ public class Account : IClassFixture<HostFixture>
 
         await SignInToAccountPage(page, user);
 
-        Assert.False(await page.GetByTestId("dqt-name-pending-review-tag").IsVisibleAsync());
+        Assert.False(await page.GetByTestId("dqt-first-name-pending-review-tag").IsVisibleAsync());
 
-        await page.ClickChangeLinkForElementWithTestId("dqt-name-change-link");
+        await page.ClickChangeLinkForElementWithTestId("dqt-first-name-change-link");
 
         await page.WaitForUrlPathAsync("/account/official-name");
         await page.ClickContinueButton();

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/IndexTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/IndexTests.cs
@@ -74,11 +74,13 @@ public class IndexTests : TestBase
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
     }
 
-    [Fact]
-    public async Task Get_ValidRequest_ReturnsUserDetails()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Get_ValidRequestForUserWithoutTrn_ShowsIdentityNames(bool hasPreferredName)
     {
         // Arrange
-        var user = await TestData.CreateUser(hasPreferredName: true);
+        var user = await TestData.CreateUser(hasPreferredName: hasPreferredName);
         HostFixture.SetUserId(user.UserId);
 
         var request = new HttpRequestMessage(HttpMethod.Get, "/account");
@@ -89,58 +91,30 @@ public class IndexTests : TestBase
         // Assert
         var doc = await response.GetDocument();
 
-        Assert.Equal($"{user.FirstName} {user.MiddleName} {user.LastName}", doc.GetSummaryListValueForKey("Name"));
-        Assert.Equal(user.PreferredName, doc.GetSummaryListValueForKey("Preferred name"));
+        Assert.Equal(user.FirstName, doc.GetSummaryListValueForKey("First names"));
+        Assert.Equal(user.MiddleName, doc.GetSummaryListValueForKey("Middle names"));
+        Assert.Equal(user.LastName, doc.GetSummaryListValueForKey("Last names"));
+        if (hasPreferredName)
+        {
+            Assert.Equal(user.PreferredName, doc.GetSummaryListValueForKey("Preferred name"));
+        }
+        else
+        {
+            Assert.Equal("Not provided", doc.GetSummaryListValueForKey("Preferred name"));
+        }
+
         Assert.Equal($"{user.DateOfBirth?.ToString(Constants.DateFormat)}", doc.GetSummaryListValueForKey("Date of birth"));
         Assert.Equal(user.EmailAddress, doc.GetSummaryListValueForKey("Email"));
-        Assert.Equal(user.MobileNumber, doc.GetSummaryListValueForKey("Mobile number"));
+        Assert.Equal(user.MobileNumber, doc.GetSummaryListValueForKey("Mobile phone"));
     }
 
-    [Fact]
-    public async Task Get_ValidRequestForUserWithoutPreferredName_ReturnsUserDetailsWithPlaceholderForPreferredName()
+    [Theory]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task Get_ValidRequestForUserWithTrn_ShowsOfficialNames(bool hasPreferredName)
     {
         // Arrange
-        var user = await TestData.CreateUser(hasPreferredName: false);
-        HostFixture.SetUserId(user.UserId);
-
-        var request = new HttpRequestMessage(HttpMethod.Get, "/account");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        var doc = await response.GetDocument();
-
-        Assert.Equal($"{user.FirstName} {user.MiddleName} {user.LastName}", doc.GetSummaryListValueForKey("Name"));
-        Assert.Equal("Not provided", doc.GetSummaryListValueForKey("Preferred name"));
-        Assert.Equal($"{user.DateOfBirth?.ToString(Constants.DateFormat)}", doc.GetSummaryListValueForKey("Date of birth"));
-        Assert.Equal(user.EmailAddress, doc.GetSummaryListValueForKey("Email"));
-        Assert.Equal(user.MobileNumber, doc.GetSummaryListValueForKey("Mobile number"));
-    }
-
-    [Fact]
-    public async Task Get_ValidRequestForUserWithoutTrn_DoesNotShowOfficialNameRow()
-    {
-        // Arrange
-        var user = await TestData.CreateUser(hasTrn: false);
-        HostFixture.SetUserId(user.UserId);
-
-        var request = new HttpRequestMessage(HttpMethod.Get, "/account");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        var doc = await response.GetDocument();
-
-        Assert.Null(doc.GetSummaryListRowForKey("Official name"));
-    }
-
-    [Fact]
-    public async Task Get_ValidRequestForUserWithTrn_DoesShowOfficialNameRow()
-    {
-        // Arrange
-        var user = await TestData.CreateUser(hasTrn: true);
+        var user = await TestData.CreateUser(hasTrn: true, hasPreferredName: hasPreferredName);
         HostFixture.SetUserId(user.UserId);
 
         var officialFirstName = Faker.Name.First();
@@ -170,60 +144,21 @@ public class IndexTests : TestBase
         // Assert
         var doc = await response.GetDocument();
 
-        Assert.Equal(
-            $"{officialFirstName} {officialMiddleName} {officialLastName}",
-            doc.GetSummaryListValueForKey("Official name")?.Replace("Displayed on teaching certificates", "").Trim());
-    }
+        Assert.Equal(officialFirstName, doc.GetSummaryListValueForKey("First names"));
+        Assert.Equal(officialMiddleName, doc.GetSummaryListValueForKey("Middle names"));
+        Assert.Equal(officialLastName, doc.GetSummaryListValueForKey("Last names"));
+        if (hasPreferredName)
+        {
+            Assert.Equal(user.PreferredName, doc.GetSummaryListValueForKey("Preferred name"));
+        }
+        else
+        {
+            Assert.Equal("Not provided", doc.GetSummaryListValueForKey("Preferred name"));
+        }
 
-    [Fact]
-    public async Task Get_ValidRequestForUserWithoutTrn_DoesNotShowTRNRow()
-    {
-        // Arrange
-        var user = await TestData.CreateUser(hasTrn: false);
-        HostFixture.SetUserId(user.UserId);
-
-        var request = new HttpRequestMessage(HttpMethod.Get, "/account");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        var doc = await response.GetDocument();
-
-        Assert.Null(doc.GetSummaryListRowForKey("TRN"));
-    }
-
-    [Fact]
-    public async Task Get_ValidRequestForUserWithTrn_DoesShowTRNRow()
-    {
-        // Arrange
-        var user = await TestData.CreateUser(hasTrn: true);
-        HostFixture.SetUserId(user.UserId);
-
-        HostFixture.DqtApiClient
-            .Setup(mock => mock.GetTeacherByTrn(user.Trn!, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new TeacherInfo()
-            {
-                DateOfBirth = user.DateOfBirth!.Value,
-                FirstName = Faker.Name.First(),
-                MiddleName = "",
-                LastName = Faker.Name.Last(),
-                NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber(),
-                Trn = user.Trn!,
-                PendingNameChange = false,
-                PendingDateOfBirthChange = false,
-                Email = null
-            });
-
-        var request = new HttpRequestMessage(HttpMethod.Get, "/account");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        var doc = await response.GetDocument();
-
-        Assert.Equal(user.Trn, doc.GetSummaryListValueForKey("TRN"));
+        Assert.Equal($"{user.DateOfBirth?.ToString(Constants.DateFormat)}", doc.GetSummaryListValueForKey("Date of birth"));
+        Assert.Equal(user.EmailAddress, doc.GetSummaryListValueForKey("Email"));
+        Assert.Equal(user.MobileNumber, doc.GetSummaryListValueForKey("Mobile phone"));
     }
 
     [Theory]
@@ -347,7 +282,9 @@ public class IndexTests : TestBase
         // Assert
         var doc = await response.GetDocument();
 
-        Assert.NotNull(doc.GetElementByTestId("name-pending-review-tag"));
+        Assert.NotNull(doc.GetElementByTestId("first-name-pending-review-tag"));
+        Assert.NotNull(doc.GetElementByTestId("middle-name-pending-review-tag"));
+        Assert.NotNull(doc.GetElementByTestId("last-name-pending-review-tag"));
     }
 
     [Fact]

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/IndexTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/IndexTests.cs
@@ -162,59 +162,6 @@ public class IndexTests : TestBase
     }
 
     [Theory]
-    [InlineData(true)]
-    [InlineData(false)]
-    public async Task Get_ValidRequestForUserWithTrn_DoesNotShowChangeNameLink(bool dqtSynchronizationEnabled)
-    {
-        // Arrange
-        var user = await TestData.CreateUser(hasTrn: true);
-        HostFixture.SetUserId(user.UserId);
-
-        HostFixture.DqtApiClient
-            .Setup(mock => mock.GetTeacherByTrn(user.Trn!, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new TeacherInfo()
-            {
-                DateOfBirth = user.DateOfBirth!.Value,
-                FirstName = Faker.Name.First(),
-                MiddleName = "",
-                LastName = Faker.Name.Last(),
-                NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber(),
-                Trn = user.Trn!,
-                PendingNameChange = false,
-                PendingDateOfBirthChange = false,
-                Email = null
-            });
-
-        if (dqtSynchronizationEnabled)
-        {
-            HostFixture.Configuration["DqtSynchronizationEnabled"] = "true";
-        }
-
-        var request = new HttpRequestMessage(HttpMethod.Get, "/account");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        var doc = await response.GetDocument();
-
-        if (dqtSynchronizationEnabled)
-        {
-            Assert.Null(doc.GetElementByTestId("name-change-link"));
-        }
-        else
-        {
-            Assert.NotNull(doc.GetElementByTestId("name-change-link"));
-        }
-
-        // Reset config
-        if (dqtSynchronizationEnabled)
-        {
-            HostFixture.Configuration["DqtSynchronizationEnabled"] = "false";
-        }
-    }
-
-    [Theory]
     [MemberData(nameof(DateOfBirthState))]
     public async Task Get_ValidRequestForUser_ShowsCorrectDobSummaryRowElements(
         bool hasTrn,

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Name/ConfirmTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Name/ConfirmTests.cs
@@ -5,6 +5,7 @@ using TeacherIdentity.AuthServer.Models;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Account.Name;
 
+[Collection(nameof(DisableParallelization))]
 public class ConfirmTests : TestBase
 {
     public ConfirmTests(HostFixture hostFixture)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialName/DetailsTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialName/DetailsTests.cs
@@ -128,6 +128,31 @@ public class DetailsTests : TestBase
         await AssertEx.HtmlResponseHasError(response, "FirstName", "The name entered matches your official name");
     }
 
+    [Fact]
+    public async Task Post_MiddleNameFromEmptyToNullIsNamesUnchanged_ReturnsBadRequest()
+    {
+        // Arrange
+        var user = TestUsers.DefaultUserWithTrn;
+        var middleName = Faker.Name.Middle();
+        HostFixture.SetUserId(user.UserId);
+        MockDqtApiResponse(TestUsers.DefaultUserWithTrn, hasPendingNameChange: false, string.Empty);
+
+        var request = new HttpRequestMessage(HttpMethod.Post, AppendQueryParameterSignature($"/account/official-name/details"))
+        {
+            Content = new FormUrlEncodedContentBuilder()
+            {
+                { "FirstName", user.FirstName },
+                { "LastName", user.LastName },
+            }
+        };
+
+        // Act
+        var response = await HttpClient.SendAsync(request);
+
+        // Assert
+        await AssertEx.HtmlResponseHasError(response, "FirstName", "The name entered matches your official name");
+    }
+
     [Theory]
     [InlineData(true)]
     [InlineData(false)]


### PR DESCRIPTION
### Context

We have a revised version of the account page that better fits when we’ve got DQT name synchronisation enabled.

### Changes proposed in this pull request

Amend the account page so that when the DQT name synchronisation feature is enabled we show a revised version of the page as shown on [Avoiding duplicate names](https://tra-digital-design-history.herokuapp.com/get-an-identity/avoiding-duplicate-names/)

The page header should be ‘Confirm your details’.

Add the ‘Check your details we have for you from your DfE teaching record’ and ‘You’ll need to provide evidence for some name changes and all date of birth changes.' paragraphs.

Add the ‘Teaching record’ block with first, middle, last names and date of birth. The Change links for the name rows should go to /account/official-name if the user has a TRN linked, otherwise to /account/name. If the DQT DOB and ID DOB's don't match then show both in their own rows, with the appropriate Change link for each. If the DOB's do match, do not show a Change link. If the DQT DOB is pending review show the 'PENDING REVIEW' tag.

Add the ‘Account details’ blow with rows for preferred name, email and phone number with the appropriate change links.

We should retain the ‘Confirm your correct date of birth’ notification banner if the DQT DOB and ID DOB’s do not match.

Unlike the design history post, we should not have a ‘Confirm’ button but keep the ‘Back to <client>’ button we have today.

### Guidance to review

N/A

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
