### PR TITLE
Reference DQT record to allow teachers with prohibitions to sign in

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/AuthenticationState.cs
@@ -143,6 +143,8 @@ public class AuthenticationState
     public bool? RequiresTrnVerificationLevelElevation { get; private set; }
     public bool? TrnVerificationElevationSuccessful { get; set; }
 
+    public bool? Blocked { get; set; }
+
     [JsonIgnore]
     public bool EmailAddressSet => EmailAddress is not null;
     [JsonIgnore]

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/IdentityLinkGenerator.cs
@@ -40,6 +40,8 @@ public abstract class IdentityLinkGenerator
         return url;
     }
 
+    public string Blocked() => Page("/SignIn/Blocked");
+
     public string CompleteAuthorization() => Page("/SignIn/Complete");
 
     public string Reset() => Page("/SignIn/Reset");

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/CoreSignInJourney.cs
@@ -30,6 +30,7 @@ public class CoreSignInJourney : SignInJourney
         return step switch
         {
             Steps.Landing => true,
+            Steps.Blocked => AuthenticationState.Blocked == true,
             SignInJourney.Steps.Email => true,
             SignInJourney.Steps.EmailConfirmation => AuthenticationState is { EmailAddressSet: true, EmailAddressVerified: false },
             Steps.NoAccount => AuthenticationState.EmailAddressVerified,
@@ -148,6 +149,7 @@ public class CoreSignInJourney : SignInJourney
         SignInJourney.Steps.Email => LinkGenerator.Email(),
         SignInJourney.Steps.EmailConfirmation => LinkGenerator.EmailConfirmation(),
         Steps.Landing => LinkGenerator.Landing(),
+        Steps.Blocked => LinkGenerator.Blocked(),
         Steps.Email => LinkGenerator.RegisterEmail(),
         Steps.EmailConfirmation => LinkGenerator.RegisterEmailConfirmation(),
         Steps.InstitutionEmail => LinkGenerator.RegisterInstitutionEmail(),
@@ -208,5 +210,6 @@ public class CoreSignInJourney : SignInJourney
         public const string ChangeEmailRequest = $"{nameof(CoreSignInJourney)}.{nameof(ChangeEmailRequest)}";
         public const string CheckAnswers = $"{nameof(CoreSignInJourney)}.{nameof(CheckAnswers)}";
         public const string NoAccount = $"{nameof(CoreSignInJourney)}.{nameof(NoAccount)}";
+        public const string Blocked = $"{nameof(CoreSignInJourney)}.{nameof(Blocked)}";
     }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/ElevateTrnVerificationLevelJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/ElevateTrnVerificationLevelJourney.cs
@@ -16,8 +16,6 @@ public class ElevateTrnVerificationLevelJourney : SignInJourney
         _trnLookupHelper = trnLookupHelper;
     }
 
-    public static string GetStartStepUrl(IdentityLinkGenerator linkGenerator) => linkGenerator.ElevateLanding();
-
     public async Task LookupTrn()
     {
         var trn = await _trnLookupHelper.LookupTrn(AuthenticationState);
@@ -41,6 +39,7 @@ public class ElevateTrnVerificationLevelJourney : SignInJourney
         CoreSignInJourneyWithTrnLookup.Steps.NiNumber => true,
         CoreSignInJourneyWithTrnLookup.Steps.Trn => AuthenticationState.HasNationalInsuranceNumber.HasValue,
         Steps.CheckAnswers => AuthenticationState.HasNationalInsuranceNumber.HasValue && AuthenticationState.StatedTrn is not null,
+        CoreSignInJourney.Steps.Blocked => AuthenticationState.Blocked == true,
         _ => false
     };
 
@@ -60,10 +59,12 @@ public class ElevateTrnVerificationLevelJourney : SignInJourney
         _ => null
     };
 
