### PR TITLE
Obfuscate new client secret before storing

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Oidc/TeacherIdentityApplicationManager.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Oidc/TeacherIdentityApplicationManager.cs
@@ -123,6 +123,9 @@ public partial class TeacherIdentityApplicationManager : OpenIddictApplicationMa
         return false;
     }
 
+    public new ValueTask<string> ObfuscateClientSecretAsync(string secret, CancellationToken cancellationToken = default) =>
+        base.ObfuscateClientSecretAsync(secret, cancellationToken);
+
     [GeneratedRegex("\\/__\\.")]
     private static partial Regex WildcardPathSegmentPattern();
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditClient.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/EditClient.cshtml.cs
@@ -17,11 +17,16 @@ namespace TeacherIdentity.AuthServer.Pages.Admin;
 public class EditClientModel : PageModel
 {
     private readonly TeacherIdentityApplicationStore _applicationStore;
+    private readonly TeacherIdentityApplicationManager _applicationManager;
     private readonly IClock _clock;
 
-    public EditClientModel(TeacherIdentityApplicationStore applicationStore, IClock clock)
+    public EditClientModel(
+        TeacherIdentityApplicationStore applicationStore,
+        TeacherIdentityApplicationManager applicationManager,
+        IClock clock)
     {
         _applicationStore = applicationStore;
+        _applicationManager = applicationManager;
         _clock = clock;
     }
 
@@ -183,7 +188,8 @@ public class EditClientModel : PageModel
 
         if (!string.IsNullOrEmpty(ClientSecret))
         {
-            await _applicationStore.SetClientSecretAsync(client, ClientSecret, CancellationToken.None);
+            var obfuscatedSecret = await _applicationManager.ObfuscateClientSecretAsync(ClientSecret, CancellationToken.None);
+            await _applicationStore.SetClientSecretAsync(client, obfuscatedSecret, CancellationToken.None);
         }
 
         if (changes != ClientUpdatedEventChanges.None)


### PR DESCRIPTION
Our Edit Client page was storing client secrets in plaintext but everywhere else expects them to be hashed.