### PR TITLE
Removed DqtSynchronizationEnabled feature flag

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -626,7 +626,7 @@ public class AuthenticationState
         return NameHelper.GetFullName(FirstName, includeMiddleName ? MiddleName : null, LastName);
     }
 
-    public void OnTrnLookupCompleted(FindTeachersResponseResult? findTeachersResult, TrnLookupStatus trnLookupStatus, bool dqtSynchronizationEnabled = false)
+    public void OnTrnLookupCompleted(FindTeachersResponseResult? findTeachersResult, TrnLookupStatus trnLookupStatus)
     {
         var trn = findTeachersResult?.Trn;
 
@@ -643,7 +643,7 @@ public class AuthenticationState
         Trn = trn;
         TrnLookupStatus = trnLookupStatus;
 
-        if (dqtSynchronizationEnabled && findTeachersResult is not null && !string.IsNullOrEmpty(findTeachersResult.FirstName) && !string.IsNullOrEmpty(findTeachersResult.LastName))
+        if (findTeachersResult is not null && !string.IsNullOrEmpty(findTeachersResult.FirstName) && !string.IsNullOrEmpty(findTeachersResult.LastName))
         {
             DqtFirstName = findTeachersResult.FirstName;
             DqtMiddleName = findTeachersResult.MiddleName;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnLookupHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnLookupHelper.cs
@@ -15,11 +15,9 @@ public class TrnLookupHelper
     private readonly ILogger<TrnLookupHelper> _logger;
     private readonly BlobServiceClient _blobServiceClient;
     private readonly IClock _clock;
-    private readonly bool _dqtSynchronizationEnabled;
 
     public TrnLookupHelper(
         IDqtApiClient dqtApiClient,
-        IConfiguration configuration,
         ILogger<TrnLookupHelper> logger,
         BlobServiceClient blobServiceClient,
         IClock clock)
@@ -28,7 +26,6 @@ public class TrnLookupHelper
         _logger = logger;
         _blobServiceClient = blobServiceClient;
         _clock = clock;
-        _dqtSynchronizationEnabled = configuration.GetValue("DqtSynchronizationEnabled", false);
     }
 
     public async Task<string?> LookupTrn(AuthenticationState authenticationState)
@@ -75,7 +72,7 @@ public class TrnLookupHelper
                 await CheckDqtTeacherNames(findTeachersResult);
             }
 