-    protected override string GetStartStep() => Steps.Landing;
+    protected override string GetStartStep() =>
+        AuthenticationState.Blocked == true ? CoreSignInJourney.Steps.Blocked : Steps.Landing;
 
     protected override string GetStepUrl(string step) => step switch
     {
+        CoreSignInJourney.Steps.Blocked => LinkGenerator.Blocked(),
         Steps.Landing => LinkGenerator.ElevateLanding(),
         CoreSignInJourneyWithTrnLookup.Steps.NiNumber => LinkGenerator.RegisterNiNumber(),
         CoreSignInJourneyWithTrnLookup.Steps.Trn => LinkGenerator.RegisterTrn(),

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/SignInJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/SignInJourney.cs
@@ -137,7 +137,7 @@ public abstract class SignInJourney
     {
         if (user.Trn is not null)
         {
-            await UserHelper.EnsureDqtUserNameMatch(user, AuthenticationState);
+            await UserHelper.SyncStateFromDqtRecord(user, AuthenticationState);
         }
         await AuthenticationState.SignIn(HttpContext);
     }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenSignInJourney.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/TrnTokenSignInJourney.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using TeacherIdentity.AuthServer.Models;
 
@@ -18,6 +19,16 @@ public class TrnTokenSignInJourney : SignInJourney
 
     public override async Task<IActionResult> CreateUser(string currentStep)
     {
+        await UserHelper.CheckCanAccessService(AuthenticationState);
+        Debug.Assert(AuthenticationState.Blocked.HasValue);
+
+        if (AuthenticationState.Blocked == true)
+        {
+            var nextPageUrl = GetNextStepUrl(currentStep);
+            Debug.Assert(nextPageUrl == GetStepUrl(CoreSignInJourney.Steps.Blocked));
+            return new RedirectResult(nextPageUrl);
+        }
+
         var user = await UserHelper.CreateUserWithTrnToken(AuthenticationState);
 
         AuthenticationState.OnUserRegistered(user);

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Blocked.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Blocked.cshtml
@@ -1,0 +1,18 @@
+@page "/sign-in/blocked"
+@inject IConfiguration Configuration
+@model TeacherIdentity.AuthServer.Pages.SignIn.BlockedModel
+@{
+    ViewBag.Title = $"You cannot {Model.ClientName}";
+}
+
+<div class="govuk-panel app-panel--interruption" data-testid="landing-panel">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <h1 class="govuk-heading-l">@ViewBag.Title</h1>
+
+            <p>
+                Email <a href="mailto:@(Configuration["SupportEmail"])">@(Configuration["SupportEmail"])</a> to find out how to @Model.ClientName.
+            </p>
+        </div>
+    </div>
+</div>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Blocked.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Blocked.cshtml.cs
@@ -1,0 +1,26 @@
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using TeacherIdentity.AuthServer.Journeys;
+using TeacherIdentity.AuthServer.Oidc;
+using TeacherIdentity.AuthServer.State;
+
+namespace TeacherIdentity.AuthServer.Pages.SignIn;
+
+[CheckCanAccessStep(CoreSignInJourney.Steps.Blocked)]
+[AllowCompletedAuthenticationJourney]
+public class BlockedModel : PageModel
+{
+    private readonly ICurrentClientProvider _currentClientProvider;
+
+    public BlockedModel(ICurrentClientProvider currentClientProvider)
+    {
+        _currentClientProvider = currentClientProvider;
+    }
+
+    public string? ClientName { get; set; }
+
+    public async Task OnGet()
+    {
+        var client = await _currentClientProvider.GetCurrentClient();
+        ClientName = client!.DisplayName;
+    }
+}

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Complete.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Complete.cshtml
@@ -5,7 +5,7 @@
 @{
     ViewBag.Title = Model.TrnVerificationElevationSuccessful == true ? "The information you gave has been verified" :
         Model.TrnVerificationElevationSuccessful == false ? "The information you gave could not be verified" :
-        !Model.CanAccessService ? $"You cannot {Model.ClientDisplayName} online" :
+        !Model.CanAccessService ? "You cannot access this service yet" :
         Model.FirstTimeSignInForEmail ? "You’ve created a DfE Identity account" :
         "You’ve signed in to your DfE Identity account";
 
@@ -50,19 +50,7 @@
                 }
                 else if (Model.TrnRequirementType == TrnRequirementType.Required)
                 {
-                    if (Model.TrnLookupStatus == TrnLookupStatus.Found && !Model.CanAccessService)
-                    {
-                        if (Model.FirstTimeSignInForEmail)
-                        {
-                            <p>You’ve created a DfE Identity account but cannot use it for this service.</p>
-                        }
-
-                        <p>
-                            Email <a href="mailto:@(Configuration["SupportEmail"])">@(Configuration["SupportEmail"])</a>
-                            to find out how to @Model.ClientDisplayName.
-                        </p>
-                    }
-                    else if (Model.TrnLookupStatus == TrnLookupStatus.Found)
+                    if (Model.TrnLookupStatus == TrnLookupStatus.Found)
                     {
                         if (Model.FirstTimeSignInForEmail)
                         {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Complete.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Complete.cshtml.cs
@@ -5,7 +5,6 @@ using Microsoft.EntityFrameworkCore;
 using TeacherIdentity.AuthServer.Journeys;
 using TeacherIdentity.AuthServer.Models;
 using TeacherIdentity.AuthServer.Oidc;
-using TeacherIdentity.AuthServer.Services.DqtApi;
 using TeacherIdentity.AuthServer.State;
 
 namespace TeacherIdentity.AuthServer.Pages.SignIn;
@@ -16,18 +15,15 @@ public class CompleteModel : PageModel
     private readonly SignInJourney _journey;
     private readonly TeacherIdentityApplicationManager _applicationManager;
     private readonly TeacherIdentityServerDbContext _dbContext;
-    private readonly IDqtApiClient _dqtApiClient;
 
     public CompleteModel(
         SignInJourney journey,
         TeacherIdentityApplicationManager applicationManager,
-        TeacherIdentityServerDbContext dbContext,
-        IDqtApiClient dqtApiClient)
+        TeacherIdentityServerDbContext dbContext)
     {
         _journey = journey;
         _applicationManager = applicationManager;
         _dbContext = dbContext;
-        _dqtApiClient = dqtApiClient;
     }
 
     public string? Email { get; set; }
@@ -64,6 +60,7 @@ public class CompleteModel : PageModel
         RedirectUri = authenticationState.OAuthState.RedirectUri;
         ResponseMode = authenticationState.OAuthState.AuthorizationResponseMode!;
         ResponseParameters = authenticationState.OAuthState.AuthorizationResponseParameters!;
+        CanAccessService = authenticationState.OAuthState.TrnRequirementType != Models.TrnRequirementType.Required || authenticationState.Trn is not null;
         Email = authenticationState.EmailAddress;
         FirstTimeSignInForEmail = authenticationState.FirstTimeSignInForEmail!.Value;
         Trn = authenticationState.Trn;
@@ -76,28 +73,8 @@ public class CompleteModel : PageModel
         TrnLookupSupportTicketCreated = user?.TrnLookupSupportTicketCreated == true;
 
         var clientId = authenticationState.OAuthState.ClientId;
-        var client = await _applicationManager.FindByClientIdAsync(clientId!);
+        var client = await _applicationManager.FindByClientIdAsync(clientId);
         ClientDisplayName = await _applicationManager.GetDisplayNameAsync(client!);
-
-        CanAccessService = authenticationState.OAuthState.TrnRequirementType switch
-        {
-            Models.TrnRequirementType.Required => authenticationState.Trn is not null,
-            _ => true
-        };
-
-        if (authenticationState.OAuthState.TrnRequirementType == Models.TrnRequirementType.Required &&
-            authenticationState.OAuthState.BlockProhibitedTeachers == true &&
-            authenticationState.Trn is string trn &&
-            CanAccessService)
-        {
-            var dqtUser = await _dqtApiClient.GetTeacherByTrn(trn) ??
-                throw new Exception($"Failed to retreive teacher with TRN {trn} from DQT.");
-
-            if (dqtUser.Alerts.Any(a => a.AlertType == AlertType.Prohibition))
-            {
-                CanAccessService = false;
-            }
-        }
 
         HttpContext.Features.Get<WebRequestEventFeature>()?.Event.AddTag(FirstTimeSignInForEmail ? "FirstTimeUser" : "ReturningUser");
     }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/DqtApiClient.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/DqtApiClient.cs
@@ -44,7 +44,7 @@ public class DqtApiClient : IDqtApiClient
 
     public async Task<TeacherInfo?> GetTeacherByTrn(string trn, CancellationToken cancellationToken)
     {
-        var response = await _client.GetAsync($"/v3/teachers/{trn}?include=PendingDetailChanges,Alerts", cancellationToken);
+        var response = await _client.GetAsync($"/v3/teachers/{trn}?include=PendingDetailChanges,Alerts,_AllowIdSignInWithProhibitions", cancellationToken);
 
         if ((int)response.StatusCode == StatusCodes.Status404NotFound)
         {

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/TeacherInfo.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/TeacherInfo.cs
@@ -13,6 +13,7 @@ public record TeacherInfo
     public required bool PendingDateOfBirthChange { get; init; }
     public required string? Email { get; init; }
     public required IReadOnlyCollection<AlertInfo> Alerts { get; init; }
+    public required bool AllowIdSignInWithProhibitions { get; set; }
 }
 
 public record AlertInfo

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Account.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/Account.cs
@@ -69,7 +69,8 @@ public class Account : IClassFixture<HostFixture>
             PendingNameChange = false,
             Trn = user.Trn!,
             Email = null,
-            Alerts = Array.Empty<AlertInfo>()
+            Alerts = Array.Empty<AlertInfo>(),
+            AllowIdSignInWithProhibitions = false
         };
 
         ConfigureDqtApiGetTeacherResponse(user.Trn!, dqtTeacherInfo);
@@ -159,7 +160,8 @@ public class Account : IClassFixture<HostFixture>
             PendingNameChange = false,
             Trn = user.Trn!,
             Email = null,
-            Alerts = Array.Empty<AlertInfo>()
+            Alerts = Array.Empty<AlertInfo>(),
+            AllowIdSignInWithProhibitions = false
         };
 
         ConfigureDqtApiGetTeacherResponse(user.Trn!, dqtTeacherInfo);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/PageExtensions.cs
@@ -39,7 +39,8 @@ public static class PageExtensions
         string? additionalScope = null,
         TrnRequirementType? trnRequirement = null,
         string? trnToken = null,
-        TrnMatchPolicy trnMatchPolicy = TrnMatchPolicy.Default)
+        TrnMatchPolicy trnMatchPolicy = TrnMatchPolicy.Default,
+        bool? blockProhibitedTeachers = null)
     {
         var allScopes = new List<string>()
         {
@@ -67,6 +68,11 @@ public static class PageExtensions
         }
 
         url.SetQueryParam("trn_match_policy", trnMatchPolicy.ToString());
+
+        if (blockProhibitedTeachers is not null)
+        {
+            url.SetQueryParam("block_prohibited_teachers", blockProhibitedTeachers.ToString());
+        }
 
         await page.GotoAsync(url);
     }
