### PR TITLE
Don't send TrnLookupStatus claim without TRN

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/UserClaimHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/UserClaimHelper.cs
@@ -91,9 +91,6 @@ public class UserClaimHelper
 
         if (trnMatchPolicy is not null)
         {
-            Debug.Assert(user.TrnLookupStatus.HasValue);
-            claims.Add(new Claim(CustomClaims.TrnLookupStatus, user.TrnLookupStatus!.Value.ToString()));
-
             var haveSufficientTrnMatch = user.Trn is not null &&
                 (trnMatchPolicy == TrnMatchPolicy.Default ||
                 user.TrnVerificationLevel == TrnVerificationLevel.Medium ||
@@ -102,7 +99,10 @@ public class UserClaimHelper
 
             if (haveSufficientTrnMatch)
             {
+                Debug.Assert(user.Trn is not null);
+                Debug.Assert(user.TrnLookupStatus.HasValue);
                 claims.Add(new Claim(CustomClaims.Trn, user.Trn!));
+                claims.Add(new Claim(CustomClaims.TrnLookupStatus, user.TrnLookupStatus!.Value.ToString()));
 
                 if (trnMatchPolicy == TrnMatchPolicy.Strict)
                 {


### PR DESCRIPTION
If we're not sending a TRN claim because the user's `TrnVerificationLevel` isn't high enough then we shouldn't send a `TrnLookupStatus` claim either.