-            authenticationState.OnTrnLookupCompleted(findTeachersResult, trnLookupStatus, _dqtSynchronizationEnabled);
+            authenticationState.OnTrnLookupCompleted(findTeachersResult, trnLookupStatus);
         }
 
         return findTeachersResult?.Trn;

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenHelper.cs
@@ -148,19 +148,16 @@ public class TrnTokenHelper
     {
         var changes = UserUpdatedEventChanges.None;
 
-        if (_configuration.GetValue("DqtSynchronizationEnabled", false))
+        var dqtUser = await _dqtApiClient.GetTeacherByTrn(trn);
+        if (dqtUser is not null && await CheckDqtTeacherNames(dqtUser))
         {
-            var dqtUser = await _dqtApiClient.GetTeacherByTrn(trn);
-            if (dqtUser is not null && await CheckDqtTeacherNames(dqtUser))
-            {
-                changes |= (user.FirstName != dqtUser.FirstName ? UserUpdatedEventChanges.FirstName : UserUpdatedEventChanges.None) |
-                           (user.MiddleName != dqtUser.MiddleName ? UserUpdatedEventChanges.MiddleName : UserUpdatedEventChanges.None) |
-                           (user.LastName != dqtUser.LastName ? UserUpdatedEventChanges.LastName : UserUpdatedEventChanges.None);
+            changes |= (user.FirstName != dqtUser.FirstName ? UserUpdatedEventChanges.FirstName : UserUpdatedEventChanges.None) |
+                       ((user.MiddleName ?? string.Empty) != dqtUser.MiddleName ? UserUpdatedEventChanges.MiddleName : UserUpdatedEventChanges.None) |
+                       (user.LastName != dqtUser.LastName ? UserUpdatedEventChanges.LastName : UserUpdatedEventChanges.None);
 
-                user.FirstName = dqtUser.FirstName;
-                user.MiddleName = dqtUser.MiddleName;
-                user.LastName = dqtUser.LastName;
-            }
+            user.FirstName = dqtUser.FirstName;
+            user.MiddleName = dqtUser.MiddleName;
+            user.LastName = dqtUser.LastName;
         }
 
         if (user.Trn is null)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/CheckNameChangeIsEnabledAttribute.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/Name/CheckNameChangeIsEnabledAttribute.cs
@@ -29,19 +29,11 @@ public class CheckNameChangeIsEnabledAttribute : Attribute, IAsyncPageFilter, IO
     private async Task<bool> NameChangeEnabled(HttpContext httpContext)
     {
         var configuration = httpContext.RequestServices.GetRequiredService<IConfiguration>();
-        var dqtSynchronizationEnabled = configuration.GetValue("DqtSynchronizationEnabled", false);
-        if (dqtSynchronizationEnabled)
-        {
-            var dbContext = httpContext.RequestServices.GetRequiredService<TeacherIdentityServerDbContext>();
-            var user = await dbContext.Users
-                .Where(u => u.UserId == httpContext.User.GetUserId())
-                .SingleAsync();
+        var dbContext = httpContext.RequestServices.GetRequiredService<TeacherIdentityServerDbContext>();
+        var user = await dbContext.Users
+            .Where(u => u.UserId == httpContext.User.GetUserId())
+            .SingleAsync();
 
-            return user.Trn is null;
-        }
-        else
-        {
-            return true;
-        }
+        return user.Trn is null;
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/AssignTrn/Confirm.cshtml.cs
@@ -17,18 +17,15 @@ public class ConfirmModel : PageModel
     private readonly TeacherIdentityServerDbContext _dbContext;
     private readonly IDqtApiClient _dqtApiClient;
     private readonly IClock _clock;
-    private readonly bool _dqtSynchronizationEnabled;
 
     public ConfirmModel(
         TeacherIdentityServerDbContext dbContext,
         IDqtApiClient dqtApiClient,
-        IConfiguration configuration,
         IClock clock)
     {
         _dbContext = dbContext;
         _dqtApiClient = dqtApiClient;
         _clock = clock;
-        _dqtSynchronizationEnabled = configuration.GetValue("DqtSynchronizationEnabled", false);
     }
 
     [FromRoute]
@@ -100,15 +97,12 @@ public class ConfirmModel : PageModel
             changes = changes | Events.UserUpdatedEventChanges.Trn;
             user.TrnLookupStatus = TrnLookupStatus.Found;
 
-            if (_dqtSynchronizationEnabled)
-            {
-                changes |= (user.FirstName != DqtFirstName ? Events.UserUpdatedEventChanges.FirstName : Events.UserUpdatedEventChanges.None) |
+            changes |= (user.FirstName != DqtFirstName ? Events.UserUpdatedEventChanges.FirstName : Events.UserUpdatedEventChanges.None) |
                            ((user.MiddleName ?? string.Empty) != (DqtMiddleName ?? string.Empty) ? Events.UserUpdatedEventChanges.MiddleName : Events.UserUpdatedEventChanges.None) |
                            (user.LastName != DqtLastName ? Events.UserUpdatedEventChanges.LastName : Events.UserUpdatedEventChanges.None);
-                user.FirstName = DqtFirstName!;
-                user.MiddleName = DqtMiddleName;
-                user.LastName = DqtLastName!;
-            }
+            user.FirstName = DqtFirstName!;
+            user.MiddleName = DqtMiddleName;
+            user.LastName = DqtLastName!;
         }
         else
         {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Production.json
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Production.json
@@ -39,6 +39,5 @@
   "WebHooks": {
     "WebHooksCacheDurationSeconds": 120
   },
-  "RegisterWithTrnTokenEnabled": false,
-  "DqtSynchronizationEnabled":  true
+  "RegisterWithTrnTokenEnabled": false
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.json
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.json
@@ -30,7 +30,6 @@
     "RefreshEstablishmentDomainsJobSchedule": "0 2 * * *"
   },
   "RegisterWithTrnTokenEnabled": true,
-  "DqtSynchronizationEnabled": true,
   "BlockEstablishmentEmailDomains": false,
   "SupportEmail": "qts.enquiries@education.gov.uk",
   "TrnTokens": {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Register.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Register.cs
@@ -243,7 +243,7 @@ public class Register : IClassFixture<HostFixture>
     }
 
     [Fact]
-    public async Task NewUser_WithTrnLookup_TrnFoundDifferentNameAndDqtSynchronizationEnabled_UpdatesNameAndCanRegister()
+    public async Task NewUser_WithTrnLookup_TrnFoundDifferentName_UpdatesNameAndCanRegister()
     {
         var email = Faker.Internet.Email();
         var mobileNumber = _hostFixture.TestData.GenerateUniqueMobileNumber();
@@ -255,8 +255,6 @@ public class Register : IClassFixture<HostFixture>
         var dqtFirstName = Faker.Name.First();
         var dqtMiddleName = Faker.Name.Middle();
         var dqtLastName = Faker.Name.Last();
-
-        _hostFixture.Configuration["DqtSynchronizationEnabled"] = "true";
 
         ConfigureDqtApiFindTeachersRequest(result: new()
         {
@@ -310,85 +308,6 @@ public class Register : IClassFixture<HostFixture>
                 Assert.Equal(dqtFirstName, userRegisteredEvent.User.FirstName);
                 Assert.Equal(dqtMiddleName, userRegisteredEvent.User.MiddleName);
                 Assert.Equal(dqtLastName, userRegisteredEvent.User.LastName);
-                Assert.Equal(dateOfBirth, userRegisteredEvent.User.DateOfBirth);
-
-                createdUserId = userRegisteredEvent.User.UserId;
-            },
-            e =>
-            {
-                var userSignedInEvent = Assert.IsType<UserSignedInEvent>(e);
-                Assert.Equal(createdUserId, userSignedInEvent.User.UserId);
-            });
-
-        // Reset config
-        _hostFixture.Configuration["DqtSynchronizationEnabled"] = "false";
-    }
-
-    [Fact]
-    public async Task NewUser_WithTrnLookup_TrnFoundDifferentNameAndDqtSynchronizationNotEnabled_CanRegister()
-    {
-        var email = Faker.Internet.Email();
-        var mobileNumber = _hostFixture.TestData.GenerateUniqueMobileNumber();
-        var firstName = Faker.Name.First();
-        var lastName = Faker.Name.Last();
-        var dateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth());
-        var trn = _hostFixture.TestData.GenerateTrn();
-
-        var dqtFirstName = Faker.Name.First();
-        var dqtMiddleName = Faker.Name.Middle();
-        var dqtLastName = Faker.Name.Last();
-
-        ConfigureDqtApiFindTeachersRequest(result: new()
-        {
-            DateOfBirth = dateOfBirth,
-            FirstName = dqtFirstName,
-            MiddleName = dqtMiddleName,
-            LastName = dqtLastName,
-            EmailAddresses = new[] { email },
-            HasActiveSanctions = false,
-            NationalInsuranceNumber = null,
-            Trn = trn,
-            Uid = Guid.NewGuid().ToString()
-        });
-
-        await using var context = await _hostFixture.CreateBrowserContext();
-        var page = await context.NewPageAsync();
-
-        await page.StartOAuthJourney(CustomScopes.DqtRead, TrnRequirementType.Required);
-
-        await page.RegisterFromLandingPage();
-
-        await page.SubmitRegisterEmailPage(email);
-
-        await page.SubmitRegisterEmailConfirmationPage();
-
-        await page.SubmitRegisterPhonePage(mobileNumber);
-
-        await page.SubmitRegisterPhoneConfirmationPage();
-
-        await page.SubmitRegisterNamePage(firstName, lastName);
-
-        await page.SubmitRegisterPreferredNamePage();
-
-        await page.SubmitDateOfBirthPage(dateOfBirth);
-
-        await page.SubmitCheckAnswersPage();
-
-        await page.SubmitCompletePageForNewUser();
-
-        await page.AssertSignedInOnTestClient(email, trn, firstName, lastName);
-
-        Guid createdUserId = default;
-
-        _hostFixture.EventObserver.AssertEventsSaved(
-            e =>
-            {
-                var userRegisteredEvent = Assert.IsType<UserRegisteredEvent>(e);
-                Assert.Equal(_hostFixture.TestClientId, userRegisteredEvent.ClientId);
-                Assert.Equal(email, userRegisteredEvent.User.EmailAddress);
-                Assert.Equal(mobileNumber, userRegisteredEvent.User.MobileNumber);
-                Assert.Equal(firstName, userRegisteredEvent.User.FirstName);
-                Assert.Equal(lastName, userRegisteredEvent.User.LastName);
                 Assert.Equal(dateOfBirth, userRegisteredEvent.User.DateOfBirth);
 
                 createdUserId = userRegisteredEvent.User.UserId;

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/TrnTokenSignInJourney.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/TrnTokenSignInJourney.cs
@@ -341,7 +341,7 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
     }
 
     [Fact]
-    public async Task ExistingUserNoTrn_ValidTrnTokenMatchingEmailNotMatchingNameAndDqtSynchronizationEnabled_SignsInUserUpdatesTrnAndNameInvalidatesToken()
+    public async Task ExistingUserNoTrn_ValidTrnTokenMatchingEmailNotMatchingName_SignsInUserUpdatesTrnAndNameInvalidatesToken()
     {
         await using var context = await _hostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();
@@ -350,8 +350,6 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
 
         var dqtFirstName = Faker.Name.First();
         var dqtLastName = Faker.Name.Last();
-
-        _hostFixture.Configuration["DqtSynchronizationEnabled"] = "true";
 
         var trnToken = await CreateValidTrnToken(email: user.EmailAddress, firstName: dqtFirstName, lastName: dqtLastName);
 
@@ -373,47 +371,6 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
                 Assert.Equal(user.UserId, userUpdatedEvent.User.UserId);
             },
             e => Assert.IsType<UserSignedInEvent>(e));
-
-        // Reset config
-        _hostFixture.Configuration["DqtSynchronizationEnabled"] = "false";
-    }
-
-    [Fact]
-    public async Task ExistingUserNoTrn_ValidTrnTokenMatchingEmailNotMatchingNameAndDqtSynchronizationNotEnabled_SignsInUserUpdatesTrnInvalidatesToken()
-    {
-        await using var context = await _hostFixture.CreateBrowserContext();
-        var page = await context.NewPageAsync();
-
-        var user = await _hostFixture.TestData.CreateUser(userType: UserType.Default);
-
-        var dqtFirstName = Faker.Name.First();
-        var dqtLastName = Faker.Name.Last();
-
-        _hostFixture.Configuration["DqtSynchronizationEnabled"] = "false";
-
-        var trnToken = await CreateValidTrnToken(email: user.EmailAddress, firstName: dqtFirstName, lastName: dqtLastName);
-
-        await page.StartOAuthJourney(CustomScopes.DqtRead, trnToken: trnToken.TrnToken);
-
-        await page.SubmitCompletePageForExistingUser();
-
-        await page.AssertSignedInOnTestClient(user.EmailAddress, trnToken.Trn, user.FirstName, user.LastName);
-
-        var trnTokenModel = await _hostFixture.TestData.GetTrnToken(trnToken.TrnToken);
-        Assert.Equal(user.UserId, trnTokenModel?.UserId);
-
-        _hostFixture.EventObserver.AssertEventsSaved(
-            e =>
-            {
-                var userUpdatedEvent = Assert.IsType<UserUpdatedEvent>(e);
-                Assert.Equal(UserUpdatedEventChanges.Trn | UserUpdatedEventChanges.TrnLookupStatus, userUpdatedEvent.Changes);
-                Assert.Equal(trnTokenModel?.Trn, userUpdatedEvent.User.Trn);
-                Assert.Equal(user.UserId, userUpdatedEvent.User.UserId);
-            },
-            e => Assert.IsType<UserSignedInEvent>(e));
-
-        // Reset config
-        _hostFixture.Configuration["DqtSynchronizationEnabled"] = "true";
     }
 
     [Fact]
