### PR TITLE
Ensure evidence file names don't exceed limit

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialDateOfBirth/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialDateOfBirth/Confirm.cshtml.cs
@@ -48,7 +48,7 @@ public class Confirm : PageModel
         var teacherDobChangeRequest = new TeacherDateOfBirthChangeRequest()
         {
             DateOfBirth = DateOfBirth!.Value,
-            EvidenceFileName = FileName!,
+            EvidenceFileName = FileName!.Truncate(DqtApiClient.MaxEvidenceFileNameLength),
             EvidenceFileUrl = sasUri,
             Trn = User.GetTrn()!
         };

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Confirm.cshtml.cs
@@ -68,7 +68,7 @@ public class Confirm : PageModel
             FirstName = FirstName!,
             MiddleName = MiddleName,
             LastName = LastName!,
-            EvidenceFileName = FileName!,
+            EvidenceFileName = FileName!.Truncate(DqtApiClient.MaxEvidenceFileNameLength),
             EvidenceFileUrl = sasUri,
             Trn = User.GetTrn()!
         };

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/DqtApiClient.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/DqtApiClient.cs
@@ -7,6 +7,8 @@ namespace TeacherIdentity.AuthServer.Services.DqtApi;
 
 public class DqtApiClient : IDqtApiClient
 {
+    public const int MaxEvidenceFileNameLength = 100;
+
     private readonly HttpClient _client;
 
     private static JsonSerializerOptions _serializerOptions { get; } = new JsonSerializerOptions(JsonSerializerDefaults.Web)

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/StringExtensions.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/StringExtensions.cs
@@ -3,4 +3,6 @@ namespace TeacherIdentity.AuthServer;
 public static class StringExtensions
 {
     public static string? ToNullIfEmpty(this string? value) => string.IsNullOrWhiteSpace(value) ? null : value;
+
+    public static string Truncate(this string value, int maxLength) => value.Length > maxLength ? value[..maxLength] : value;
 }


### PR DESCRIPTION
There's a 100 character limit in CRM for evidence file names.