### PR TITLE
Adding warning to user page when user has prohibition

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/User.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/User.cshtml
@@ -6,12 +6,24 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link asp-page="Users"/>
+    <govuk-back-link asp-page="Users" />
 }
 
 <h1 class="govuk-heading-l">
     @Model.Name
 </h1>
+
+
+@if (Model.HasProhibitions)
+{
+    <section class="govuk-!-margin-bottom-6">
+        <govuk-warning-text icon-fallback-text="Warning" data-testid="user-has-prohibitions">
+            <span>This user has prohibitions and cannot access every service</span>
+        </govuk-warning-text>
+    </section>
+}
+
+
 
 <section class="x-govuk-summary-card govuk-!-margin-bottom-6">
     <header class="x-govuk-summary-card__header">
@@ -126,17 +138,17 @@
                     <govuk-summary-list-row-value>@Model.Trn</govuk-summary-list-row-value>
                 </govuk-summary-list-row>
                 @{
-                    if(Model.EffectiveVerificationLevel == TrnVerificationLevel.Low)
+                    if (Model.EffectiveVerificationLevel == TrnVerificationLevel.Low)
                     {
-                      <govuk-summary-list-row>
+                        <govuk-summary-list-row>
                             <govuk-summary-list-row-key>TRN verification level</govuk-summary-list-row-key>
                             <govuk-summary-list-row-value><govuk-tag class="govuk-tag--yellow">Low</govuk-tag></govuk-summary-list-row-value>
                             <govuk-summary-list-row-actions>
-                             <govuk-summary-list-row-action asp-page="ElevateUserTrnVerification" asp-route-userId="@Model.UserId" visually-hidden-text="TRN verification level">Elevate</govuk-summary-list-row-action>
+                                <govuk-summary-list-row-action asp-page="ElevateUserTrnVerification" asp-route-userId="@Model.UserId" visually-hidden-text="TRN verification level">Elevate</govuk-summary-list-row-action>
                             </govuk-summary-list-row-actions>
-                      </govuk-summary-list-row>
+                        </govuk-summary-list-row>
                     }
-                    else if(Model.EffectiveVerificationLevel == TrnVerificationLevel.Medium)
+                    else if (Model.EffectiveVerificationLevel == TrnVerificationLevel.Medium)
                     {
                         <govuk-summary-list-row>
                             <govuk-summary-list-row-key>TRN verification level</govuk-summary-list-row-key>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/User.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/User.cshtml.cs
@@ -49,6 +49,8 @@ public class UserModel : PageModel
 
     public TrnVerificationLevel? EffectiveVerificationLevel { get; set; }
 
+    public bool HasProhibitions { get; set; }
+
     [FromRoute]
     public Guid UserId { get; set; }
 
@@ -112,6 +114,7 @@ public class UserModel : PageModel
             DqtName = $"{dqtUser.FirstName} {dqtUser.LastName}";
             DqtDateOfBirth = dqtUser.DateOfBirth;
             DqtNationalInsuranceNumber = dqtUser.NationalInsuranceNumber;
+            HasProhibitions = dqtUser.Alerts.Any(y => y.AlertType == AlertType.Prohibition);
         }
 
         return Page();

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/TeacherInfo.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/TeacherInfo.cs
@@ -1,3 +1,4 @@
+
 namespace TeacherIdentity.AuthServer.Services.DqtApi;
 
 public record TeacherInfo
@@ -11,4 +12,17 @@ public record TeacherInfo
     public required bool PendingNameChange { get; init; }
     public required bool PendingDateOfBirthChange { get; init; }
     public required string? Email { get; init; }
+    public required IReadOnlyCollection<AlertInfo> Alerts { get; init; }
 }
+
+public record AlertInfo
+{
+    public required AlertType AlertType { get; init; }
+    public required string DqtSanctionCode { get; init; }
+}
+
+public enum AlertType
+{
+    Prohibition
+}
+

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Account.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Account.cs
@@ -68,7 +68,8 @@ public class Account : IClassFixture<HostFixture>
             PendingDateOfBirthChange = false,
             PendingNameChange = false,
             Trn = user.Trn!,