@@ -494,7 +451,7 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
     }
 
     [Fact]
-    public async Task ExistingUserSignsInNoTrn_ValidTrnTokenDifferentNameAndDqtSynchronizationEnabled_AssignsTokenUpdatesName()
+    public async Task ExistingUserSignsInNoTrn_ValidTrnTokenDifferentName_AssignsTokenUpdatesName()
     {
         await using var context = await _hostFixture.CreateBrowserContext();
         var page = await context.NewPageAsync();
@@ -504,8 +461,6 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
 
         var dqtFirstName = Faker.Name.First();
         var dqtLastName = Faker.Name.Last();
-
-        _hostFixture.Configuration["DqtSynchronizationEnabled"] = "true";
 
         var trnToken = await CreateValidTrnToken(email: differentEmail, firstName: dqtFirstName, lastName: dqtLastName);
 
@@ -533,54 +488,6 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
                 Assert.Equal(user.UserId, userUpdatedEvent.User.UserId);
             },
             e => Assert.IsType<UserSignedInEvent>(e));
-
-        // Reset config
-        _hostFixture.Configuration["DqtSynchronizationEnabled"] = "false";
-    }
-
-    [Fact]
-    public async Task ExistingUserSignsInNoTrn_ValidTrnTokenDifferentNameAndDqtSynchronizationNotEnabled_AssignsToken()
-    {
-        await using var context = await _hostFixture.CreateBrowserContext();
-        var page = await context.NewPageAsync();
-
-        var user = await _hostFixture.TestData.CreateUser(userType: UserType.Default);
-        var differentEmail = _hostFixture.TestData.GenerateUniqueEmail();
-
-        var dqtFirstName = Faker.Name.First();
-        var dqtLastName = Faker.Name.Last();
-
-        _hostFixture.Configuration["DqtSynchronizationEnabled"] = "false";
-
-        var trnToken = await CreateValidTrnToken(email: differentEmail, firstName: dqtFirstName, lastName: dqtLastName);
-
-        await page.StartOAuthJourney(CustomScopes.DqtRead, trnToken: trnToken.TrnToken);
-
-        await page.SignInFromTrnTokenLandingPage();
-
-        await page.SubmitEmailPage(user.EmailAddress);
-
-        await page.SubmitEmailConfirmationPage();
-
-        await page.SubmitCompletePageForExistingUser();
-
-        await page.AssertSignedInOnTestClient(user.EmailAddress, trnToken.Trn, user.FirstName, user.LastName);
-
-        var trnTokenModel = await _hostFixture.TestData.GetTrnToken(trnToken.TrnToken);
-        Assert.Equal(user.UserId, trnTokenModel?.UserId);
-
-        _hostFixture.EventObserver.AssertEventsSaved(
-            e =>
-            {
-                var userUpdatedEvent = Assert.IsType<UserUpdatedEvent>(e);
-                Assert.Equal(UserUpdatedEventChanges.Trn | UserUpdatedEventChanges.TrnLookupStatus, userUpdatedEvent.Changes);
-                Assert.Equal(trnTokenModel?.Trn, userUpdatedEvent.User.Trn);
-                Assert.Equal(user.UserId, userUpdatedEvent.User.UserId);
-            },
-            e => Assert.IsType<UserSignedInEvent>(e));
-
-        // Reset config
-        _hostFixture.Configuration["DqtSynchronizationEnabled"] = "true";
     }
 
     [Fact]

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/appsettings.json
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/appsettings.json
@@ -11,8 +11,7 @@
     "UserVerification": {
       "UseFixedPin": true
     },
