### PR TITLE
Add Sign out link to Elevate journey

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Controllers/AuthorizationController.cs
@@ -405,13 +405,17 @@ public class AuthorizationController : Controller
     [ActionName(nameof(SignOut)), HttpPost("~/connect/signout")]
     public async Task<IActionResult> SignOutPost()
     {
+        var redirectUri = HttpContext.TryGetAuthenticationState(out var authenticationState) ?
+            authenticationState.PostSignInUrl :
+            "/";
+
         await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
 
         return SignOut(
             authenticationSchemes: OpenIddictServerAspNetCoreDefaults.AuthenticationScheme,
             properties: new AuthenticationProperties
             {
-                RedirectUri = "/"
+                RedirectUri = redirectUri
             });
     }
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/_Layout.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/_Layout.cshtml
@@ -1,19 +1,6 @@
 @{
     ViewBag.ServiceUrl = LinkGenerator.Account(Context.GetClientRedirectInfo());
     Layout = "/Views/Shared/_Layout.cshtml";
-
-    var signOutUrl = Context.GetClientRedirectInfo()?.SignOutUri ?? LinkGenerator.SignOut();
-}
-
-@section HeaderNav {
-    <nav aria-label="Menu" class="govuk-header__navigation">
-        <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide menu" hidden>Menu</button>
-        <ul id="navigation" class="govuk-header__navigation-list">
-            <li class="govuk-header__navigation-item @(Context.Request.Path.StartsWithSegments("/sign-out") ? "govuk-header__navigation-item--active" : "")">
-                <a class="govuk-header__link" href="@signOutUrl">Sign out</a>
-            </li>
-        </ul>
-    </nav>
 }
 
 @section BeforeContent {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Complete.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Complete.cshtml
@@ -24,8 +24,6 @@
         }
     }
 
-    var signOutLink = LinkGenerator.SignOut();
-
     async Task RenderContent()
     {
         <govuk-panel class="app-panel--interruption">
@@ -133,17 +131,6 @@
             </govuk-panel-body>
         </govuk-panel>
     }
-}
-
-@section HeaderNav {
-    <nav aria-label="Menu" class="govuk-header__navigation ">
-        <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide menu" hidden>Menu</button>
-        <ul id="navigation" class="govuk-header__navigation-list">
-            <li class="govuk-header__navigation-item @(ViewContext.HttpContext.Request.Path == signOutLink ? "govuk-header__navigation-item--active" : "")">
-                <a class="govuk-header__link" href="@signOutLink">Sign out</a>
-            </li>
-        </ul>
-    </nav>
 }
 
 @if (Model.CanAccessService)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Views/Shared/_Layout.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Views/Shared/_Layout.cshtml
@@ -1,4 +1,5 @@
 @using TeacherIdentity.AuthServer.Journeys;
+@using Microsoft.AspNetCore.Authentication;
 @inject TeacherIdentity.AuthServer.Oidc.ICurrentClientProvider CurrentClientProvider
 @inject ClientScopedViewHelper ClientScopedViewHelper
 @inject SignInJourneyProvider SignInJourneyProvider
@@ -13,6 +14,9 @@
 
     var serviceName = ViewBag.ServiceName ?? "DfE Identity account";
     var serviceUrl = ViewBag.ServiceUrl ?? "/";
+
+    var isSignedIn = (await Context.AuthenticateAsync(Microsoft.AspNetCore.Authentication.Cookies.CookieAuthenticationDefaults.AuthenticationScheme)).Succeeded;
+    var signOutLink = Context.GetClientRedirectInfo()?.SignOutUri ?? LinkGenerator.SignOut();
 }
 
 @section Head {
@@ -45,7 +49,25 @@
                 <a href="@serviceUrl" class="govuk-header__link govuk-header__link--service-name">
                     @serviceName
                 </a>
-                @RenderSection("HeaderNav", required: false)
+
+                @if (IsSectionDefined("HeaderNav"))
+                {
+                    @RenderSection("HeaderNav")
+                }
+                else
+                {
+                    @if (isSignedIn)
+                    {
+                        <nav aria-label="Menu" class="govuk-header__navigation">
+                            <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide menu" hidden>Menu</button>
+                            <ul id="navigation" class="govuk-header__navigation-list">
+                                <li class="govuk-header__navigation-item @(Url.IsLocalUrl(signOutLink) && ViewContext.HttpContext.Request.Path == signOutLink ? "govuk-header__navigation-item--active" : "")">
+                                    <a class="govuk-header__link" href="@signOutLink">Sign out</a>
+                                </li>
+                            </ul>
+                        </nav>
+                    }
+                }
             </div>
         </div>
     </header>
@@ -55,13 +77,13 @@
     @RenderSection("BeforeContent", required: false)
 }
 
-@if (TempData.TryGetFlashSuccess(out (string heading, string? message)? flashSuccess))
+@if (TempData.TryGetFlashSuccess(out (string Heading, string? Message)? flashSuccess))
 {
     <govuk-notification-banner type="Success">
-        <p class="govuk-notification-banner__heading">@flashSuccess.Value.heading</p>
-        @if (flashSuccess.Value.message is not null)
+        <p class="govuk-notification-banner__heading">@flashSuccess.Value.Heading</p>
+        @if (flashSuccess.Value.Message is not null)
         {
-            @foreach (var line in flashSuccess.Value.message.Split(Environment.NewLine))
+            @foreach (var line in flashSuccess.Value.Message.Split(Environment.NewLine))
             {
                 <span>@line</span><br/>
             }            


### PR DESCRIPTION
Users who go through the Elevate journey are already signed in as far as ID is concerned; they need a way to sign out.

As part of this I've moved the Sign out link (and the containing nav) into the base Layout to remove some of the duplication. The sign out process itself is also amended to return the user to the `authorize` endpoint if they signed out during an authorization code flow.