### PR TITLE
Prevent TrnMatchPolicy and TrnRequirementType from being overriden

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Development.json
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/appsettings.Development.json
@@ -68,5 +68,6 @@
   "UserVerification": {
     "UseFixedPin": true,
     "Pin": "00000"
-  }
+  },
+  "AllowTrnConfigurationOverrides": true
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/appsettings.json
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/appsettings.json
@@ -11,7 +11,8 @@
     "UserVerification": {
       "UseFixedPin": true
     },
-    "BlockEstablishmentEmailDomains": true
+    "BlockEstablishmentEmailDomains": true,
+    "AllowTrnConfigurationOverrides": true
   },
   "TestClient": {
     "ClientId": "testclient",

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/appsettings.json
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/appsettings.json
@@ -10,5 +10,6 @@
   "BlockEstablishmentEmailDomains": true,
   "WebHooks": {
     "WebHooksCacheDurationSeconds": 30
-  }
+  },
+  "AllowTrnConfigurationOverrides": true
 }


### PR DESCRIPTION
We allow the client's configured `TrnMatchPolicy` and `TrnRequirementType` to be overridden by query parameters on the authorization request for testing purposes but we shouldn't allow it in production for 'real' clients. This change adds guards to those overrides so that they're only allowed for the `testclient` (I felt making it configurable per-service was overkill here).