### PR TITLE
Fix selected trn from being lost when merging two records

### DIFF
--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/MergeUser/Confirm.cshtml
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/MergeUser/Confirm.cshtml
@@ -5,14 +5,14 @@
 }
 
 @section BeforeContent {
-    <govuk-back-link asp-page="SelectUser" asp-route-userId="@Model.UserId"/>
+    <govuk-back-link asp-page="SelectUser" asp-route-userId="@Model.UserId" />
 }
 
 <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds-from-desktop">
         <form asp-page="Confirm" method="post">
             <h1 class="govuk-heading-l">@ViewBag.Title</h1>
-
+            @Html.Hidden("ChosenTrn", Model.ChosenTrn)
             <govuk-summary-list>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Email address</govuk-summary-list-row-key>
@@ -20,7 +20,7 @@
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>Name</govuk-summary-list-row-key>
-                <govuk-summary-list-row-value>@Model.User!.FirstName @Model.User!.LastName</govuk-summary-list-row-value>
+                    <govuk-summary-list-row-value>@Model.User!.FirstName @Model.User!.LastName</govuk-summary-list-row-value>
                 </govuk-summary-list-row>
                 <govuk-summary-list-row>
                     <govuk-summary-list-row-key>TRN</govuk-summary-list-row-key>

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/MergeUser/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Admin/MergeUser/Confirm.cshtml.cs
@@ -29,8 +29,9 @@ public class Confirm : PageModel
 
     public User? UserToMerge { get; set; }
 
-    [FromQuery(Name = "trn")]
+    [BindProperty]
     public string? ChosenTrn { get; set; }
+
 
     public void OnGet()
     {
@@ -121,6 +122,11 @@ public class Confirm : PageModel
 
     private bool ValidateChosenTrn()
     {
+        if (Request.Query.ContainsKey("trn"))
+        {
+            ChosenTrn = Request.Query["trn"];
+        }
+
         ChosenTrn = ChosenTrn == "None" ? null : ChosenTrn ?? User!.Trn;
         return ChosenTrn == User!.Trn || ChosenTrn == UserToMerge!.Trn;
     }


### PR DESCRIPTION
Fixed merging accounts - when you select a TRN it doesn't seem to be actually transferring that to the merged account. 

-   [ ] Attach to Trello card
-   [x] Rebased master
-   [x] Cleaned commit history
-   [x] Tested by running locally
-   [x] Reminder created to manually clean any removed app settings post deployment
