### PR TITLE
Fix double space in name claim for users without middle name

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/UserClaimHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/UserClaimHelper.cs
@@ -59,7 +59,7 @@ public class UserClaimHelper
             return Array.Empty<Claim>();
         }
 
-        var fullName = user.MiddleName is null
+        var fullName = string.IsNullOrWhiteSpace(user.MiddleName)
             ? $"{user.FirstName} {user.LastName}"
             : $"{user.FirstName} {user.MiddleName} {user.LastName}";
 


### PR DESCRIPTION
Users that get into the DB via the user import process have an empty string middle name rather than `null`. This tweaks the full name logic to account for that and prevent two spaces between first and last name.