-            Email = null
+            Email = null,
+            Alerts = Array.Empty<AlertInfo>()
         };
 
         ConfigureDqtApiGetTeacherResponse(user.Trn!, dqtTeacherInfo);
@@ -157,7 +158,8 @@ public class Account : IClassFixture<HostFixture>
             PendingDateOfBirthChange = false,
             PendingNameChange = false,
             Trn = user.Trn!,
-            Email = null
+            Email = null,
+            Alerts = Array.Empty<AlertInfo>()
         };
 
         ConfigureDqtApiGetTeacherResponse(user.Trn!, dqtTeacherInfo);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Elevate.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Elevate.cs
@@ -62,7 +62,8 @@ public class Elevate : IClassFixture<HostFixture>
             NationalInsuranceNumber = nino,
             PendingDateOfBirthChange = false,
             PendingNameChange = false,
-            Trn = user.Trn!
+            Trn = user.Trn!,
+            Alerts = Array.Empty<AlertInfo>()
         });
 
         await page.SubmitElevateCheckAnswersPage();
@@ -171,7 +172,8 @@ public class Elevate : IClassFixture<HostFixture>
             NationalInsuranceNumber = nino,
             PendingDateOfBirthChange = false,
             PendingNameChange = false,
-            Trn = user.Trn!
+            Trn = user.Trn!,
+            Alerts = Array.Empty<AlertInfo>()
         });
 
         await page.SubmitElevateCheckAnswersPage();

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/TrnTokenSignInJourney.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/TrnTokenSignInJourney.cs
@@ -42,7 +42,8 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
                 NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber(),
                 PendingDateOfBirthChange = false,
                 PendingNameChange = false,
-                Email = trnToken.Email
+                Email = trnToken.Email,
+                Alerts = Array.Empty<AlertInfo>()
             });
 
         await using var context = await _hostFixture.CreateBrowserContext();
@@ -92,7 +93,8 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
                 NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber(),
                 PendingDateOfBirthChange = false,
                 PendingNameChange = false,
-                Email = trnToken.Email
+                Email = trnToken.Email,
+                Alerts = Array.Empty<AlertInfo>()
             });
 
         await using var context = await _hostFixture.CreateBrowserContext();
@@ -143,7 +145,8 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
                 NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber(),
                 PendingDateOfBirthChange = false,
                 PendingNameChange = false,
-                Email = trnToken.Email
+                Email = trnToken.Email,
+                Alerts = Array.Empty<AlertInfo>()
             });
 
         await using var context = await _hostFixture.CreateBrowserContext();
@@ -769,7 +772,8 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
                 NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber(),
                 PendingDateOfBirthChange = false,
                 PendingNameChange = false,
-                Email = trnToken.Email
+                Email = trnToken.Email,
+                Alerts = Array.Empty<AlertInfo>()
             });
 
         var invalidEmailSuffix = "invalid.sch.uk";
@@ -929,7 +933,8 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
                 NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber(),
                 PendingDateOfBirthChange = false,
                 PendingNameChange = false,
-                Email = email
+                Email = email,
+                Alerts = Array.Empty<AlertInfo>()
             });
 
         return await _hostFixture.TestData.GenerateTrnToken(trn, email: email);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/DateOfBirth/DateOfBirthTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/DateOfBirth/DateOfBirthTests.cs
@@ -1,4 +1,6 @@
 using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Services.DqtApi;
+
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Account.DateOfBirth;
 
 public class DateOfBirthTests : TestBase
@@ -189,7 +191,8 @@ public class DateOfBirthTests : TestBase
                 Trn = user.Trn!,
                 PendingNameChange = false,
                 PendingDateOfBirthChange = hasPendingDobChange,
-                Email = null
+                Email = null,
+                Alerts = Array.Empty<AlertInfo>()
             });
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/IndexTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/IndexTests.cs
@@ -133,7 +133,8 @@ public class IndexTests : TestBase
                 Trn = user.Trn!,
                 PendingNameChange = false,
                 PendingDateOfBirthChange = false,
-                Email = null
+                Email = null,
+                Alerts = Array.Empty<AlertInfo>()
             });
 
         var request = new HttpRequestMessage(HttpMethod.Get, "/account");
