### PR TITLE
Updated Journey to skip qts/itt questions if trnmatchpolicy is strict

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourneyWithTrnLookup.cs
@@ -105,8 +105,8 @@ public class CoreSignInJourneyWithTrnLookup : CoreSignInJourney
         Steps.NiNumber => AuthenticationState is { HasNationalInsuranceNumber: true, ContactDetailsVerified: true },
         Steps.HasTrn => (AuthenticationState is ({ NationalInsuranceNumberSet: true } or { HasNationalInsuranceNumberSet: true, HasNationalInsuranceNumber: false }) and { ContactDetailsVerified: true }),
         Steps.Trn => AuthenticationState is { HasTrn: true, ContactDetailsVerified: true },
-        Steps.HasQts => AuthenticationState is ({ StatedTrn: { } } or { HasTrnSet: true, HasTrn: false }) and { ContactDetailsVerified: true },
-        Steps.IttProvider => AuthenticationState is { AwardedQts: true, ContactDetailsVerified: true },
+        Steps.HasQts => AuthenticationState is ({ StatedTrn: { }, OAuthState: { TrnMatchPolicy: Models.TrnMatchPolicy.Default } } or { OAuthState: { TrnMatchPolicy: Models.TrnMatchPolicy.Default }, HasTrnSet: true, HasTrn: false }) and { ContactDetailsVerified: true },
+        Steps.IttProvider => AuthenticationState is { OAuthState: { TrnMatchPolicy: Models.TrnMatchPolicy.Default }, AwardedQts: true, ContactDetailsVerified: true },
         SignInJourney.Steps.TrnInUse => AuthenticationState.TrnLookup == AuthenticationState.TrnLookupState.ExistingTrnFound,
         SignInJourney.Steps.TrnInUseResendTrnOwnerEmailConfirmation => AuthenticationState.TrnLookup == AuthenticationState.TrnLookupState.ExistingTrnFound,
         SignInJourney.Steps.TrnInUseChooseEmail => AuthenticationState.TrnLookup == AuthenticationState.TrnLookupState.EmailOfExistingAccountForTrnVerified,
@@ -125,6 +125,7 @@ public class CoreSignInJourneyWithTrnLookup : CoreSignInJourney
             (Steps.HasNiNumber, { HasNationalInsuranceNumber: false }) => shouldCheckAnswers ? CoreSignInJourney.Steps.CheckAnswers : Steps.HasTrn,
             (Steps.NiNumber, _) => shouldCheckAnswers ? CoreSignInJourney.Steps.CheckAnswers : Steps.HasTrn,
             (Steps.HasTrn, { HasTrn: true }) => Steps.Trn,
+            (Steps.HasTrn, { HasTrn: false, OAuthState.TrnMatchPolicy: Models.TrnMatchPolicy.Strict }) => CoreSignInJourney.Steps.CheckAnswers,
             (Steps.HasTrn, { HasTrn: false }) => shouldCheckAnswers ? CoreSignInJourney.Steps.CheckAnswers : Steps.HasQts,
             (Steps.Trn, _) => shouldCheckAnswers ? CoreSignInJourney.Steps.CheckAnswers : Steps.HasQts,
             (Steps.HasQts, { AwardedQts: true }) => Steps.IttProvider,
@@ -202,8 +203,8 @@ public class CoreSignInJourneyWithTrnLookup : CoreSignInJourney
         AuthenticationState.DateOfBirthSet &&
         AuthenticationState.HasNationalInsuranceNumberSet &&
         (AuthenticationState.NationalInsuranceNumberSet || AuthenticationState.HasNationalInsuranceNumber == false) &&
-        AuthenticationState.AwardedQtsSet &&
-        (AuthenticationState.HasIttProviderSet || AuthenticationState.AwardedQts == false);
+        ((AuthenticationState.AwardedQtsSet &&
+        (AuthenticationState.HasIttProviderSet || AuthenticationState.AwardedQts == false) || (AuthenticationState.AwardedQtsSet == false && AuthenticationState?.OAuthState?.TrnMatchPolicy == Models.TrnMatchPolicy.Strict)));
 
     public new static class Steps
     {

--- a/dotnet-authserver/src/TeacherIdentity.TestClient/Program.cs
+++ b/dotnet-authserver/src/TeacherIdentity.TestClient/Program.cs
@@ -75,6 +75,12 @@ public class Program
                         ctx.ProtocolMessage.SetParameter("trn_requirement", trnRequirement);
                     }
 
+                    var trnMatchPolicy = ctx.HttpContext.Request.Query["trn_match_policy"].ToString();
+                    if (!string.IsNullOrEmpty(trnMatchPolicy))
+                    {
+                        ctx.ProtocolMessage.SetParameter("trn_match_policy", trnMatchPolicy);
+                    }
+
                     var trnToken = ctx.HttpContext.Request.Query["trn_token"].ToString();
                     if (!string.IsNullOrEmpty(trnToken))
                     {

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
@@ -38,7 +38,8 @@ public static class PageExtensions
         this IPage page,
         string? additionalScope = null,
         TrnRequirementType? trnRequirement = null,
-        string? trnToken = null)
+        string? trnToken = null,
+        TrnMatchPolicy trnMatchPolicy = TrnMatchPolicy.Default)
     {
         var allScopes = new List<string>()
         {
@@ -64,6 +65,8 @@ public static class PageExtensions
         {
             url.SetQueryParam("trn_token", trnToken);
         }
+
+        url.SetQueryParam("trn_match_policy", trnMatchPolicy.ToString());
 
         await page.GotoAsync(url);
     }


### PR DESCRIPTION
### Context

Skip the QTS provider questions for `Strict` `TrnMatchPolicy` journeys

https://trello.com/c/wbVOO7Bz/1213-skip-the-qts-provider-questions-for-strict-trnmatchpolicy-journeys

### Changes proposed in this pull request

- Added test to show that itt/qts questions are skipped when trnmatchpolicy is strict.
- Updated client to pass extra parameter - trn_match_policy

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [x] Reminder created to manually clean any removed app settings post deployment
