### PR TITLE
Amend the wording on the NINO page for Strict TRN lookups

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/NiNumberPage.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/NiNumberPage.cshtml
@@ -16,10 +16,12 @@
             </govuk-input>
 
             <govuk-details>
-                <govuk-details-summary>I do not know my National Insurance number</govuk-details-summary>
+                <govuk-details-summary>
+                    @(Model.TrnMatchPolicy == TrnMatchPolicy.Strict ? "I cannot provide my National Insurance number" : "I do not know my National Insurance number")
+                </govuk-details-summary>
                 <govuk-details-text>
                     <p>You can <a href="https://www.gov.uk/lost-national-insurance-number" rel="noreferrer noopener" target="_blank">find a lost National Insurance number (opens in new tab)</a>.</p>
-                    <p>Or you can continue without it, but we are less likely to find your TRN.</p>
+                    <p>@(Model.TrnMatchPolicy == TrnMatchPolicy.Strict ? "If you do not have a National Insurance number you can continue without it." : "Or you can continue without it, but we are less likely to find your TRN.")</p>
                     <govuk-button type="submit" class="govuk-button--secondary" name="submit" value="ni_number_not_known">
                         Continue without it
                     </govuk-button>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/NiNumberPage.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/NiNumberPage.cshtml.cs
@@ -2,6 +2,7 @@ using System.ComponentModel.DataAnnotations;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using TeacherIdentity.AuthServer.Journeys;
+using TeacherIdentity.AuthServer.Models;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn.Register;
 
@@ -19,6 +20,8 @@ public class NiNumberPage : PageModel
     }
 
     public string BackLink => _journey.GetPreviousStepUrl(CurrentStep);
+
+    public TrnMatchPolicy? TrnMatchPolicy => _journey.AuthenticationState.TryGetOAuthState(out var oAuthState) ? oAuthState.TrnMatchPolicy : null;
 
     [BindProperty]
     [Display(Name = "What is your National Insurance number?", Description = "It’s on your National Insurance card, benefit letter, payslip or P60. For example, ‘QQ 12 34 56 C’.")]


### PR DESCRIPTION
We need people who have a NINO to enter it when going through a `TrnMatchPolicy.Strict` journey otherwise they won't match (if their DQT record has their NINO). The previous wording 'I do not know my National Insurance number' / 'Continue without it' suggests that people who have a NINO, but don't have it to hand, can continue successfully.

This changes the wording to 'I cannot provide my National Insurance number' / 'If you do not have a National Insurance number you can continue without it.' to try to encourage everyone who has a NINO to enter it here.