### PR TITLE
Fix Enter key action for pages with multiple submit buttons

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/NiNumberPage.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/NiNumberPage.cshtml
@@ -15,6 +15,9 @@
                 <govuk-input-label is-page-heading="true" class="govuk-label--l"/>
             </govuk-input>
 
+            @* Pressing the Enter key will submit the first submit button - make sure it's the default action *@
+            <button type="submit" class="govuk-!-display-none"></button>
+
             <govuk-details>
                 <govuk-details-summary>
                     @(Model.TrnMatchPolicy == TrnMatchPolicy.Strict ? "I cannot provide my National Insurance number" : "I do not know my National Insurance number")

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Phone.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/Phone.cshtml
@@ -22,6 +22,9 @@
                 input-class="govuk-input--extra-letter-spacing"
                 label-class="govuk-label--s" />
 
+            @* Pressing the Enter key will submit the first submit button - make sure it's the default action *@
+            <button type="submit" class="govuk-!-display-none"></button>
+
             <govuk-details>
                 <govuk-details-summary>I do not have access to a mobile phone</govuk-details-summary>
                 <govuk-details-text>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/PhoneConfirmation.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/PhoneConfirmation.cshtml
@@ -23,6 +23,9 @@
                 autocomplete="one-time-code"
                 label-class="govuk-label--s" />
 
+            @* Pressing the Enter key will submit the first submit button - make sure it's the default action *@
+            <button type="submit" class="govuk-!-display-none"></button>
+
             <govuk-details>
                 <govuk-details-summary>I have not received a code</govuk-details-summary>
                 <govuk-details-text>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/TrnPage.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/SignIn/Register/TrnPage.cshtml
@@ -23,6 +23,9 @@
                 spellcheck="false"
                 label-class="govuk-label--s"/>
 
+            @* Pressing the Enter key will submit the first submit button - make sure it's the default action *@
+            <button type="submit" class="govuk-!-display-none"></button>
+
             @if (Model.ShowContinueWithoutTrnButton)
             {
                 <govuk-details>


### PR DESCRIPTION
Pressing the Enter key within a form will submit the first submit button within the form. We have a few cases where we have multiple submit buttons and the first submit button is never the one we want to submit.

This is a quick work-around; we add an invisible submit button with the default action before any other submit buttons to make sure the right action is called when Enter is pressed.