### PR TITLE
Fix initializing TrnLookup from an existing session

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -629,7 +629,7 @@ public class AuthenticationState
                 user.EffectiveVerificationLevel != TrnVerificationLevel.Medium :
                 null;
         HaveCompletedTrnLookup = user?.CompletedTrnLookup is not null;
-        TrnLookup = user?.CompletedTrnLookup is not null ? TrnLookupState.Complete : TrnLookupState.None;
+        TrnLookup = user?.CompletedTrnLookup is not null || user?.Trn is not null ? TrnLookupState.Complete : TrnLookupState.None;
         UserType = user?.UserType;
         StaffRoles = user?.StaffRoles;
         TrnLookupStatus = user?.TrnLookupStatus;


### PR DESCRIPTION
We have some Sentry errors caused by users hitting the `/sign-in/register/email-exists` after the `/sign-in/email-confirmation`. That shouldn't be possible; we shouldn't be showing the 'you already have an account' interstitial when users have chosen to sign in, only when they've tried to register.

I think this might be caused by the `AuthenticationState` initialization we do from an existing cookie - clearing cookies and signing in doesn't seem to show this issue.

The `IsFinished()` check that we do to know we're done requires `AuthenticationState.TrnLookup` to be `Complete`. For users who registered via magic link this will be `false` since `CompletedTrnLookup` will be `false`. This change updates the initialization to set `TrnLookup` to `Complete` whenever `Trn` is not null.