### PR TITLE
Send email address with change name/DOB requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 docs/.structurizr/**
 fetch_config.rb
 /.vs
+.idea

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialDateOfBirth/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialDateOfBirth/Confirm.cshtml.cs
@@ -47,13 +47,13 @@ public class Confirm : PageModel
 
         var teacherDobChangeRequest = new TeacherDateOfBirthChangeRequest()
         {
+            EmailAddress = User.GetEmailAddress(),
             DateOfBirth = DateOfBirth!.Value,
             EvidenceFileName = FileName!.Truncate(DqtApiClient.MaxEvidenceFileNameLength),
-            EvidenceFileUrl = sasUri,
-            Trn = User.GetTrn()!
+            EvidenceFileUrl = sasUri
         };
 
-        await _dqtApiClient.PostTeacherDateOfBirthChange(teacherDobChangeRequest);
+        await _dqtApiClient.PostTeacherDateOfBirthChange(User.GetTrn(), teacherDobChangeRequest);
 
         TempData.SetFlashSuccess(
             "We’ve received your request to change your date of birth",

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Confirm.cshtml.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Pages/Account/OfficialName/Confirm.cshtml.cs
@@ -65,15 +65,15 @@ public class Confirm : PageModel
 
         var teacherNameChangeRequest = new TeacherNameChangeRequest()
         {
+            EmailAddress = User.GetEmailAddress(),
             FirstName = FirstName!,
             MiddleName = MiddleName,
             LastName = LastName!,
             EvidenceFileName = FileName!.Truncate(DqtApiClient.MaxEvidenceFileNameLength),
-            EvidenceFileUrl = sasUri,
-            Trn = User.GetTrn()!
+            EvidenceFileUrl = sasUri
         };
 
-        await _dqtApiClient.PostTeacherNameChange(teacherNameChangeRequest);
+        await _dqtApiClient.PostTeacherNameChange(User.GetTrn(), teacherNameChangeRequest);
 
         var preferredNameMessage = string.Empty;
         var user = await _dbContext.Users.SingleAsync(u => u.UserId == User.GetUserId());

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/IDqtApiClient.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/IDqtApiClient.cs
@@ -5,6 +5,6 @@ public interface IDqtApiClient
     Task<FindTeachersResponse> FindTeachers(FindTeachersRequest request, CancellationToken cancellationToken = default);
     public Task<TeacherInfo?> GetTeacherByTrn(string trn, CancellationToken cancellationToken = default);
     public Task<GetIttProvidersResponse> GetIttProviders(CancellationToken cancellationToken = default);
-    public Task PostTeacherNameChange(TeacherNameChangeRequest request, CancellationToken cancellationToken = default);
-    public Task PostTeacherDateOfBirthChange(TeacherDateOfBirthChangeRequest request, CancellationToken cancellationToken = default);
+    public Task PostTeacherNameChange(string trn, TeacherNameChangeRequest request, CancellationToken cancellationToken = default);
+    public Task PostTeacherDateOfBirthChange(string trn, TeacherDateOfBirthChangeRequest request, CancellationToken cancellationToken = default);
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/TeacherDateOfBirthChangeRequest.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/TeacherDateOfBirthChangeRequest.cs
@@ -2,8 +2,8 @@ namespace TeacherIdentity.AuthServer.Services.DqtApi;
 
 public record TeacherDateOfBirthChangeRequest
 {
+    public required string EmailAddress { get; init; }
     public required DateOnly DateOfBirth { get; init; }
     public required string EvidenceFileName { get; init; }
     public required string EvidenceFileUrl { get; init; }
-    public required string Trn { get; init; }
 }

--- a/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/TeacherNameChangeRequest.cs
+++ b/dotnet-authserver/src/TeacherIdentity.AuthServer/Services/DqtApi/TeacherNameChangeRequest.cs
@@ -2,10 +2,10 @@ namespace TeacherIdentity.AuthServer.Services.DqtApi;
 
 public record TeacherNameChangeRequest
 {
+    public required string EmailAddress { get; init; }
     public required string FirstName { get; init; }
     public required string? MiddleName { get; init; }
     public required string LastName { get; init; }
     public required string EvidenceFileName { get; init; }
     public required string EvidenceFileUrl { get; init; }
-    public required string Trn { get; init; }
 }

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialDateOfBirth/ConfirmTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialDateOfBirth/ConfirmTests.cs
@@ -99,7 +99,7 @@ public class ConfirmTests : TestBase
         Assert.Equal($"/account?{_clientRedirectInfo.ToQueryParam()}", response.Headers.Location?.OriginalString);
 
         HostFixture.DqtEvidenceStorageService.Verify(s => s.GetSasConnectionString(It.IsAny<string>(), It.IsAny<int>()));
-        HostFixture.DqtApiClient.Verify(s => s.PostTeacherDateOfBirthChange(It.IsAny<TeacherDateOfBirthChangeRequest>(), It.IsAny<CancellationToken>()));
+        HostFixture.DqtApiClient.Verify(s => s.PostTeacherDateOfBirthChange(It.IsAny<string>(), It.IsAny<TeacherDateOfBirthChangeRequest>(), It.IsAny<CancellationToken>()));
 
         var redirectedResponse = await response.FollowRedirect(HttpClient);
         var redirectedDoc = await redirectedResponse.GetDocument();

--- a/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialName/ConfirmTests.cs
+++ b/dotnet-authserver/tests/TeacherIdentity.AuthServer.Tests/EndpointTests/Account/OfficialName/ConfirmTests.cs
@@ -165,7 +165,7 @@ public class ConfirmTests : TestBase
         }
 
         HostFixture.DqtEvidenceStorageService.Verify(s => s.GetSasConnectionString(It.IsAny<string>(), It.IsAny<int>()));
-        HostFixture.DqtApiClient.Verify(s => s.PostTeacherNameChange(It.IsAny<TeacherNameChangeRequest>(), It.IsAny<CancellationToken>()));
+        HostFixture.DqtApiClient.Verify(s => s.PostTeacherNameChange(It.IsAny<string>(), It.IsAny<TeacherNameChangeRequest>(), It.IsAny<CancellationToken>()));
 
         var redirectedResponse = await response.FollowRedirect(HttpClient);
         var redirectedDoc = await redirectedResponse.GetDocument();


### PR DESCRIPTION
We're removing the sync that sets the teaching record's email to the ID user's email address. As such, we need to explicitly provide an email address for change of name/DOB requests so that automated emails go to the right requesting user's email.

The TRS API versions that support passing an email use a different authentication scheme to what we normally use here so have to create a JWT and pass that instead of using the fixed API key.