### PR TITLE
added preferred name edit functionality

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditUserName.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditUserName.cshtml
@@ -41,6 +41,10 @@
                 <govuk-input-label class="govuk-label--s"/>
             </govuk-input>
 
+            <govuk-input asp-for="PreferredName">
+                <govuk-input-label class="govuk-label--s"/>
+            </govuk-input>
+
             <govuk-button type="submit">Continue</govuk-button>
         </form>
     </div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditUserName.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditUserName.cshtml.cs
@@ -44,6 +44,11 @@ public class EditUserNameModel : PageModel
     [MaxLength(Models.User.MiddleNameMaxLength, ErrorMessage = "Middle name must be 200 characters or less")]
     public string? MiddleName { get; set; }
 
+    [BindProperty]
+    [Display(Name = "Preferred name")]
+    [MaxLength(Models.User.PreferredNameMaxLength, ErrorMessage = "Preferred name must be 200 characters or less")]
+    public string? PreferredName { get; set; }
+
     public void OnGet()
     {
     }
@@ -60,11 +65,13 @@ public class EditUserNameModel : PageModel
         var changes = UserUpdatedEventChanges.None |
             (user.FirstName != NewFirstName ? UserUpdatedEventChanges.FirstName : UserUpdatedEventChanges.None) |
             (user.LastName != NewLastName ? UserUpdatedEventChanges.LastName : UserUpdatedEventChanges.None) |
-            (user.MiddleName != MiddleName ? UserUpdatedEventChanges.MiddleName : UserUpdatedEventChanges.None);
+            (user.MiddleName != MiddleName ? UserUpdatedEventChanges.MiddleName : UserUpdatedEventChanges.None) |
+            (user.PreferredName != PreferredName ? UserUpdatedEventChanges.PreferredName : UserUpdatedEventChanges.None);
 
         user.FirstName = NewFirstName!;
         user.LastName = NewLastName!;
         user.MiddleName = MiddleName;
+        user.PreferredName = PreferredName;
 
         if (changes != UserUpdatedEventChanges.None)
         {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/User.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/User.cshtml
@@ -43,6 +43,9 @@
             <govuk-summary-list-row>
                 <govuk-summary-list-row-key>Preferred name</govuk-summary-list-row-key>
                 <govuk-summary-list-row-value>@Model.PreferredName</govuk-summary-list-row-value>
+                <govuk-summary-list-row-actions>
+                    <govuk-summary-list-row-action asp-page="EditUserName" asp-route-userId="@Model.UserId" visually-hidden-text="preferred name">Change</govuk-summary-list-row-action>
+                </govuk-summary-list-row-actions>
             </govuk-summary-list-row>
             <govuk-summary-list-row>
                 <govuk-summary-list-row-key>Email address</govuk-summary-list-row-key>


### PR DESCRIPTION
### Context

We don’t currently expose a mechanism for admins to update a user’s preferred name.

### Changes proposed in this pull request

- preferred name can not be edited via admin area
- updated test to cover preferred name

### Guidance to review

- `Faker.Name.FullName();` has been used for one of the test as there's no `Faker.Name.GetPreferredName()` method.

### Checklist

-   [#1153]