@@ -152,6 +158,11 @@ public static class PageExtensions
     public static async Task AssertOnAccountPage(this IPage page)
     {
         await page.WaitForUrlPathAsync("/account");
+    }
+
+    public static async Task AssertOnBlockedPage(this IPage page)
+    {
+        await page.WaitForUrlPathAsync("/sign-in/blocked");
     }
 
     public static async Task SignOutFromAccountPageWithoutClientContext(this IPage page)

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/TrnTokenSignInJourney.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.EndToEndTests/TrnTokenSignInJourney.cs
@@ -43,7 +43,8 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
                 PendingDateOfBirthChange = false,
                 PendingNameChange = false,
                 Email = trnToken.Email,
-                Alerts = Array.Empty<AlertInfo>()
+                Alerts = Array.Empty<AlertInfo>(),
+                AllowIdSignInWithProhibitions = false
             });
 
         await using var context = await _hostFixture.CreateBrowserContext();
@@ -94,7 +95,8 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
                 PendingDateOfBirthChange = false,
                 PendingNameChange = false,
                 Email = trnToken.Email,
-                Alerts = Array.Empty<AlertInfo>()
+                Alerts = Array.Empty<AlertInfo>(),
+                AllowIdSignInWithProhibitions = false
             });
 
         await using var context = await _hostFixture.CreateBrowserContext();
