### PR TITLE
Fix assigning TrnVerificationLevel for new users

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/UserHelper.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Journeys/UserHelper.cs
@@ -88,6 +88,10 @@ public class UserHelper
             && !string.IsNullOrEmpty(authenticationState.DqtFirstName)
             && !string.IsNullOrEmpty(authenticationState.DqtLastName);
 
+        TrnVerificationLevel? trnVerificationLevel = authenticationState.Trn is null ? null :
+            authenticationState.TryGetOAuthState(out var oAuthState) && oAuthState.TrnMatchPolicy == TrnMatchPolicy.Strict ? TrnVerificationLevel.Medium :
+            TrnVerificationLevel.Low;
+
         var user = new User()
         {
             CompletedTrnLookup = _clock.UtcNow,
@@ -108,7 +112,7 @@ public class UserHelper
             LastSignedIn = _clock.UtcNow,
             RegisteredWithClientId = authenticationState.OAuthState?.ClientId,
             TrnLookupStatus = authenticationState.TrnLookupStatus,
-            TrnVerificationLevel = TrnVerificationLevel.Low,
+            TrnVerificationLevel = trnVerificationLevel,
             NationalInsuranceNumber = authenticationState.NationalInsuranceNumber,
         };
 

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20231205165910_FixTrnVerificationLevel.Designer.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20231205165910_FixTrnVerificationLevel.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using System.Collections.Generic;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using TeacherIdentity.AuthServer.Models;
@@ -12,9 +13,11 @@ using TeacherIdentity.AuthServer.Models;
 namespace TeacherIdentity.AuthServer.Migrations
 {
     [DbContext(typeof(TeacherIdentityServerDbContext))]
-    partial class TeacherIdentityServerDbContextModelSnapshot : ModelSnapshot
+    [Migration("20231205165910_FixTrnVerificationLevel")]
+    partial class FixTrnVerificationLevel
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20231205165910_FixTrnVerificationLevel.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Migrations/20231205165910_FixTrnVerificationLevel.cs
@@ -1,0 +1,34 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace TeacherIdentity.AuthServer.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixTrnVerificationLevel : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("""
+                update users u
+                set trn_verification_level = 1
+                from (
+                    select cast(payload->>'UserId' as uuid) user_id from authentication_states
+                    where payload->>'FirstTimeSignInForEmail' = 'true'
+                    and payload->>'Trn' is not null
+                    and payload->'OAuthState'->>'TrnMatchPolicy' = '1'
+                    and payload->>'UserId' is not null
+                ) a
+                where u.user_id = a.user_id
+                and u.trn_verification_level != 1;
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+
+        }
+    }
+}


### PR DESCRIPTION
AYTQ has been blowing up for some users with a 403 from the API. After some debugging we find the access token is missing the `trn` claim. The logic that adds the `trn` claim omitted it because the `User`'s `TrnVerificationLevel` was set as `Low` (and the journey requires `Medium`), even though they've gone through a journey that should set it to `Medium`.

This fixes the user creation logic to correctly assign `TrnVerificationLevel`. It also adds a migration to fix up the data for the users who have encountered this.