-    "BlockEstablishmentEmailDomains": true,
-    "DqtSynchronizationEnabled": true
+    "BlockEstablishmentEmailDomains": true
   },
   "TestClient": {
     "ClientId": "testclient",

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Name/ConfirmTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Name/ConfirmTests.cs
@@ -21,7 +21,6 @@ public class ConfirmTests : TestBase
         var middleName = Faker.Name.Middle();
         var lastName = Faker.Name.Last();
 
-        HostFixture.Configuration["DqtSynchronizationEnabled"] = "true";
         HostFixture.SetUserId(TestUsers.DefaultUserWithTrn.UserId);
 
         var request = new HttpRequestMessage(
@@ -33,9 +32,6 @@ public class ConfirmTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
-
-        // Reset config
-        HostFixture.Configuration["DqtSynchronizationEnabled"] = "false";
     }
 
     [Fact]

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Name/NameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/Name/NameTests.cs
@@ -11,7 +11,6 @@ public class NameTests : TestBase
     public async Task Get_NameChangeDisabled_ReturnsBadRequest()
     {
         // Arrange
-        HostFixture.Configuration["DqtSynchronizationEnabled"] = "true";
         HostFixture.SetUserId(TestUsers.DefaultUserWithTrn.UserId);
 
         var request = new HttpRequestMessage(
@@ -23,9 +22,6 @@ public class NameTests : TestBase
 
         // Assert
         Assert.Equal(StatusCodes.Status400BadRequest, (int)response.StatusCode);
-
-        // Reset config
-        HostFixture.Configuration["DqtSynchronizationEnabled"] = "false";
     }
 
     [Fact]

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
@@ -461,7 +461,7 @@ public class EmailConfirmationTests : TestBase
     }
 
     [Fact]
-    public async Task Post_ValidPinForKnownUserWithTrnAndDifferentDqtNameAndDqtSynchronizationEnabled_UpdatesUserSignsInAndRedirects()
+    public async Task Post_ValidPinForKnownUserWithTrnAndDifferentDqtName_UpdatesUserSignsInAndRedirects()
     {
         // Arrange
         var user = await TestData.CreateUser(hasTrn: true);
@@ -487,7 +487,6 @@ public class EmailConfirmationTests : TestBase
                 PendingNameChange = false
             });
 