@@ -146,7 +148,8 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
                 PendingDateOfBirthChange = false,
                 PendingNameChange = false,
                 Email = trnToken.Email,
-                Alerts = Array.Empty<AlertInfo>()
+                Alerts = Array.Empty<AlertInfo>(),
+                AllowIdSignInWithProhibitions = false
             });
 
         await using var context = await _hostFixture.CreateBrowserContext();
@@ -184,6 +187,21 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
         var page = await context.NewPageAsync();
 
         var user = await _hostFixture.TestData.CreateUser(userType: UserType.Default, hasTrn: true);
+
+        ConfigureDqtApiGetTeacherByTrnRequest(user.Trn!, new()
+        {
+            FirstName = user.FirstName,
+            MiddleName = user.MiddleName ?? string.Empty,
+            LastName = user.LastName,
+            DateOfBirth = user.DateOfBirth,
+            Email = user.EmailAddress,
+            NationalInsuranceNumber = user.NationalInsuranceNumber,
+            PendingDateOfBirthChange = false,
+            PendingNameChange = false,
+            Trn = user.Trn!,
+            Alerts = Array.Empty<AlertInfo>(),
+            AllowIdSignInWithProhibitions = false
+        });
 
         await SignInUser(user, page, context);
 
@@ -239,6 +257,21 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
 
         var user = await _hostFixture.TestData.CreateUser(userType: UserType.Default, hasTrn: true);
         var differentTrn = _hostFixture.TestData.GenerateTrn();
+
+        ConfigureDqtApiGetTeacherByTrnRequest(user.Trn!, new()
+        {
+            FirstName = user.FirstName,
+            MiddleName = user.MiddleName ?? string.Empty,
+            LastName = user.LastName,
+            DateOfBirth = user.DateOfBirth,
+            Email = user.EmailAddress,
+            NationalInsuranceNumber = user.NationalInsuranceNumber,
+            PendingDateOfBirthChange = false,
+            PendingNameChange = false,
+            Trn = user.Trn!,
+            Alerts = Array.Empty<AlertInfo>(),
+            AllowIdSignInWithProhibitions = false
+        });
 
         await SignInUser(user, page, context);
 
@@ -385,6 +418,21 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
         var user = await _hostFixture.TestData.CreateUser(userType: UserType.Default, hasTrn: true);
         var differentTrn = _hostFixture.TestData.GenerateTrn();
 
+        ConfigureDqtApiGetTeacherByTrnRequest(differentTrn, new()
+        {
+            FirstName = user.FirstName,
+            MiddleName = user.MiddleName ?? string.Empty,
+            LastName = user.LastName,
+            DateOfBirth = user.DateOfBirth,
+            Email = user.EmailAddress,
+            NationalInsuranceNumber = user.NationalInsuranceNumber,
+            PendingDateOfBirthChange = false,
+            PendingNameChange = false,
+            Trn = user.Trn!,
+            Alerts = Array.Empty<AlertInfo>(),
+            AllowIdSignInWithProhibitions = false
+        });
+
         var trnToken = await CreateValidTrnToken(trn: differentTrn, email: user.EmailAddress);
 
         var email = Faker.Internet.Email();
@@ -501,6 +549,21 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
 
         var user = await _hostFixture.TestData.CreateUser(userType: UserType.Default, hasTrn: true);
 
+        ConfigureDqtApiGetTeacherByTrnRequest(user.Trn!, new()
+        {
+            FirstName = user.FirstName,
+            MiddleName = user.MiddleName ?? string.Empty,
+            LastName = user.LastName,
+            DateOfBirth = user.DateOfBirth,
+            Email = user.EmailAddress,
+            NationalInsuranceNumber = user.NationalInsuranceNumber,
+            PendingDateOfBirthChange = false,
+            PendingNameChange = false,
+            Trn = user.Trn!,
+            Alerts = Array.Empty<AlertInfo>(),
+            AllowIdSignInWithProhibitions = false
+        });
+
         var differentTrn = _hostFixture.TestData.GenerateTrn();
         var differentEmail = _hostFixture.TestData.GenerateUniqueEmail();
 
@@ -594,6 +657,21 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
 
         var user = await _hostFixture.TestData.CreateUser(userType: UserType.Default, hasTrn: true);
 
+        ConfigureDqtApiGetTeacherByTrnRequest(user.Trn!, new()
+        {
+            FirstName = user.FirstName,
+            MiddleName = user.MiddleName ?? string.Empty,
+            LastName = user.LastName,
+            DateOfBirth = user.DateOfBirth,
+            Email = user.EmailAddress,
+            NationalInsuranceNumber = user.NationalInsuranceNumber,
+            PendingDateOfBirthChange = false,
+            PendingNameChange = false,
+            Trn = user.Trn!,
+            Alerts = Array.Empty<AlertInfo>(),
+            AllowIdSignInWithProhibitions = false
+        });
+
         var differentTrn = _hostFixture.TestData.GenerateTrn();
 
         var trnToken = await CreateValidTrnToken(trn: differentTrn, firstName: user.FirstName, lastName: user.LastName, dateOfBirth: user.DateOfBirth);
