### PR TITLE
Amend dqt sync to handle dqt data with incomplete names

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -643,7 +643,7 @@ public class AuthenticationState
         Trn = trn;
         TrnLookupStatus = trnLookupStatus;
 
-        if (dqtSynchronizationEnabled && findTeachersResult is not null)
+        if (dqtSynchronizationEnabled && findTeachersResult is not null && !string.IsNullOrEmpty(findTeachersResult.FirstName) && !string.IsNullOrEmpty(findTeachersResult.LastName))
         {
             DqtFirstName = findTeachersResult.FirstName;
             DqtMiddleName = findTeachersResult.MiddleName;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenHelper.cs
@@ -204,7 +204,7 @@ public class TrnTokenHelper
                 using var stream = new MemoryStream(Encoding.UTF8.GetBytes(debugLog));
                 await blobClient.UploadAsync(stream);
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 // Don't want logging issues to abort whole process
             }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenHelper.cs
@@ -1,3 +1,6 @@
+using System.Text;
+using System.Text.Json;
+using Azure.Storage.Blobs;
 using Microsoft.EntityFrameworkCore;
 using OpenIddict.Abstractions;
 using TeacherIdentity.AuthServer.Events;
@@ -10,24 +13,29 @@ namespace TeacherIdentity.AuthServer.Journeys;
 
 public class TrnTokenHelper
 {
+    private const string DebugLogsContainerName = "debug-logs";
+
     private readonly TeacherIdentityServerDbContext _dbContext;
     private readonly IClock _clock;
     private readonly IDqtApiClient _dqtApiClient;
     private readonly IConfiguration _configuration;
     private readonly IUserSearchService _userSearchService;
+    private readonly BlobServiceClient _blobServiceClient;
 
     public TrnTokenHelper(
         TeacherIdentityServerDbContext dbContext,
         IClock clock,
         IDqtApiClient dqtApiClient,
         IConfiguration configuration,
-        IUserSearchService userSearchService)
+        IUserSearchService userSearchService,
+        BlobServiceClient blobServiceClient)
     {
         _dbContext = dbContext;
         _clock = clock;
         _dqtApiClient = dqtApiClient;
         _configuration = configuration;
         _userSearchService = userSearchService;
+        _blobServiceClient = blobServiceClient;
     }
 
     public async Task<EnhancedTrnToken?> GetValidTrnToken(OpenIddictRequest request)
@@ -119,6 +127,8 @@ public class TrnTokenHelper
             return null;
         }
 
