### PR TITLE
Enabled DQT Synchronization

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Production.json
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Production.json
@@ -40,5 +40,5 @@
     "WebHooksCacheDurationSeconds": 120
   },
   "RegisterWithTrnTokenEnabled": false,
-  "DqtSynchronizationEnabled":  false
+  "DqtSynchronizationEnabled":  true
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.json
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.json
@@ -30,7 +30,7 @@
     "RefreshEstablishmentDomainsJobSchedule": "0 2 * * *"
   },
   "RegisterWithTrnTokenEnabled": true,
-  "DqtSynchronizationEnabled": false,
+  "DqtSynchronizationEnabled": true,
   "BlockEstablishmentEmailDomains": false,
   "SupportEmail": "qts.enquiries@education.gov.uk",
   "TrnTokens": {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/TrnTokenSignInJourney.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/TrnTokenSignInJourney.cs
@@ -389,6 +389,8 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
         var dqtFirstName = Faker.Name.First();
         var dqtLastName = Faker.Name.Last();
 
+        _hostFixture.Configuration["DqtSynchronizationEnabled"] = "false";
+
         var trnToken = await CreateValidTrnToken(email: user.EmailAddress, firstName: dqtFirstName, lastName: dqtLastName);
 
         await page.StartOAuthJourney(CustomScopes.DqtRead, trnToken: trnToken.TrnToken);
@@ -409,6 +411,9 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
                 Assert.Equal(user.UserId, userUpdatedEvent.User.UserId);
             },
             e => Assert.IsType<UserSignedInEvent>(e));
+
+        // Reset config
+        _hostFixture.Configuration["DqtSynchronizationEnabled"] = "true";
     }
 
     [Fact]
@@ -545,6 +550,8 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
         var dqtFirstName = Faker.Name.First();
         var dqtLastName = Faker.Name.Last();
 
+        _hostFixture.Configuration["DqtSynchronizationEnabled"] = "false";
+
         var trnToken = await CreateValidTrnToken(email: differentEmail, firstName: dqtFirstName, lastName: dqtLastName);
 
         await page.StartOAuthJourney(CustomScopes.DqtRead, trnToken: trnToken.TrnToken);
@@ -571,6 +578,9 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
                 Assert.Equal(user.UserId, userUpdatedEvent.User.UserId);
             },
             e => Assert.IsType<UserSignedInEvent>(e));
+
+        // Reset config
+        _hostFixture.Configuration["DqtSynchronizationEnabled"] = "true";
     }
 
     [Fact]

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/appsettings.json
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/appsettings.json
@@ -11,7 +11,8 @@
     "UserVerification": {
       "UseFixedPin": true
     },
-    "BlockEstablishmentEmailDomains": true
+    "BlockEstablishmentEmailDomains": true,
+    "DqtSynchronizationEnabled": true
   },
   "TestClient": {
     "ClientId": "testclient",

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/CheckAnswersTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/Register/CheckAnswersTests.cs
@@ -11,6 +11,7 @@ using User = TeacherIdentity.AuthServer.Models.User;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.SignIn.Register;
 
+[Collection(nameof(DisableParallelization))]
 public class CheckAnswersTests : TestBase
 {
     public CheckAnswersTests(HostFixture hostFixture)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/appsettings.json
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/appsettings.json
@@ -8,6 +8,7 @@
   "BaseAddress": "http://localhost",
   "QueryStringSignatureKey": "qskey",
   "BlockEstablishmentEmailDomains": true,
+  "DqtSynchronizationEnabled": true,
   "WebHooks": {
     "WebHooksCacheDurationSeconds": 30
   }


### PR DESCRIPTION
### Context

We have a feature flag that controls whether we sync names from DQT. It’s currently disabled; we need to turn it on.

### Changes proposed in this pull request

Enable the DQT name synchronisation feature flag.

### Guidance to review

Config change

### Checklist

-   [x] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