@@ -621,6 +699,21 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
         var page = await context.NewPageAsync();
 
         var user = await _hostFixture.TestData.CreateUser(userType: UserType.Default, hasTrn: true);
+
+        ConfigureDqtApiGetTeacherByTrnRequest(user.Trn!, new()
+        {
+            FirstName = user.FirstName,
+            MiddleName = user.MiddleName ?? string.Empty,
+            LastName = user.LastName,
+            DateOfBirth = user.DateOfBirth,
+            Email = user.EmailAddress,
+            NationalInsuranceNumber = user.NationalInsuranceNumber,
+            PendingDateOfBirthChange = false,
+            PendingNameChange = false,
+            Trn = user.Trn!,
+            Alerts = Array.Empty<AlertInfo>(),
+            AllowIdSignInWithProhibitions = false
+        });
 
         var differentTrn = _hostFixture.TestData.GenerateTrn();
 
@@ -724,6 +817,21 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
 
         var user = await _hostFixture.TestData.CreateUser(userType: UserType.Default, hasTrn: true);
 
+        ConfigureDqtApiGetTeacherByTrnRequest(user.Trn!, new()
+        {
+            FirstName = user.FirstName,
+            MiddleName = user.MiddleName ?? string.Empty,
+            LastName = user.LastName,
+            DateOfBirth = user.DateOfBirth,
+            Email = user.EmailAddress,
+            NationalInsuranceNumber = user.NationalInsuranceNumber,
+            PendingDateOfBirthChange = false,
+            PendingNameChange = false,
+            Trn = user.Trn!,
+            Alerts = Array.Empty<AlertInfo>(),
+            AllowIdSignInWithProhibitions = false
+        });
+
         var differentTrn = _hostFixture.TestData.GenerateTrn();
         var trnToken = await CreateValidTrnToken(differentTrn);
 
@@ -773,7 +881,8 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
                 PendingDateOfBirthChange = false,
                 PendingNameChange = false,
                 Email = trnToken.Email,
-                Alerts = Array.Empty<AlertInfo>()
+                Alerts = Array.Empty<AlertInfo>(),
+                AllowIdSignInWithProhibitions = false
             });
 
         var invalidEmailSuffix = "invalid.sch.uk";
@@ -934,7 +1043,8 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
                 PendingDateOfBirthChange = false,
                 PendingNameChange = false,
                 Email = email,
-                Alerts = Array.Empty<AlertInfo>()
+                Alerts = Array.Empty<AlertInfo>(),
+                AllowIdSignInWithProhibitions = false
             });
 
         return await _hostFixture.TestData.GenerateTrnToken(trn, email: email);
@@ -950,5 +1060,12 @@ public class TrnTokenSignInJourney : IClassFixture<HostFixture>
             {
                 Results = results
             });
+    }
+
+    private void ConfigureDqtApiGetTeacherByTrnRequest(string trn, TeacherInfo? result)
+    {
+        _hostFixture.DqtApiClient
+            .Setup(mock => mock.GetTeacherByTrn(trn, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(result);
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/DateOfBirth/DateOfBirthTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/DateOfBirth/DateOfBirthTests.cs
@@ -181,7 +181,7 @@ public class DateOfBirthTests : TestBase
     private void MockDqtApiResponse(User user, bool hasDobConflict, bool hasPendingDobChange)
     {
         HostFixture.DqtApiClient.Setup(mock => mock.GetTeacherByTrn(user.Trn!, It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new AuthServer.Services.DqtApi.TeacherInfo()
+            .ReturnsAsync(new TeacherInfo()
             {
                 DateOfBirth = hasDobConflict ? user.DateOfBirth!.Value.AddDays(1) : user.DateOfBirth!.Value,
                 FirstName = user.FirstName,
@@ -192,7 +192,8 @@ public class DateOfBirthTests : TestBase
                 PendingNameChange = false,
                 PendingDateOfBirthChange = hasPendingDobChange,
                 Email = null,
-                Alerts = Array.Empty<AlertInfo>()
+                Alerts = Array.Empty<AlertInfo>(),
+                AllowIdSignInWithProhibitions = false
             });
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/IndexTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/IndexTests.cs
@@ -134,7 +134,8 @@ public class IndexTests : TestBase
                 PendingNameChange = false,
                 PendingDateOfBirthChange = false,
                 Email = null,
-                Alerts = Array.Empty<AlertInfo>()
+                Alerts = Array.Empty<AlertInfo>(),
+                AllowIdSignInWithProhibitions = false
             });
 
         var request = new HttpRequestMessage(HttpMethod.Get, "/account");
@@ -188,7 +189,8 @@ public class IndexTests : TestBase
                 PendingNameChange = false,
                 PendingDateOfBirthChange = hasPendingReview,
                 Email = null,
-                Alerts = Array.Empty<AlertInfo>()
+                Alerts = Array.Empty<AlertInfo>(),
+                AllowIdSignInWithProhibitions = false
             });
 
         var request = new HttpRequestMessage(HttpMethod.Get, "/account");
@@ -221,7 +223,8 @@ public class IndexTests : TestBase
                 PendingNameChange = true,
                 PendingDateOfBirthChange = false,
                 Email = null,
-                Alerts = Array.Empty<AlertInfo>()
+                Alerts = Array.Empty<AlertInfo>(),
+                AllowIdSignInWithProhibitions = false
             });
 
         var request = new HttpRequestMessage(HttpMethod.Get, "/account");

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialDateOfBirth/ConfirmTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialDateOfBirth/ConfirmTests.cs
@@ -120,7 +120,8 @@ public class ConfirmTests : TestBase
                 PendingDateOfBirthChange = hasPendingDateOfBirthChange,
                 PendingNameChange = false,
                 Email = null,