+        await CheckDqtTeacherNames(teacher);
+
         return new EnhancedTrnToken()
         {
             TrnToken = trnToken.TrnToken,
@@ -141,7 +151,7 @@ public class TrnTokenHelper
         if (_configuration.GetValue("DqtSynchronizationEnabled", false))
         {
             var dqtUser = await _dqtApiClient.GetTeacherByTrn(trn);
-            if (dqtUser is not null)
+            if (dqtUser is not null && await CheckDqtTeacherNames(dqtUser))
             {
                 changes |= (user.FirstName != dqtUser.FirstName ? UserUpdatedEventChanges.FirstName : UserUpdatedEventChanges.None) |
                            (user.MiddleName != dqtUser.MiddleName ? UserUpdatedEventChanges.MiddleName : UserUpdatedEventChanges.None) |
@@ -180,5 +190,41 @@ public class TrnTokenHelper
         }
 
         return user;
+    }
+
+    private async Task<bool> CheckDqtTeacherNames(TeacherInfo teacher)
+    {
+        if (string.IsNullOrEmpty(teacher.FirstName) || string.IsNullOrEmpty(teacher.LastName))
+        {
+            try
+            {
+                var blobName = $"{nameof(TrnTokenHelper)}-{_clock.UtcNow:yyyyMMddHHmmssfff}-{Guid.NewGuid()}.json";
+                var blobClient = await GetBlobClient(blobName);
+                var debugLog = JsonSerializer.Serialize(teacher);
+                using var stream = new MemoryStream(Encoding.UTF8.GetBytes(debugLog));
+                await blobClient.UploadAsync(stream);
+            }
+            catch (Exception ex)
+            {
+                // Don't want logging issues to abort whole process
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private async Task<BlobClient> GetBlobClient(string blobName)
+    {
+        var blobContainerClient = await GetBlobContainerClient();
+        return blobContainerClient.GetBlobClient(blobName);
+    }
+
+    private async Task<BlobContainerClient> GetBlobContainerClient()
+    {
+        var blobContainerClient = _blobServiceClient.GetBlobContainerClient(DebugLogsContainerName);
+        await blobContainerClient.CreateIfNotExistsAsync();
+        return blobContainerClient;
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/UserHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/UserHelper.cs
@@ -316,7 +316,7 @@ public class UserHelper
                 using var stream = new MemoryStream(Encoding.UTF8.GetBytes(debugLog));
                 await blobClient.UploadAsync(stream);
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 // Don't want logging issues to abort whole process
             }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/HostFixture.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/HostFixture.cs
@@ -1,3 +1,4 @@
+using Azure.Storage.Blobs;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
@@ -167,6 +168,7 @@ public class HostFixture : WebApplicationFactory<TeacherIdentity.AuthServer.Prog
             services.AddTransient(_ => ZendeskApiWrapper.Object);
             services.AddTransient(_ => UserImportCsvStorageService.Object);
             services.AddTransient(_ => DqtEvidenceStorageService.Object);
+            services.AddSingleton(new BlobServiceClient("DefaultEndpointsProtocol=https;AccountName=MyAccount;AccountKey=MyAccountKey;EndpointSuffix=core.windows.net"));
             ConfigureWebHooks(services);
         });
     }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Jobs/SyncNamesWithDqtJobTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Jobs/SyncNamesWithDqtJobTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Azure.Storage.Blobs;
 using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Events;
 using TeacherIdentity.AuthServer.Jobs;
@@ -79,7 +80,8 @@ public class SyncNamesWithDqtJobTests : IClassFixture<DbFixture>, IAsyncLifetime
         var job = new SyncNamesWithDqtJob(
             _dbFixture.GetDbContextFactory(),
             dqtApiClient,
-            _dbFixture.Clock);
+            _dbFixture.Clock,
+            new BlobServiceClient("DefaultEndpointsProtocol=https;AccountName=MyAccount;AccountKey=MyAccountKey;EndpointSuffix=core.windows.net"));
         await job.Execute(CancellationToken.None);
 
         // Assert
@@ -161,7 +163,8 @@ public class SyncNamesWithDqtJobTests : IClassFixture<DbFixture>, IAsyncLifetime
         var job = new SyncNamesWithDqtJob(
             _dbFixture.GetDbContextFactory(),
             dqtApiClient,
-            _dbFixture.Clock);
+            _dbFixture.Clock,
+            new BlobServiceClient("DefaultEndpointsProtocol=https;AccountName=MyAccount;AccountKey=MyAccountKey;EndpointSuffix=core.windows.net"));
         await job.Execute(CancellationToken.None);
 
         // Assert

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/JourneyTests/TrnLookupHelperTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/JourneyTests/TrnLookupHelperTests.cs
@@ -1,3 +1,4 @@
+using Azure.Storage.Blobs;
 using Microsoft.Extensions.Logging.Abstractions;
 using TeacherIdentity.AuthServer.Journeys;
 using TeacherIdentity.AuthServer.Services.DqtApi;
@@ -30,7 +31,12 @@ public class TrnLookupHelperTests
 
         var logger = new NullLogger<TrnLookupHelper>();
 
