### PR TITLE
added dob to user detail page

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/User.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/User.cshtml
@@ -62,6 +62,10 @@
                 </govuk-summary-list-row-actions>
             </govuk-summary-list-row>
             <govuk-summary-list-row>
+                <govuk-summary-list-row-key>Date of birth</govuk-summary-list-row-key>
+                <govuk-summary-list-row-value>@(Model.DateOfBirth.HasValue ? Model.DateOfBirth.Value.ToString("d MMMM yyyy") : "")</govuk-summary-list-row-value>
+            </govuk-summary-list-row>
+            <govuk-summary-list-row>
                 <govuk-summary-list-row-key>DQT record</govuk-summary-list-row-key>
                 <govuk-summary-list-row-value>@(Model.HaveDqtRecord ? "Yes" : "No")</govuk-summary-list-row-value>
                 @if (Model.CanChangeDqtRecord)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/User.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/User.cshtml.cs
@@ -40,6 +40,8 @@ public class UserModel : PageModel
 
     public DateOnly? DqtDateOfBirth { get; set; }
 
+    public DateOnly? DateOfBirth { get; set; }
+
     public string? DqtNationalInsuranceNumber { get; set; }
 
     public string? Trn { get; set; }
@@ -93,6 +95,7 @@ public class UserModel : PageModel
         HaveDqtRecord = user.Trn is not null;
         CanChangeDqtRecord = !HaveDqtRecord;
         MergedUserIds = user.MergedUserIds;
+        DateOfBirth = user.DateOfBirth;
 
         if (user.Trn is not null)
         {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/UserTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/UserTests.cs
@@ -58,6 +58,7 @@ public class UserTests : TestBase
         // Arrange
         var user = await TestData.CreateUser(hasTrn: false, userType: Models.UserType.Default, hasPreferredName: true);
         var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/users/{user.UserId}");
+        var formattedDateOfBirth = user.DateOfBirth?.ToString("d MMMM yyyy");
 
         // Act
         var response = await HttpClient.SendAsync(request);
@@ -69,6 +70,7 @@ public class UserTests : TestBase
         Assert.Equal($"{user.FirstName} {user.MiddleName} {user.LastName}", doc.GetElementByTestId("Name")?.TextContent);
         Assert.Equal($"{user.PreferredName}", doc.GetSummaryListValueForKey("Preferred name"));
         Assert.Equal(user.EmailAddress, doc.GetSummaryListValueForKey("Email address"));
+        Assert.Equal(formattedDateOfBirth, doc.GetSummaryListValueForKey("Date of birth"));
         Assert.Equal("No", doc.GetSummaryListValueForKey("DQT record"));
         Assert.Equal("None", doc.GetSummaryListValueForKey("Merged user IDs"));
         Assert.NotEmpty(doc.GetSummaryListActionsForKey("DQT record"));
@@ -112,7 +114,7 @@ public class UserTests : TestBase
         Assert.Empty(doc.GetSummaryListActionsForKey("DQT record"));
         Assert.NotNull(doc.GetElementByTestId("DqtSection"));
         Assert.Equal($"{dqtFirstName} {dqtLastName}", doc.GetSummaryListValueForKey("DQT name"));
-        Assert.Equal(dqtDateOfBirth.ToString("d MMMM yyyy"), doc.GetSummaryListValueForKey("Date of birth"));
+        Assert.Equal(dqtDateOfBirth.ToString("d MMMM yyyy"), doc.GetElementByTestId("DqtSection")?.GetSummaryListValueForKey("Date of birth"));
         Assert.Equal("Provided", doc.GetSummaryListValueForKey("National insurance number"));
         Assert.Equal(user.Trn, doc.GetSummaryListValueForKey("TRN"));
     }


### PR DESCRIPTION
### Context

A support agent cannot currently see the ID DOB assigned to a user.

### Changes proposed in this pull request

- added changes to include DOB on user detail page
- amended test to match the new changes

### Guidance to review

`doc.GetElementByTestId("DqtSection")` has been used in one of the test because there are multiple ui rows for DOB

### Checklist

-   [#895]