-                Alerts = Array.Empty<AlertInfo>()
+                Alerts = Array.Empty<AlertInfo>(),
+                AllowIdSignInWithProhibitions = false
             });
     }
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialDateOfBirth/DetailsTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialDateOfBirth/DetailsTests.cs
@@ -182,7 +182,8 @@ public class DetailsTests : TestBase
                 PendingDateOfBirthChange = hasPendingDateOfBirthChange,
                 PendingNameChange = false,
                 Email = null,
-                Alerts = Array.Empty<AlertInfo>()
+                Alerts = Array.Empty<AlertInfo>(),
+                AllowIdSignInWithProhibitions = false
             });
     }
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialDateOfBirth/EvidenceTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialDateOfBirth/EvidenceTests.cs
@@ -181,7 +181,8 @@ public class EvidenceTests : TestBase
                 PendingDateOfBirthChange = hasPendingDateOfBirthChange,
                 PendingNameChange = false,
                 Email = null,
-                Alerts = Array.Empty<AlertInfo>()
+                Alerts = Array.Empty<AlertInfo>(),
+                AllowIdSignInWithProhibitions = false
             });
     }
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialDateOfBirth/OfficialDateOfBirthTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialDateOfBirth/OfficialDateOfBirthTests.cs
@@ -63,7 +63,8 @@ public class OfficialDateOfBirthTests : TestBase
                 PendingDateOfBirthChange = hasPendingDateOfBirthChange,
                 PendingNameChange = false,
                 Email = null,
-                Alerts = Array.Empty<AlertInfo>()
+                Alerts = Array.Empty<AlertInfo>(),
+                AllowIdSignInWithProhibitions = false
             });
     }
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialName/ConfirmTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialName/ConfirmTests.cs
@@ -186,7 +186,8 @@ public class ConfirmTests : TestBase
                 PendingDateOfBirthChange = false,
                 PendingNameChange = hasPendingNameChange,
                 Email = null,
-                Alerts = Array.Empty<AlertInfo>()
+                Alerts = Array.Empty<AlertInfo>(),
+                AllowIdSignInWithProhibitions = false
             });
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialName/DetailsTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialName/DetailsTests.cs
@@ -205,7 +205,8 @@ public class DetailsTests : TestBase
                 PendingDateOfBirthChange = false,
                 PendingNameChange = hasPendingNameChange,
                 Email = null,
-                Alerts = Array.Empty<AlertInfo>()
+                Alerts = Array.Empty<AlertInfo>(),
+                AllowIdSignInWithProhibitions = false
             });
     }
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialName/EvidenceTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialName/EvidenceTests.cs
@@ -228,7 +228,8 @@ public class EvidenceTests : TestBase
                 PendingDateOfBirthChange = false,
                 PendingNameChange = hasPendingNameChange,
                 Email = null,
-                Alerts = Array.Empty<AlertInfo>()
+                Alerts = Array.Empty<AlertInfo>(),
+                AllowIdSignInWithProhibitions = false
             });
     }
 

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialName/OfficialNameTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialName/OfficialNameTests.cs
@@ -64,7 +64,8 @@ public class OfficialNameTests : TestBase
                 PendingDateOfBirthChange = false,
                 PendingNameChange = hasPendingNameChange,
                 Email = null,
-                Alerts = Array.Empty<AlertInfo>()
+                Alerts = Array.Empty<AlertInfo>(),
+                AllowIdSignInWithProhibitions = false
             });
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AssignTrn/ConfirmTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AssignTrn/ConfirmTests.cs
@@ -554,7 +554,8 @@ public class ConfirmTests : TestBase
                 PendingNameChange = false,
                 PendingDateOfBirthChange = false,
                 Email = email ?? Faker.Internet.Email(),
-                Alerts = Array.Empty<AlertInfo>()
+                Alerts = Array.Empty<AlertInfo>(),
+                AllowIdSignInWithProhibitions = false
             });
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AssignTrn/IndexTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/AssignTrn/IndexTests.cs
@@ -300,7 +300,8 @@ public class IndexTests : TestBase
                 PendingNameChange = false,
                 PendingDateOfBirthChange = false,
                 Email = email ?? Faker.Internet.Email(),
-                Alerts = Array.Empty<AlertInfo>()
+                Alerts = Array.Empty<AlertInfo>(),
+                AllowIdSignInWithProhibitions = false
             });
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/UserTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Admin/UserTests.cs
@@ -103,7 +103,8 @@ public class UserTests : TestBase
                 PendingNameChange = false,
                 PendingDateOfBirthChange = false,
                 Email = null,