@@ -186,7 +187,8 @@ public class IndexTests : TestBase
                 Trn = user.Trn!,
                 PendingNameChange = false,
                 PendingDateOfBirthChange = hasPendingReview,
-                Email = null
+                Email = null,
+                Alerts = Array.Empty<AlertInfo>()
             });
 
         var request = new HttpRequestMessage(HttpMethod.Get, "/account");
@@ -218,7 +220,8 @@ public class IndexTests : TestBase
                 Trn = user.Trn!,
                 PendingNameChange = true,
                 PendingDateOfBirthChange = false,
-                Email = null
+                Email = null,
+                Alerts = Array.Empty<AlertInfo>()
             });
 
         var request = new HttpRequestMessage(HttpMethod.Get, "/account");

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialDateOfBirth/ConfirmTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialDateOfBirth/ConfirmTests.cs
@@ -119,7 +119,8 @@ public class ConfirmTests : TestBase
                 Trn = user.Trn!,
                 PendingDateOfBirthChange = hasPendingDateOfBirthChange,
                 PendingNameChange = false,
-                Email = null
+                Email = null,
+                Alerts = Array.Empty<AlertInfo>()
             });
     }
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialDateOfBirth/DetailsTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialDateOfBirth/DetailsTests.cs
@@ -1,3 +1,4 @@
+using TeacherIdentity.AuthServer.Services.DqtApi;
 using User = TeacherIdentity.AuthServer.Models.User;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Account.OfficialDateOfBirth;
@@ -180,7 +181,8 @@ public class DetailsTests : TestBase
                 Trn = user.Trn!,
                 PendingDateOfBirthChange = hasPendingDateOfBirthChange,
                 PendingNameChange = false,
-                Email = null
+                Email = null,
+                Alerts = Array.Empty<AlertInfo>()
             });
     }
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialDateOfBirth/EvidenceTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialDateOfBirth/EvidenceTests.cs
@@ -1,3 +1,4 @@
+using TeacherIdentity.AuthServer.Services.DqtApi;
 using User = TeacherIdentity.AuthServer.Models.User;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Account.OfficialDateOfBirth;
@@ -179,7 +180,8 @@ public class EvidenceTests : TestBase
                 Trn = user.Trn!,
                 PendingDateOfBirthChange = hasPendingDateOfBirthChange,
                 PendingNameChange = false,
-                Email = null
+                Email = null,
+                Alerts = Array.Empty<AlertInfo>()
             });
     }
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialDateOfBirth/OfficialDateOfBirthTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialDateOfBirth/OfficialDateOfBirthTests.cs
@@ -1,4 +1,5 @@
 using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Services.DqtApi;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Account.OfficialDateOfBirth;
 
@@ -61,7 +62,8 @@ public class OfficialDateOfBirthTests : TestBase
                 Trn = user.Trn!,
                 PendingDateOfBirthChange = hasPendingDateOfBirthChange,
                 PendingNameChange = false,
-                Email = null
+                Email = null,
+                Alerts = Array.Empty<AlertInfo>()
             });
     }
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialName/ConfirmTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialName/ConfirmTests.cs
@@ -185,7 +185,8 @@ public class ConfirmTests : TestBase
                 Trn = user.Trn!,
                 PendingDateOfBirthChange = false,
                 PendingNameChange = hasPendingNameChange,
-                Email = null
+                Email = null,
+                Alerts = Array.Empty<AlertInfo>()
             });
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialName/DetailsTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialName/DetailsTests.cs
@@ -1,3 +1,4 @@
+using TeacherIdentity.AuthServer.Services.DqtApi;
 using User = TeacherIdentity.AuthServer.Models.User;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Account.OfficialName;
@@ -203,7 +204,8 @@ public class DetailsTests : TestBase
                 Trn = user.Trn!,
                 PendingDateOfBirthChange = false,
                 PendingNameChange = hasPendingNameChange,
-                Email = null
+                Email = null,
+                Alerts = Array.Empty<AlertInfo>()
             });
     }
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialName/EvidenceTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialName/EvidenceTests.cs
@@ -1,5 +1,6 @@
 using System.Text.RegularExpressions;
 using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Services.DqtApi;
 using User = TeacherIdentity.AuthServer.Models.User;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Account.OfficialName;