-        HostFixture.Configuration["DqtSynchronizationEnabled"] = "true";
         var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(user.EmailAddress), additionalScopes: null);
         var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
         {
@@ -524,62 +523,5 @@ public class EmailConfirmationTests : TestBase
                 Assert.Equal(dqtMiddleName, userUpdatedEvent.User.MiddleName);
                 Assert.Equal(dqtLastName, userUpdatedEvent.User.LastName);
             });
-
-        // Reset config
-        HostFixture.Configuration["DqtSynchronizationEnabled"] = "false";
-    }
-
-    [Fact]
-    public async Task Post_ValidPinForKnownUserWithTrnAndDifferentDqtNameAndDqtSynchronizationNotEnabled_SignsInAndRedirects()
-    {
-        // Arrange
-        var user = await TestData.CreateUser(hasTrn: true);
-
-        var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
-        var pinResult = await userVerificationService.GenerateEmailPin(user.EmailAddress);
-
-        var dqtFirstName = Faker.Name.First();
-        var dqtMiddleName = Faker.Name.Middle();
-        var dqtLastName = Faker.Name.Last();
-
-        HostFixture.DqtApiClient.Setup(mock => mock.GetTeacherByTrn(user.Trn!, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new AuthServer.Services.DqtApi.TeacherInfo()
-            {
-                DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
-                Email = Faker.Internet.Email(),
-                FirstName = dqtFirstName,
-                MiddleName = dqtMiddleName,
-                LastName = dqtLastName,
-                NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber(),
-                Trn = user.Trn!,
-                PendingDateOfBirthChange = false,
-                PendingNameChange = false
-            });
-
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(user.EmailAddress), additionalScopes: null);
-        var request = new HttpRequestMessage(HttpMethod.Post, $"/sign-in/email-confirmation?{authStateHelper.ToQueryParam()}")
-        {
-            Content = new FormUrlEncodedContentBuilder()
-            {
-                { "Code", pinResult.Pin! }
-            }
-        };
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        Assert.Equal(StatusCodes.Status302Found, (int)response.StatusCode);
-        Assert.Equal(authStateHelper.AuthenticationState.PostSignInUrl, response.Headers.Location?.OriginalString);
-
-        Assert.True(authStateHelper.AuthenticationState.EmailAddressVerified);
-        Assert.NotNull(authStateHelper.AuthenticationState.UserId);
-        Assert.False(authStateHelper.AuthenticationState.FirstTimeSignInForEmail);
-        Assert.Equal(user.Trn, authStateHelper.AuthenticationState.Trn);
-        Assert.Equal(user.FirstName, authStateHelper.AuthenticationState.FirstName);
-        Assert.Equal(user.MiddleName, authStateHelper.AuthenticationState.MiddleName);
-        Assert.Equal(user.LastName, authStateHelper.AuthenticationState.LastName);
-
-        EventObserver.AssertEventsSaved();
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/JourneyTests/TrnLookupHelperTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/JourneyTests/TrnLookupHelperTests.cs
@@ -33,7 +33,6 @@ public class TrnLookupHelperTests
 
         var helper = new TrnLookupHelper(
             dqtApiClientMock.Object,
-            _configuration,
             logger,
             new BlobServiceClient("DefaultEndpointsProtocol=https;AccountName=MyAccount;AccountKey=MyAccountKey;EndpointSuffix=core.windows.net"),
             new TestClock());
@@ -69,7 +68,6 @@ public class TrnLookupHelperTests
 
         var helper = new TrnLookupHelper(
             dqtApiClientMock.Object,
-            _configuration,
             logger,
             new BlobServiceClient("DefaultEndpointsProtocol=https;AccountName=MyAccount;AccountKey=MyAccountKey;EndpointSuffix=core.windows.net"),
             new TestClock());
@@ -131,7 +129,6 @@ public class TrnLookupHelperTests
 
         var helper = new TrnLookupHelper(
             dqtApiClientMock.Object,
-            _configuration,
             logger,
             new BlobServiceClient("DefaultEndpointsProtocol=https;AccountName=MyAccount;AccountKey=MyAccountKey;EndpointSuffix=core.windows.net"),
             new TestClock());
@@ -181,7 +178,6 @@ public class TrnLookupHelperTests
 
         var helper = new TrnLookupHelper(
             dqtApiClientMock.Object,
-            _configuration,
             logger,
             new BlobServiceClient("DefaultEndpointsProtocol=https;AccountName=MyAccount;AccountKey=MyAccountKey;EndpointSuffix=core.windows.net"),
             new TestClock());
@@ -214,7 +210,6 @@ public class TrnLookupHelperTests
 
         var helper = new TrnLookupHelper(
             dqtApiClientMock.Object,
-            _configuration,
             logger,
             new BlobServiceClient("DefaultEndpointsProtocol=https;AccountName=MyAccount;AccountKey=MyAccountKey;EndpointSuffix=core.windows.net"),
             new TestClock());
@@ -246,7 +241,6 @@ public class TrnLookupHelperTests
 
         var helper = new TrnLookupHelper(
             dqtApiClientMock.Object,
-            _configuration,
             logger,
             new BlobServiceClient("DefaultEndpointsProtocol=https;AccountName=MyAccount;AccountKey=MyAccountKey;EndpointSuffix=core.windows.net"),
             new TestClock());
@@ -277,7 +271,6 @@ public class TrnLookupHelperTests
 
         var helper = new TrnLookupHelper(
             dqtApiClientMock.Object,
-            _configuration,
             logger,
             new BlobServiceClient("DefaultEndpointsProtocol=https;AccountName=MyAccount;AccountKey=MyAccountKey;EndpointSuffix=core.windows.net"),
             new TestClock());
@@ -306,7 +299,6 @@ public class TrnLookupHelperTests
 
         var helper = new TrnLookupHelper(
             dqtApiClientMock.Object,
-            _configuration,
             logger,
             new BlobServiceClient("DefaultEndpointsProtocol=https;AccountName=MyAccount;AccountKey=MyAccountKey;EndpointSuffix=core.windows.net"),
             new TestClock());
@@ -333,7 +325,6 @@ public class TrnLookupHelperTests
 
         var helper = new TrnLookupHelper(
             dqtApiClientMock.Object,
-            _configuration,
             logger,
             new BlobServiceClient("DefaultEndpointsProtocol=https;AccountName=MyAccount;AccountKey=MyAccountKey;EndpointSuffix=core.windows.net"),
             new TestClock());
@@ -360,7 +351,6 @@ public class TrnLookupHelperTests
 
         var helper = new TrnLookupHelper(
             dqtApiClientMock.Object,
-            _configuration,
             logger,
             new BlobServiceClient("DefaultEndpointsProtocol=https;AccountName=MyAccount;AccountKey=MyAccountKey;EndpointSuffix=core.windows.net"),
             new TestClock());
@@ -385,7 +375,6 @@ public class TrnLookupHelperTests
 
         var helper = new TrnLookupHelper(
             dqtApiClientMock.Object,
-            _configuration,
             logger,
             new BlobServiceClient("DefaultEndpointsProtocol=https;AccountName=MyAccount;AccountKey=MyAccountKey;EndpointSuffix=core.windows.net"),
             new TestClock());

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/appsettings.json
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/appsettings.json
@@ -8,7 +8,6 @@
   "BaseAddress": "http://localhost",
   "QueryStringSignatureKey": "qskey",
   "BlockEstablishmentEmailDomains": true,
-  "DqtSynchronizationEnabled": true,
   "WebHooks": {
     "WebHooksCacheDurationSeconds": 30
   }


### PR DESCRIPTION
### Context

Once we’ve enable DQT name synchronisation and it’s proved to be working correctly in production we should remove the feature flag to simplify our code.

### Changes proposed in this pull request

Once Enable DQT name synchronisation has been done in production and it has been running for 2 days without any issues then remove the feature flag so that DQT name synchronisation is on permanently.

### Guidance to review

Removing use of feature flag in code & tests.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [ ] Cleaned commit history
-   [x] Tested by running locally
-   [ ] Reminder created to manually clean any removed app settings post deployment