-                Alerts = Array.Empty<AlertInfo>()
+                Alerts = Array.Empty<AlertInfo>(),
+                AllowIdSignInWithProhibitions = false
             });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/users/{user.UserId}");
@@ -167,7 +168,8 @@ public class UserTests : TestBase
                 PendingNameChange = false,
                 PendingDateOfBirthChange = false,
                 Email = null,
-                Alerts = Array.Empty<AlertInfo>()
+                Alerts = Array.Empty<AlertInfo>(),
+                AllowIdSignInWithProhibitions = false
             });
 
         // Act
@@ -220,7 +222,8 @@ public class UserTests : TestBase
                 PendingNameChange = false,
                 PendingDateOfBirthChange = false,
                 Email = null,
-                Alerts = new[] { new AlertInfo() { AlertType = AlertType.Prohibition, DqtSanctionCode = "" } }
+                Alerts = new[] { new AlertInfo() { AlertType = AlertType.Prohibition, DqtSanctionCode = "" } },
+                AllowIdSignInWithProhibitions = false
             });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/users/{user.UserId}");
@@ -258,7 +261,8 @@ public class UserTests : TestBase
                 PendingNameChange = false,
                 PendingDateOfBirthChange = false,
                 Email = null,
-                Alerts = Array.Empty<AlertInfo>()
+                Alerts = Array.Empty<AlertInfo>(),
+                AllowIdSignInWithProhibitions = false
             });
 
         var request = new HttpRequestMessage(HttpMethod.Get, $"/admin/users/{user.UserId}");

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Oidc/AuthorizeTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Oidc/AuthorizeTests.cs
@@ -525,7 +525,8 @@ public class AuthorizeTests : TestBase
                 PendingDateOfBirthChange = false,
                 PendingNameChange = false,
                 Email = null,
-                Alerts = Array.Empty<AlertInfo>()
+                Alerts = Array.Empty<AlertInfo>(),
+                AllowIdSignInWithProhibitions = false
             });
     }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/CompleteTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/CompleteTests.cs
@@ -234,7 +234,7 @@ public class CompleteTests : TestBase
             false,
             new[]
             {
-                $"You cannot {TestClients.DefaultClient.DisplayName} online",
+                "You cannot access this service yet",
                 "This could be because you do not have teaching qualifications, for example, qualified teacher status (QTS).",
                 "You’ve created a DfE Identity account. When you’re eligible to use this service, you can sign in just using your email"
             }
@@ -250,7 +250,7 @@ public class CompleteTests : TestBase
             true,
             new[]
             {
-                $"You cannot {TestClients.DefaultClient.DisplayName} online",
+                "You cannot access this service yet",
                 "We need to do some more checks to see if your details are in our records.",
                 "We’ll email you when we’ve completed those checks - we may need some more information.",
                 "You’ve created a DfE Identity account. To sign in to this service in the future, you’ll just need your email address"
@@ -282,7 +282,7 @@ public class CompleteTests : TestBase
             false,
             new[]
             {
-                $"You cannot {TestClients.DefaultClient.DisplayName} online",
+                "You cannot access this service yet",
                 "This could be because you do not have teaching qualifications, for example, qualified teacher status (QTS).",
                 "You’ve signed in to your DfE Identity account"
             }
@@ -313,7 +313,7 @@ public class CompleteTests : TestBase
             true,
             new[]
             {
-                $"You cannot {TestClients.DefaultClient.DisplayName} online",
+                "You cannot access this service yet",
                 "We need to do some more checks to see if your details are in our records.",
                 "We’ll email you when we’ve completed those checks - we may need some more information.",
                 "You’ve signed in to your DfE Identity account"

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/SignIn/EmailConfirmationTests.cs
@@ -304,6 +304,22 @@ public class EmailConfirmationTests : TestBase
         // Arrange
         var user = await TestData.CreateUser(hasTrn: hasTrn);
 
+        HostFixture.DqtApiClient.Setup(mock => mock.GetTeacherByTrn(user.Trn!, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new TeacherInfo()
+            {
+                DateOfBirth = DateOnly.FromDateTime(Faker.Identification.DateOfBirth()),
+                Email = Faker.Internet.Email(),
+                FirstName = user.FirstName,
+                MiddleName = user.MiddleName ?? string.Empty,
+                LastName = user.LastName,
+                NationalInsuranceNumber = user.NationalInsuranceNumber,
+                Trn = user.Trn!,
+                PendingDateOfBirthChange = false,
+                PendingNameChange = false,
+                Alerts = Array.Empty<AlertInfo>(),
+                AllowIdSignInWithProhibitions = false
+            });
+
         var userVerificationService = HostFixture.Services.GetRequiredService<IUserVerificationService>();
         var pinResult = await userVerificationService.GenerateEmailPin(user.EmailAddress);
 
@@ -486,7 +502,8 @@ public class EmailConfirmationTests : TestBase
                 Trn = user.Trn!,
                 PendingDateOfBirthChange = false,
                 PendingNameChange = false,
-                Alerts = Array.Empty<AlertInfo>()
+                Alerts = Array.Empty<AlertInfo>(),
+                AllowIdSignInWithProhibitions = false
             });
 
         var authStateHelper = await CreateAuthenticationStateHelper(c => c.EmailSet(user.EmailAddress), additionalScopes: null);

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Jobs/SyncNamesWithDqtJobTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Jobs/SyncNamesWithDqtJobTests.cs
@@ -69,7 +69,8 @@ public class SyncNamesWithDqtJobTests : IClassFixture<DbFixture>, IAsyncLifetime
             PendingNameChange = false,
             PendingDateOfBirthChange = false,
             Email = Faker.Internet.Email(),
-            Alerts = Array.Empty<AlertInfo>()
+            Alerts = Array.Empty<AlertInfo>(),
+            AllowIdSignInWithProhibitions = false
         };
 
         var dqtApiClient = Mock.Of<IDqtApiClient>();
