### PR TITLE
Add content to landing page when we require TRN and NINO to match

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Landing.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Landing.cshtml
@@ -1,4 +1,5 @@
 @page "/sign-in/landing"
+@model TeacherIdentity.AuthServer.Pages.SignIn.Landing
 @{
     ViewBag.Title = "Create a DfE Identity account";
 }
@@ -11,10 +12,23 @@
             <ul class="govuk-list govuk-list--bullet">
                 <li>email address (used for contact and account security)</li>
                 <li>mobile phone number (used for account security)</li>
-                <li>name and date of birth</li>
+                <li>name</li>
+                <li>date of birth</li>
             </ul>
 
-            <vc:client-scoped-partial view-name="_SignIn.Landing.{0}.Content" />
+            @if (Model.ClientDisplayName is not null)
+            {
+                @if (Model.TrnMatchPolicy == TrnMatchPolicy.Strict)
+                {
+                    <p>To use your DfE Identity account to @Model.ClientDisplayName, you’ll also need your:</p>
+                    <ul class="govuk-list govuk-list--bullet">
+                        <li>National Insurance number</li>
+                        <li>teacher reference number (TRN)</li>
+                    </ul>
+                }
+
+                <p>Once you’ve created an account, you can continue to <strong>@Model.ClientDisplayName</strong>.</p>
+            }
 
             <govuk-details>
                 <govuk-details-summary>About DfE Identity accounts</govuk-details-summary>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Landing.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Landing.cshtml.cs
@@ -1,0 +1,37 @@
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeacherIdentity.AuthServer.Journeys;
+using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Oidc;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn;
+
+[CheckCanAccessStep(CurrentStep)]
+public class Landing : PageModel
+{
+    private const string CurrentStep = CoreSignInJourney.Steps.Landing;
+
+    private readonly SignInJourney _journey;
+    private readonly ICurrentClientProvider _currentClientProvider;
+
+    public Landing(
+        SignInJourney journey,
+        ICurrentClientProvider currentClientProvider)
+    {
+        _journey = journey;
+        _currentClientProvider = currentClientProvider;
+    }
+
+    public string? ClientDisplayName { get; set; }
+
+    public TrnMatchPolicy? TrnMatchPolicy { get; set; }
+
+    public async override Task OnPageHandlerExecutionAsync(PageHandlerExecutingContext context, PageHandlerExecutionDelegate next)
+    {
+        ClientDisplayName = (await _currentClientProvider.GetCurrentClient())?.DisplayName;
+
+        TrnMatchPolicy = _journey.AuthenticationState.OAuthState?.TrnMatchPolicy;
+
+        await base.OnPageHandlerExecutionAsync(context, next);
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/Landing.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/TrnToken/Landing.cshtml
@@ -1,6 +1,5 @@
 @page "/sign-in/trn-token"
 @model TeacherIdentity.AuthServer.Pages.SignIn.TrnToken.Landing
-
 @{
     ViewBag.Title = "Create a DfE Identity account";
 }
@@ -14,10 +13,23 @@
                 <ul class="govuk-list govuk-list--bullet">
                     <li>email address (used for contact and account security)</li>
                     <li>mobile phone number (used for account security)</li>
-                    <li>name and date of birth</li>
+                    <li>name</li>
+                    <li>date of birth</li>
                 </ul>
 
-                <p>Once you’ve created an account, you can continue to <strong>@Model.ClientDisplayName</strong>.</p>
+                @if (Model.ClientDisplayName is not null)
+                {
+                    @if (Model.TrnMatchPolicy == TrnMatchPolicy.Strict)
+                    {
+                        <p>To use your DfE Identity account to @Model.ClientDisplayName, you’ll also need your:</p>
+                        <ul class="govuk-list govuk-list--bullet">
+                            <li>National Insurance number</li>
+                            <li>teacher reference number (TRN)</li>
+                        </ul>
+                    }
+
+                    <p>Once you’ve created an account, you can continue to <strong>@Model.ClientDisplayName</strong>.</p>
+                }
 
                 <govuk-details>
                     <govuk-details-summary>About DfE Identity accounts</govuk-details-summary>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/_SignIn.Landing.ApplyForQTS.Content.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/_SignIn.Landing.ApplyForQTS.Content.cshtml
@@ -1,1 +1,0 @@
-<p>Once you’ve created an account, you can continue to Apply for qualified teacher status (QTS) in England.</p>

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/LandingTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/LandingTests.cs
@@ -36,20 +36,4 @@ public class LandingTests : TestBase
     {
         await ValidRequest_RendersContent(c => c.Start(), additionalScopes: null, trnRequirementType: null, url: "/sign-in/landing");
     }
-
-    [Fact]
-    public async Task Get_ValidRequestApplyForQTSClient_RendersClientScopedPartialContent()
-    {
-        var authStateHelper = await CreateAuthenticationStateHelper(c => c.Start(), additionalScopes: null, trnRequirementType: null, trnMatchPolicy: null, TestClients.ApplyForQts);
-        var request = new HttpRequestMessage(HttpMethod.Get, $"/sign-in/landing?{authStateHelper.ToQueryParam()}");
-
-        // Act
-        var response = await HttpClient.SendAsync(request);
-
-        // Assert
-        response.EnsureSuccessStatusCode();
-
-        var doc = await response.GetDocument();
-        Assert.Contains("Once you’ve created an account, you can continue to Apply for qualified teacher status (QTS) in England.", doc.GetElementByTestId("landing-content")!.InnerHtml);
-    }
 }


### PR DESCRIPTION
For Claim and AYTQ we require a match on TRN and NINO. This adds content to the landing page to tell users that they will need this information.

We have two landing pages that are very similar; I've resisted the urge to unify them here