-        var helper = new TrnLookupHelper(dqtApiClientMock.Object, _configuration, logger);
+        var helper = new TrnLookupHelper(
+            dqtApiClientMock.Object,
+            _configuration,
+            logger,
+            new BlobServiceClient("DefaultEndpointsProtocol=https;AccountName=MyAccount;AccountKey=MyAccountKey;EndpointSuffix=core.windows.net"),
+            new TestClock());
 
         // Act
         var result = await helper.LookupTrn(authenticationState);
@@ -61,7 +67,12 @@ public class TrnLookupHelperTests
 
         var logger = new NullLogger<TrnLookupHelper>();
 
-        var helper = new TrnLookupHelper(dqtApiClientMock.Object, _configuration, logger);
+        var helper = new TrnLookupHelper(
+            dqtApiClientMock.Object,
+            _configuration,
+            logger,
+            new BlobServiceClient("DefaultEndpointsProtocol=https;AccountName=MyAccount;AccountKey=MyAccountKey;EndpointSuffix=core.windows.net"),
+            new TestClock());
 
         // Act
         var result = await helper.LookupTrn(authenticationState);
@@ -118,7 +129,12 @@ public class TrnLookupHelperTests
 
         var logger = new NullLogger<TrnLookupHelper>();
 
-        var helper = new TrnLookupHelper(dqtApiClientMock.Object, _configuration, logger);
+        var helper = new TrnLookupHelper(
+            dqtApiClientMock.Object,
+            _configuration,
+            logger,
+            new BlobServiceClient("DefaultEndpointsProtocol=https;AccountName=MyAccount;AccountKey=MyAccountKey;EndpointSuffix=core.windows.net"),
+            new TestClock());
 
         // Act
         var result = await helper.LookupTrn(authenticationState);
@@ -163,7 +179,12 @@ public class TrnLookupHelperTests
 
         var logger = new NullLogger<TrnLookupHelper>();
 
-        var helper = new TrnLookupHelper(dqtApiClientMock.Object, _configuration, logger);
+        var helper = new TrnLookupHelper(
+            dqtApiClientMock.Object,
+            _configuration,
+            logger,
+            new BlobServiceClient("DefaultEndpointsProtocol=https;AccountName=MyAccount;AccountKey=MyAccountKey;EndpointSuffix=core.windows.net"),
+            new TestClock());
 
         // Act
         var result = await helper.LookupTrn(authenticationState);
@@ -191,7 +212,12 @@ public class TrnLookupHelperTests
 
         var logger = new NullLogger<TrnLookupHelper>();
 
-        var helper = new TrnLookupHelper(dqtApiClientMock.Object, _configuration, logger);
+        var helper = new TrnLookupHelper(
+            dqtApiClientMock.Object,
+            _configuration,
+            logger,
+            new BlobServiceClient("DefaultEndpointsProtocol=https;AccountName=MyAccount;AccountKey=MyAccountKey;EndpointSuffix=core.windows.net"),
+            new TestClock());
 
         // Act
         await helper.LookupTrn(authenticationState);
@@ -218,7 +244,12 @@ public class TrnLookupHelperTests
 
         var logger = new NullLogger<TrnLookupHelper>();
 
-        var helper = new TrnLookupHelper(dqtApiClientMock.Object, _configuration, logger);
+        var helper = new TrnLookupHelper(
+            dqtApiClientMock.Object,
+            _configuration,
+            logger,
+            new BlobServiceClient("DefaultEndpointsProtocol=https;AccountName=MyAccount;AccountKey=MyAccountKey;EndpointSuffix=core.windows.net"),
+            new TestClock());
 
         // Act
         await helper.LookupTrn(authenticationState);
@@ -244,7 +275,12 @@ public class TrnLookupHelperTests
         var dqtApiClientMock = new Mock<IDqtApiClient>();
         var logger = new NullLogger<TrnLookupHelper>();
 