@@ -153,7 +154,8 @@ public class SyncNamesWithDqtJobTests : IClassFixture<DbFixture>, IAsyncLifetime
             PendingNameChange = false,
             PendingDateOfBirthChange = false,
             Email = Faker.Internet.Email(),
-            Alerts = Array.Empty<AlertInfo>()
+            Alerts = Array.Empty<AlertInfo>(),
+            AllowIdSignInWithProhibitions = false
         };
 
         var dqtApiClient = Mock.Of<IDqtApiClient>();

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Services/UserImport/UserImportProcessorTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/Services/UserImport/UserImportProcessorTests.cs
@@ -51,7 +51,8 @@ public class UserImportProcessorTests : IClassFixture<DbFixture>, IAsyncLifetime
             PendingNameChange = false,
             PendingDateOfBirthChange = false,
             Email = null,
-            Alerts = Array.Empty<AlertInfo>()
+            Alerts = Array.Empty<AlertInfo>(),
+            AllowIdSignInWithProhibitions = false
         };
 
         var getTeacherByTrnResultTest23 = new TeacherInfo()
@@ -65,7 +66,8 @@ public class UserImportProcessorTests : IClassFixture<DbFixture>, IAsyncLifetime
             PendingNameChange = false,
             PendingDateOfBirthChange = false,
             Email = null,
-            Alerts = Array.Empty<AlertInfo>()
+            Alerts = Array.Empty<AlertInfo>(),
+            AllowIdSignInWithProhibitions = false
         };
 
         return new TheoryData<UserImportTestScenarioData>()

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/UserClaimHelperTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/UserClaimHelperTests.cs
@@ -192,7 +192,8 @@ public class UserClaimHelperTests : IClassFixture<DbFixture>
             PendingDateOfBirthChange = false,
             PendingNameChange = false,
             Trn = user.Trn!,
-            Alerts = Array.Empty<AlertInfo>()
+            Alerts = Array.Empty<AlertInfo>(),
+            AllowIdSignInWithProhibitions = false
         });
 
         using var dbContext = _dbFixture.GetDbContext();
@@ -234,7 +235,8 @@ public class UserClaimHelperTests : IClassFixture<DbFixture>
             PendingDateOfBirthChange = false,
             PendingNameChange = false,
             Trn = user.Trn!,
-            Alerts = Array.Empty<AlertInfo>()
+            Alerts = Array.Empty<AlertInfo>(),
+            AllowIdSignInWithProhibitions = false
         });
 
         using var dbContext = _dbFixture.GetDbContext();
@@ -276,7 +278,8 @@ public class UserClaimHelperTests : IClassFixture<DbFixture>
             PendingDateOfBirthChange = false,
             PendingNameChange = false,
             Trn = user.Trn!,
-            Alerts = Array.Empty<AlertInfo>()
+            Alerts = Array.Empty<AlertInfo>(),
+            AllowIdSignInWithProhibitions = false
         });
 
         using var dbContext = _dbFixture.GetDbContext();
@@ -320,7 +323,8 @@ public class UserClaimHelperTests : IClassFixture<DbFixture>
             PendingDateOfBirthChange = false,
             PendingNameChange = false,
             Trn = user.Trn!,
-            Alerts = Array.Empty<AlertInfo>()
+            Alerts = Array.Empty<AlertInfo>(),
+            AllowIdSignInWithProhibitions = false
         });
 
         using var dbContext = _dbFixture.GetDbContext();
@@ -364,7 +368,8 @@ public class UserClaimHelperTests : IClassFixture<DbFixture>
             PendingDateOfBirthChange = false,
             PendingNameChange = false,
             Trn = user.Trn!,
-            Alerts = Array.Empty<AlertInfo>()
+            Alerts = Array.Empty<AlertInfo>(),
+            AllowIdSignInWithProhibitions = false
         });
 
         using var dbContext = _dbFixture.GetDbContext();
@@ -408,7 +413,8 @@ public class UserClaimHelperTests : IClassFixture<DbFixture>
             PendingDateOfBirthChange = false,
             PendingNameChange = false,
             Trn = user.Trn!,
-            Alerts = Array.Empty<AlertInfo>()
+            Alerts = Array.Empty<AlertInfo>(),
+            AllowIdSignInWithProhibitions = false
         });
 
         using var dbContext = _dbFixture.GetDbContext();


### PR DESCRIPTION
There's a new field in DQT - `dfeta_AllowIDSignInWithProhibitions`. If a matched record has this then we will allow sign in/registration for services that would otherwise block the user.

Another change here is blocking registration rather than creating a user but blocking completing the authorization flow.