@@ -226,7 +227,8 @@ public class EvidenceTests : TestBase
                 Trn = user.Trn!,
                 PendingDateOfBirthChange = false,
                 PendingNameChange = hasPendingNameChange,
-                Email = null
+                Email = null,
+                Alerts = Array.Empty<AlertInfo>()
             });
     }
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialName/OfficialNameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialName/OfficialNameTests.cs
@@ -1,4 +1,5 @@
 using TeacherIdentity.AuthServer.Models;
+using TeacherIdentity.AuthServer.Services.DqtApi;
 
 namespace TeacherIdentity.AuthServer.Tests.EndpointTests.Account.OfficialName;
 
@@ -62,7 +63,8 @@ public class OfficialNameTests : TestBase
                 Trn = user.Trn!,
                 PendingDateOfBirthChange = false,
                 PendingNameChange = hasPendingNameChange,
-                Email = null
+                Email = null,
+                Alerts = Array.Empty<AlertInfo>()
             });
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AssignTrn/ConfirmTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AssignTrn/ConfirmTests.cs
@@ -553,7 +553,8 @@ public class ConfirmTests : TestBase
                 Trn = trn,
                 PendingNameChange = false,
                 PendingDateOfBirthChange = false,
-                Email = email ?? Faker.Internet.Email()
+                Email = email ?? Faker.Internet.Email(),
+                Alerts = Array.Empty<AlertInfo>()
             });
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AssignTrn/IndexTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AssignTrn/IndexTests.cs
@@ -299,7 +299,8 @@ public class IndexTests : TestBase
                 Trn = trn,
                 PendingNameChange = false,
                 PendingDateOfBirthChange = false,
-                Email = email ?? Faker.Internet.Email()
+                Email = email ?? Faker.Internet.Email(),
+                Alerts = Array.Empty<AlertInfo>()
             });
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Oidc/AuthorizeTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Oidc/AuthorizeTests.cs
@@ -524,7 +524,8 @@ public class AuthorizeTests : TestBase
                 Trn = trn,
                 PendingDateOfBirthChange = false,
                 PendingNameChange = false,
-                Email = null
+                Email = null,
+                Alerts = Array.Empty<AlertInfo>()
             });
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
@@ -2,6 +2,7 @@ using Microsoft.Extensions.Options;
 using TeacherIdentity.AuthServer.Events;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Oidc;
+using TeacherIdentity.AuthServer.Services.DqtApi;
 using TeacherIdentity.AuthServer.Services.UserVerification;
 using TeacherIdentity.AuthServer.Tests.Infrastructure;
 
@@ -484,7 +485,8 @@ public class EmailConfirmationTests : TestBase
                 NationalInsuranceNumber = Faker.Identification.UkNationalInsuranceNumber(),
                 Trn = user.Trn!,
                 PendingDateOfBirthChange = false,
-                PendingNameChange = false
+                PendingNameChange = false,
+                Alerts = Array.Empty<AlertInfo>()
             });
 
         var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(user.EmailAddress), additionalScopes: null);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Jobs/SyncNamesWithDqtJobTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Jobs/SyncNamesWithDqtJobTests.cs
@@ -68,7 +68,8 @@ public class SyncNamesWithDqtJobTests : IClassFixture<DbFixture>, IAsyncLifetime
             NationalInsuranceNumber = null,
             PendingNameChange = false,
             PendingDateOfBirthChange = false,
-            Email = Faker.Internet.Email()
+            Email = Faker.Internet.Email(),
+            Alerts = Array.Empty<AlertInfo>()
         };
 
         var dqtApiClient = Mock.Of<IDqtApiClient>();
@@ -151,7 +152,8 @@ public class SyncNamesWithDqtJobTests : IClassFixture<DbFixture>, IAsyncLifetime
             NationalInsuranceNumber = null,
             PendingNameChange = false,
             PendingDateOfBirthChange = false,