-        var helper = new TrnLookupHelper(dqtApiClientMock.Object, _configuration, logger);
+        var helper = new TrnLookupHelper(
+            dqtApiClientMock.Object,
+            _configuration,
+            logger,
+            new BlobServiceClient("DefaultEndpointsProtocol=https;AccountName=MyAccount;AccountKey=MyAccountKey;EndpointSuffix=core.windows.net"),
+            new TestClock());
 
         // Act
         var (trn, trnLookupStatus) = helper.ResolveTrn(trnLookupResults, authenticationState);
@@ -268,7 +304,12 @@ public class TrnLookupHelperTests
         var dqtApiClientMock = new Mock<IDqtApiClient>();
         var logger = new NullLogger<TrnLookupHelper>();
 
-        var helper = new TrnLookupHelper(dqtApiClientMock.Object, _configuration, logger);
+        var helper = new TrnLookupHelper(
+            dqtApiClientMock.Object,
+            _configuration,
+            logger,
+            new BlobServiceClient("DefaultEndpointsProtocol=https;AccountName=MyAccount;AccountKey=MyAccountKey;EndpointSuffix=core.windows.net"),
+            new TestClock());
 
         // Act
         var (trn, trnLookupStatus) = helper.ResolveTrn(trnLookupResults, authenticationState);
@@ -290,7 +331,12 @@ public class TrnLookupHelperTests
         var dqtApiClientMock = new Mock<IDqtApiClient>();
         var logger = new NullLogger<TrnLookupHelper>();
 
-        var helper = new TrnLookupHelper(dqtApiClientMock.Object, _configuration, logger);
+        var helper = new TrnLookupHelper(
+            dqtApiClientMock.Object,
+            _configuration,
+            logger,
+            new BlobServiceClient("DefaultEndpointsProtocol=https;AccountName=MyAccount;AccountKey=MyAccountKey;EndpointSuffix=core.windows.net"),
+            new TestClock());
 
         // Act
         var (trn, trnLookupStatus) = helper.ResolveTrn(trnLookupResults, authenticationState);
@@ -312,7 +358,12 @@ public class TrnLookupHelperTests
         var dqtApiClientMock = new Mock<IDqtApiClient>();
         var logger = new NullLogger<TrnLookupHelper>();
 
-        var helper = new TrnLookupHelper(dqtApiClientMock.Object, _configuration, logger);
+        var helper = new TrnLookupHelper(
+            dqtApiClientMock.Object,
+            _configuration,
+            logger,
+            new BlobServiceClient("DefaultEndpointsProtocol=https;AccountName=MyAccount;AccountKey=MyAccountKey;EndpointSuffix=core.windows.net"),
+            new TestClock());
 
         // Act
         var (trn, trnLookupStatus) = helper.ResolveTrn(trnLookupResults, authenticationState);
@@ -332,7 +383,12 @@ public class TrnLookupHelperTests
         var dqtApiClientMock = new Mock<IDqtApiClient>();
         var logger = new NullLogger<TrnLookupHelper>();
 
-        var helper = new TrnLookupHelper(dqtApiClientMock.Object, _configuration, logger);
+        var helper = new TrnLookupHelper(
+            dqtApiClientMock.Object,
+            _configuration,
+            logger,
+            new BlobServiceClient("DefaultEndpointsProtocol=https;AccountName=MyAccount;AccountKey=MyAccountKey;EndpointSuffix=core.windows.net"),
+            new TestClock());
 
         // Act
         var (trn, trnLookupStatus) = helper.ResolveTrn(trnLookupResults, authenticationState);


### PR DESCRIPTION
### Context

The existing background job which synchronises names from DQT records to identity has failed due to some DQT records not having what were thought were mandatory fields e.g. last name.

### Changes proposed in this pull request

Amend the DQT sync job to log any issues with DQT records and not try and update the identity user for these.

Also the identity sign-in process does a DQT sync so this needs to also also ignore DQT records without both first name / last name.

### Guidance to review

N/A

### Checklist

-   [ ] Attach to Trello card
-   [ ] Rebased master
-   [ ] Cleaned commit history
-   [ ] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