-            Email = Faker.Internet.Email()
+            Email = Faker.Internet.Email(),
+            Alerts = Array.Empty<AlertInfo>()
         };
 
         var dqtApiClient = Mock.Of<IDqtApiClient>();

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Services/UserImport/UserImportProcessorTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Services/UserImport/UserImportProcessorTests.cs
@@ -50,7 +50,8 @@ public class UserImportProcessorTests : IClassFixture<DbFixture>, IAsyncLifetime
             NationalInsuranceNumber = null,
             PendingNameChange = false,
             PendingDateOfBirthChange = false,
-            Email = null
+            Email = null,
+            Alerts = Array.Empty<AlertInfo>()
         };
 
         var getTeacherByTrnResultTest23 = new TeacherInfo()
@@ -63,7 +64,8 @@ public class UserImportProcessorTests : IClassFixture<DbFixture>, IAsyncLifetime
             NationalInsuranceNumber = null,
             PendingNameChange = false,
             PendingDateOfBirthChange = false,
-            Email = null
+            Email = null,
+            Alerts = Array.Empty<AlertInfo>()
         };
 
         return new TheoryData<UserImportTestScenarioData>()

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/UserClaimHelperTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/UserClaimHelperTests.cs
@@ -191,7 +191,8 @@ public class UserClaimHelperTests : IClassFixture<DbFixture>
             NationalInsuranceNumber = nino,
             PendingDateOfBirthChange = false,
             PendingNameChange = false,
-            Trn = user.Trn!
+            Trn = user.Trn!,
+            Alerts = Array.Empty<AlertInfo>()
         });
 
         using var dbContext = _dbFixture.GetDbContext();
@@ -232,7 +233,8 @@ public class UserClaimHelperTests : IClassFixture<DbFixture>
             NationalInsuranceNumber = nino,
             PendingDateOfBirthChange = false,
             PendingNameChange = false,
-            Trn = user.Trn!
+            Trn = user.Trn!,
+            Alerts = Array.Empty<AlertInfo>()
         });
 
         using var dbContext = _dbFixture.GetDbContext();
@@ -273,7 +275,8 @@ public class UserClaimHelperTests : IClassFixture<DbFixture>
             NationalInsuranceNumber = nino,
             PendingDateOfBirthChange = false,
             PendingNameChange = false,
-            Trn = user.Trn!
+            Trn = user.Trn!,
+            Alerts = Array.Empty<AlertInfo>()
         });
 
         using var dbContext = _dbFixture.GetDbContext();
@@ -316,7 +319,8 @@ public class UserClaimHelperTests : IClassFixture<DbFixture>
             NationalInsuranceNumber = nino,
             PendingDateOfBirthChange = false,
             PendingNameChange = false,
-            Trn = user.Trn!
+            Trn = user.Trn!,
+            Alerts = Array.Empty<AlertInfo>()
         });
 
         using var dbContext = _dbFixture.GetDbContext();
@@ -359,7 +363,8 @@ public class UserClaimHelperTests : IClassFixture<DbFixture>
             NationalInsuranceNumber = nino,
             PendingDateOfBirthChange = false,
             PendingNameChange = false,
-            Trn = user.Trn!
+            Trn = user.Trn!,
+            Alerts = Array.Empty<AlertInfo>()
         });
 
         using var dbContext = _dbFixture.GetDbContext();
@@ -402,7 +407,8 @@ public class UserClaimHelperTests : IClassFixture<DbFixture>
             NationalInsuranceNumber = nino,
             PendingDateOfBirthChange = false,
             PendingNameChange = false,
-            Trn = user.Trn!
+            Trn = user.Trn!,
+            Alerts = Array.Empty<AlertInfo>()
         });
 
         using var dbContext = _dbFixture.GetDbContext();


### PR DESCRIPTION
### Context

Add warning to user summary page when user has prohibitions. 

https://trello.com/c/J2DZgGGa/1289-add-a-warning-to-user-detail-page-for-users-who-have-prohibitions

![image](https://github.com/DFE-Digital/get-an-identity/assets/60096576/ac8cc86d-3554-4406-95ee-259e0e631538)


### Changes proposed in this pull request

Include a summary of the change.

### Guidance to review

Include any useful information needed to review this change.
Include any dependencies that are required for this change.

### Checklist

-   [x] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [x] Reminder created to manually clean any removed app settings post deployment
